### PR TITLE
fix: Door.walkable and Door.transparent return bool, not open's dtype

### DIFF
--- a/navix/entities.py
+++ b/navix/entities.py
@@ -287,11 +287,11 @@ class Door(Entity, Openable, HasColour):
 
     @property
     def walkable(self) -> Array:
-        return self.open
+        return jnp.asarray(self.open, dtype=jnp.bool_)
 
     @property
     def transparent(self) -> Array:
-        return self.open
+        return jnp.asarray(self.open, dtype=jnp.bool_)
 
     @property
     def sprite(self) -> Array:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,8 +1,30 @@
 import jax
 import jax.numpy as jnp
 
-from navix.entities import Goal, Player
+from navix.entities import Door, Goal, Player
 from navix.rendering.registry import TILE_SIZE
+
+
+def test_door_open_derived_properties_are_bool():
+    # Entity.walkable and Entity.transparent are both documented as boolean
+    # arrays, but Door derives them from `open`, which Openable documents as
+    # an integer 0/1.
+    # However, callers disagree:
+    #   - door_key.py passes a bool;
+    #   - key_corridor.py and go_to_door.py pass ints.
+    # And, observations.py:130 and :241 apply `~` to transparent, as bitwise
+    # operation over an int dtype, it gives ~1 == -2 and ~0 == -1.
+    # This becomes a problem when view_cone then multiplies its field with
+    # it, because it results in unknown/invisible elements.
+    for open_ in (jnp.asarray(0), jnp.asarray(False), jnp.asarray((0, 1))):
+        door = Door(
+            position=jnp.asarray([(1, 5)]),
+            requires=jnp.asarray((0,)),
+            open=open_,
+            colour=jnp.zeros((1,), dtype=jnp.uint8),
+        )
+        assert door.transparent.dtype == jnp.bool_, open_.dtype
+        assert door.walkable.dtype == jnp.bool_, open_.dtype
 
 
 def test_indexing():
@@ -27,6 +49,7 @@ def test_get_sprites():
 
 
 if __name__ == "__main__":
+    test_door_open_derived_properties_are_bool()
     test_indexing()
     # test_get_sprites()
     jax.jit(test_get_sprites)()


### PR DESCRIPTION
### Summary

`Entity.walkable` and `Entity.transparent` are both documented as boolean arrays
(`entities.py:92`, `:99`), but `Door` derives them directly from `open`, which
`Openable` documents as an integer 0/1 (`components.py:90`). The two properties
therefore hand their consumers whatever dtype `open` happens to be stored as.

### Why it matters

`categorical_first_person` applies `~` to `transparent` when building the
view-cone transparency map (`observations.py:101`):

```python
transparency_map = transparency_map.at[tuple(positions.T)].set(~transparent)
```

Under an integer dtype `~` is bitwise, so `~1 == -2` and `~0 == -1`. These
negative values are problematic because `view_cone` then multiplies its
diffusion field with them before thresholding at `view > 0`, so the map it
receives holds `{-2, -1, 0, 1}` instead of `{0, 1}`.

Reproducing on `main`:

```python
import jax, jax.numpy as jnp, navix as nx

s = nx.make("Navix-KeyCorridorS3R1-v0").reset(jax.random.PRNGKey(0)).state
t = s.get_transparency()
tm = jnp.where(s.grid == 0, 1, 0).at[tuple(s.get_positions().T)].set(~t)
print(t.dtype, sorted(set(tm.ravel().tolist())))
# int32 [-2, -1, 0, 1]
```

With this change: `bool [0, 1]`.

### The dtype depends on which module built the door

- `door_key.py:64` passes `jnp.asarray(False)` — bool
- `key_corridor.py:95` passes `jnp.asarray(0)` — int
- `go_to_door.py:83` forwards whatever the caller supplies

So `DoorKey` already behaves correctly while `KeyCorridor` and `GoToDoor` do not,
which is what makes this easy to miss.

### The fix

Coerce in the two derived properties rather than in `open` itself:

```python
@property
def walkable(self) -> Array:
    return jnp.asarray(self.open, dtype=jnp.bool_)

@property
def transparent(self) -> Array:
    return jnp.asarray(self.open, dtype=jnp.bool_)
```

This keeps `Openable`'s documented integer semantics for `open`, and leaves
`Door.sprite`'s `open + 2 * locked` arithmetic untouched. `walkable`'s consumers
in `actions.py` and `transitions.py` already end with
`jnp.asarray(walkable, dtype=jnp.bool_)`, so this only moves that coercion to the
source; behaviour there is unchanged.

Coercing inside `Door.create` was the other option to address the issue,
but `Door(...)` is also constructed directly in several places (including
`tests/test_actions.py` and `tests/test_observations.py`), so a
constructor-only fix would not hold. Happy to move it if you would rather have
it there as well.

### Testing

- `pytest tests/` — 24 passed before, 25 after (the new test); no other change.
- `examples/*.py` both run clean.
- Full CI green on my fork across Python 3.9–3.13.

`tests/test_entities.py` gains a regression test asserting both properties return
`jnp.bool_` for int, bool, and batched inputs. It fails on `main` and passes here.

### Version bump

`navix/_version.py` is bumped 0.7.4 → 0.7.5 because the `Check-next-version` CI
job fails when `__version__` matches an existing tag. Happy to drop it if you
prefer to own version bumps.

### Not included

There is a separate question about the `~` in `categorical_first_person`
(`navix/observations.py`): `rgb_first_person` writes `.set(transparent)` without the
negation, and the map's own convention (`jnp.where(state.grid == 0, 1, 0)`) is
1 = light passes, so the two functions disagree about whether a transparent
entity occludes. That is a behaviour change rather than a type fix, so I have
left it out of this PR and will raise it as an issue.


N.B.1: line numbers as of [main @ 7c438e9](https://github.com/epignatelli/navix/commit/7c438e939dadcfde973f3fbc6869cfacc2bd6235).

N.B.2: written with AI assistance for the investigation and drafting, but all
verifications are my own.
