### PR TITLE
ci(release): checkout with admin PAT so CD can push to protected main

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Get current version from file
         id: current


### PR DESCRIPTION
## Summary
The first real CD run after merging #113 failed at the "Write bumped version to navix/_version.py" step: `main` requires changes via PR, and the default `GITHUB_TOKEN` doesn't bypass that even with `contents: write`. It failed cleanly before tagging/releasing/publishing — nothing shipped, `main` is still at `0.7.4`.

Since branch protection has `enforce_admins` off, an admin's PAT can push directly. This checks out with `secrets.RELEASE_TOKEN` instead of the default token.

## Before merging
Add a `RELEASE_TOKEN` repo secret: a fine-grained PAT scoped to this repo only, with **Contents: Read and write**, from an admin account.

## Test plan
- [ ] `RELEASE_TOKEN` secret added
- [ ] Merge, confirm the next CD run pushes the version bump, tags, releases, and publishes to PyPI successfully

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Be5vnY6tpvoTAwWAFN5mtH