### PR TITLE
fix(ci): restore claude.yml checkout with SHA ref (revert of #119's 2nd commit)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,6 +25,12 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
Restores the checkout step that #119's second commit removed. Verified on a live run that removing it entirely breaks in a new way (no .git for claude-code-action's own fetch to operate in), not the original way - see commit message for the run link and log.

Will merge and trigger a real @claude comment immediately after to confirm, rather than merge-and-hope again.