### PR TITLE
feat: disable_autoreset flag + FourRooms size variants

### DIFF
--- a/navix/environments/environment.py
+++ b/navix/environments/environment.py
@@ -147,7 +147,6 @@ class Environment(struct.PyTreeNode):
             observation_space=observation_space,
             action_space=action_space,
             reward_space=reward_space,
-            **kwargs,
             disable_autoreset=disable_autoreset,
             **kwargs,
         )

--- a/navix/environments/environment.py
+++ b/navix/environments/environment.py
@@ -166,7 +166,7 @@ class Environment(struct.PyTreeNode):
         # autoreset if necessary: 0 = transition, 1 = truncation, 2 = termination
         should_reset = timestep.step_type > 0
         return jax.lax.cond(
-            should_reset and not self.disable_autoreset,
+            jnp.logical_and(should_reset, jnp.logical_not(self.disable_autoreset)),
             lambda timestep: self.reset(timestep.state.key, timestep.state.cache),
             lambda timestep: self._step(timestep, action),
             timestep,

--- a/navix/environments/four_rooms.py
+++ b/navix/environments/four_rooms.py
@@ -117,3 +117,56 @@ register_env(
         **kwargs,
     ),
 )
+
+register_env(
+    "Navix-FourRooms-5x5-v0",
+    lambda *args, **kwargs: FourRooms.create(
+        height=5,
+        width=5,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),
+        *args,
+        **kwargs,
+    ),
+)
+
+
+register_env(
+    "Navix-FourRooms-6x6-v0",
+    lambda *args, **kwargs: FourRooms.create(
+        height=6,
+        width=6,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),
+        *args,
+        **kwargs,
+    ),
+)
+
+register_env(
+    "Navix-FourRooms-8x8-v0",
+    lambda *args, **kwargs: FourRooms.create(
+        height=8,
+        width=8,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),
+        *args,
+        **kwargs,
+    ),
+)
+
+register_env(
+    "Navix-FourRooms-16x16-v0",
+    lambda *args, **kwargs: FourRooms.create(
+        height=16,
+        width=16,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),
+        *args,
+        **kwargs,
+    ),
+)

--- a/navix/environments/four_rooms.py
+++ b/navix/environments/four_rooms.py
@@ -119,10 +119,10 @@ register_env(
 )
 
 register_env(
-    "Navix-FourRooms-5x5-v0",
+    "Navix-FourRooms-7x7-v0",
     lambda *args, **kwargs: FourRooms.create(
-        height=5,
-        width=5,
+        height=7,
+        width=7,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
         termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),
@@ -133,10 +133,10 @@ register_env(
 
 
 register_env(
-    "Navix-FourRooms-6x6-v0",
+    "Navix-FourRooms-9x9-v0",
     lambda *args, **kwargs: FourRooms.create(
-        height=6,
-        width=6,
+        height=9,
+        width=9,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
         termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),
@@ -146,10 +146,10 @@ register_env(
 )
 
 register_env(
-    "Navix-FourRooms-8x8-v0",
+    "Navix-FourRooms-11x11-v0",
     lambda *args, **kwargs: FourRooms.create(
-        height=8,
-        width=8,
+        height=11,
+        width=11,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
         termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),
@@ -159,10 +159,36 @@ register_env(
 )
 
 register_env(
-    "Navix-FourRooms-16x16-v0",
+    "Navix-FourRooms-13x13-v0",
     lambda *args, **kwargs: FourRooms.create(
-        height=16,
-        width=16,
+        height=13,
+        width=13,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),
+        *args,
+        **kwargs,
+    ),
+)
+
+register_env(
+    "Navix-FourRooms-15x15-v0",
+    lambda *args, **kwargs: FourRooms.create(
+        height=15,
+        width=15,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),
+        *args,
+        **kwargs,
+    ),
+)
+
+register_env(
+    "Navix-FourRooms-17x17-v0",
+    lambda *args, **kwargs: FourRooms.create(
+        height=17,
+        width=17,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
         termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),


### PR DESCRIPTION
## Summary
Ports two clean, self-contained additions from [p-doom/navix](https://github.com/p-doom/navix) (found while scouting forks for portable work), cherry-picked with original authorship preserved:

- `disable_autoreset: bool` field on `Environment` (defaults `False`, fully backward-compatible). When set, `step()` skips the auto-reset-on-done behavior, so a terminal/truncated `Timestep` is returned as-is instead of silently resetting. Useful for eval loops, manual episode stepping, and debugging — a common ask for gym-style envs.
- 6 new `FourRooms` size registrations: `Navix-FourRooms-7x7-v0` through `-17x17-v0` (odd sizes, matching the room-splitting geometry), following the existing registration pattern exactly.

## Commits (cherry-picked, authorship preserved)
- `feat: disable autoreset on flag` (72e1eb5)
- `feat: four rooms env of different sizes` (c3bb465)
- `fix: odd numbers for four rooms` (6bc8170)
- `fix: jnp-native and/not` (cf75086)
- `fix: remove duplicate kwargs passing` (e990f74)

## Test plan
- [ ] CI passes (Test matrix, Compliance)
- [ ] Confirm `disable_autoreset=True` correctly keeps returning a terminal `Timestep` past `max_steps` instead of auto-resetting
- [ ] Confirm all 6 new `Navix-FourRooms-*-v0` IDs resolve via `nx.make(...)`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Be5vnY6tpvoTAwWAFN5mtH