### PR TITLE
fix(ci): claude.yml fails on PR comments - checkout by SHA

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          ref: ${{ github.sha }}
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,12 +25,6 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          ref: ${{ github.sha }}
-
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary
Fixes the `@claude` mention failure reported on PR #110 ([run](https://github.com/epignatelli/navix/actions/runs/31827643053)):

```
fatal: refusing to fetch into branch 'refs/heads/main' checked out at '/home/runner/work/navix/navix'
Action failed with error: Command failed: git fetch origin --depth=20 pull/110/head:main
```

**Root cause**: `claude-code-action` fetches a PR's head into a local ref named after the PR's own head branch (visible in the log: `git fetch origin pull/110/head:main`) - PR #110 collided because keraJLi opened it directly from their fork's `main` branch, so the target name was `main`, same as ours. This is a known, currently-unresolved upstream limitation ([claude-code-action#930](https://github.com/anthropics/claude-code-action/issues/930)) - a proper fix (unique `pr-{number}` branch names) shipped in v1.0.49 and was reverted in v1.0.50 because it broke pushing Claude's commits back to the PR branch ([#936](https://github.com/anthropics/claude-code-action/issues/936)).

**First commit** in this PR checked out by `github.sha` to sidestep the collision via detached HEAD. **Second commit** removes the checkout step entirely instead, which is the actual correct fix: the [official claude-code-action example workflow](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md) for this exact tag/mention mode has **no checkout step at all** - the action does its own PR checkout internally. `/install-github-app`'s generated template added a redundant one that isn't in the official template, and that's what put a real `main` branch in place for the action's own fetch to collide with. Removing it avoids the whole class of collision, not just the `main`-vs-`main` instance we happened to hit.

`claude-code-review.yml` keeps its checkout step deliberately - that mode needs local repo/diff access for code review, unlike tag mode.

## Test plan
- [ ] Merge, then comment `@claude` on an open PR (e.g. #117 or #118) and confirm the workflow succeeds instead of failing at checkout