### PR TITLE
Fix symbolic state of `Door` Objects

### DIFF
--- a/navix/_version.py
+++ b/navix/_version.py
@@ -18,5 +18,5 @@
 # under the License.
 
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 __version_info__ = tuple(int(i) for i in __version__.split(".") if i.isdigit())

--- a/navix/observations.py
+++ b/navix/observations.py
@@ -134,19 +134,17 @@ def symbolic(state: State) -> Array:
     # place entities
     for entity_class in state.entities:
         entity = state.entities[entity_class]
+        # 1. tag layer
         tag = entity.tag
-        # colour layer
+        # 2. colour layer
         if isinstance(entity, HasColour):
             colour = entity.colour
         else:
             colour = jnp.zeros(entity.shape)
-        # state layer
-        if isinstance(entity, Openable):
-            entity_state = entity.open + (entity.requires != jnp.zeros(entity.shape))
-        elif isinstance(entity, Directional):
-            entity_state = entity.direction
-        else:
-            entity_state = jnp.zeros(entity.shape)
+        # 3. state layer
+        entity_state = entity.symbolic_state
+
+        # collate
         entity_symbol = jnp.stack([tag, colour, entity_state], axis=-1, dtype=jnp.uint8)
         obs = obs.at[tuple(entity.position.T)].set(entity_symbol)
     return obs

--- a/tests/issue_95.py
+++ b/tests/issue_95.py
@@ -1,0 +1,50 @@
+import jax.numpy as jnp
+from navix.entities import Door
+
+
+def test_open_unlocked():
+    # open=1, requires=-1 (unlocked)
+    door = Door(
+        position=jnp.zeros((1, 2)),
+        requires=jnp.asarray([-1]),
+        open=jnp.asarray([1]),
+        colour=jnp.asarray([0], dtype=jnp.uint8),
+    )
+    state = door.symbolic_state
+    assert jnp.all(state == 0), "Expected state to be 0 for open unlocked door."
+
+
+def test_closed_unlocked():
+    # open=0, requires=-1 (unlocked)
+    door = Door(
+        position=jnp.zeros((1, 2)),
+        requires=jnp.asarray([-1]),
+        open=jnp.asarray([0]),
+        colour=jnp.asarray([0], dtype=jnp.uint8),
+    )
+    state = door.symbolic_state
+    assert jnp.all(state == 1), "Expected state to be 1 for closed unlocked door."
+
+
+def test_closed_locked():
+    # open=0, requires=5 (locked)
+    door = Door(
+        position=jnp.zeros((1, 2)),
+        requires=jnp.asarray([5]),
+        open=jnp.asarray([0]),
+        colour=jnp.asarray([0], dtype=jnp.uint8),
+    )
+    state = door.symbolic_state
+    assert jnp.all(state == 2), "Expected state to be 2 for closed locked door."
+
+
+def test_open_locked():
+    # open=1, requires=5 (locked, but open)
+    door = Door(
+        position=jnp.zeros((1, 2)),
+        requires=jnp.asarray([5]),
+        open=jnp.asarray([1]),
+        colour=jnp.asarray([0], dtype=jnp.uint8),
+    )
+    state = door.symbolic_state
+    assert jnp.all(state == 0), "Expected state to be 0 for open locked door."


### PR DESCRIPTION
Fixes #95 

This implements the correct symbolic state of doors, which is currently incorrect, as highlighted in #95 -- thank you @rikifunt for the great catch.

As a byproduct, entities now have a `symbolic_state` property.