### PR TITLE
fix: open() only consumes the key when actually unlocking a door

### DIFF
--- a/navix/actions.py
+++ b/navix/actions.py
@@ -29,7 +29,7 @@ import jax.numpy as jnp
 
 from .entities import Entities, Player
 from .states import EventsManager, State
-from .components import DISCARD_PILE_COORDS, Pickable
+from .components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID, Pickable
 from .grid import translate, rotate, positions_equal
 
 
@@ -266,20 +266,24 @@ def open(state: State) -> State:
     door_found = positions_equal(position_in_front, doors.position)
 
     # and that, if so, either it does not require a key or the player has the key
+    is_open = jnp.asarray(doors.open, dtype=jnp.bool_)
     locked = doors.requires != -1
     key_match = player.pocket == doors.requires
-    can_open = door_found & (key_match | ~locked)
+    can_unlock = door_found & locked & key_match
+    can_open = door_found & (can_unlock | ~locked)
 
     # update doors if closed and can_open
-    do_open = ~doors.open & can_open
-    open = jnp.where(do_open, True, doors.open)
+    do_open = ~is_open & can_open
+    open = jnp.where(do_open, True, is_open)
     requires = jnp.where(do_open, -1, doors.requires)
     doors = doors.replace(open=open, requires=requires)
 
-    # remove key from player's pocket
-    pocket = jnp.asarray(player.pocket * jnp.any(can_open), dtype=jnp.int32)
+    # remove key from player's pocket, but only when it was actually used to
+    # unlock a locked door - not merely because the door in front happened to
+    # be open or unlocked already
+    pocket = jnp.where(jnp.any(can_unlock), EMPTY_POCKET_ID, player.pocket)
     player = jax.lax.cond(
-        jnp.any(can_open), lambda: player.replace(pocket=pocket), lambda: player
+        jnp.any(can_unlock), lambda: player.replace(pocket=pocket), lambda: player
     )
 
     # update events

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -415,7 +415,18 @@ def test_open():
         doors.open, expected_open
     ), "Expected door open status {}, got {}".format(expected_open, doors.open)
 
-    # check that opening an open door keeps it open
+    # check that the key was consumed on unlocking
+    player = state.get_player()
+    player.check_ndim(batched=False)
+    expected_pocket = EMPTY_POCKET_ID
+    assert jnp.array_equal(
+        player.pocket, expected_pocket
+    ), "Expected key to be consumed after unlocking, pocket to be {}, got {}".format(
+        expected_pocket, player.pocket
+    )
+
+    # check that opening an open door keeps it open, and does not touch the
+    # (already-empty) pocket again
     state = nx.actions.open(state)
     doors = state.get_doors()
     doors.check_ndim(batched=True)
@@ -423,6 +434,13 @@ def test_open():
     assert jnp.array_equal(
         doors.open, expected_open
     ), "Expected door open status {}, got {}".format(expected_open, doors.open)
+    player = state.get_player()
+    player.check_ndim(batched=False)
+    assert jnp.array_equal(
+        player.pocket, expected_pocket
+    ), "Expected pocket to remain {} after opening an already-open door, got {}".format(
+        expected_pocket, player.pocket
+    )
 
     # check that we can walk through an open door
     state = nx.actions.forward(state)


### PR DESCRIPTION
## Summary
Found while scouting forks for portable work: `open()`'s key-removal step was gated on `can_open`, but `can_open` is true whenever a door is found and either unlocked or already opened with a matching key — including doors that don't need a key at all. The removal itself (`player.pocket * jnp.any(can_open)`) only ever ran inside the branch where `jnp.any(can_open)` is already `True`, making it a no-op: the key was never actually removed from the pocket on unlocking, and re-toggling an already-open door risked touching the pocket for no reason.

This splits `can_unlock` (door found, locked, and key matches) out from `can_open` (found and (unlocked-by-this-action or not locked)), and only clears the pocket — to `EMPTY_POCKET_ID`, not a zeroed multiply — when a door was actually unlocked. Also coerces `doors.open` to bool at read time in this function, consistent with the dtype-coercion pattern from #111 and `AGENTS.md`'s dtype-discipline note.

[taodav/navix](https://github.com/taodav/navix) has a version of this fix, bundled with an unrelated KeyCorridor goal-entity semantics change and a stray unresolved git-merge-conflict marker left in `rendering/registry.py`. This ports just the `actions.py` logic fix cleanly, hand-written against current `main`, rather than cherry-picking those commits directly.

## Test plan
- [ ] CI passes (Test matrix, Compliance)
- [ ] `tests/test_actions.py::test_open` — added assertions that the key is consumed (`pocket == EMPTY_POCKET_ID`) after unlocking a door, and that re-opening an already-open door doesn't touch the pocket again