### PR TITLE
fix: FourRooms partition wall hardcoded to position 9

### DIFF
--- a/navix/actions.py
+++ b/navix/actions.py
@@ -269,21 +269,30 @@ def open(state: State) -> State:
     is_open = jnp.asarray(doors.open, dtype=jnp.bool_)
     locked = doors.requires != -1
     key_match = player.pocket == doors.requires
-    can_unlock = door_found & locked & key_match
-    can_open = door_found & (can_unlock | ~locked)
+    can_open = door_found & (key_match | ~locked)
 
-    # update doors if closed and can_open
+    # update doors if closed and can_open. Note: `is_open` is only used for
+    # the boolean predicate above - the write-back uses `doors.open` itself,
+    # not `is_open`, so `doors.open`'s original dtype (int or bool,
+    # depending on which environment constructed the door) is preserved via
+    # jnp.where's weak-type promotion. Writing back `is_open` instead would
+    # silently force every door to bool, which breaks jax.lax.switch's
+    # requirement that every action branch produce identical output dtypes.
     do_open = ~is_open & can_open
-    open = jnp.where(do_open, True, is_open)
+    open = jnp.where(do_open, True, doors.open)
     requires = jnp.where(do_open, -1, doors.requires)
     doors = doors.replace(open=open, requires=requires)
 
-    # remove key from player's pocket, but only when it was actually used to
-    # unlock a locked door - not merely because the door in front happened to
-    # be open or unlocked already
-    pocket = jnp.where(jnp.any(can_unlock), EMPTY_POCKET_ID, player.pocket)
+    # remove key from player's pocket, but only when this action actually
+    # unlocked a previously-closed, locked door with a matching key - not
+    # merely because the door in front happened to already be open (some
+    # environments, e.g. KeyCorridor, construct a door that is already open
+    # while still marked locked; `do_open` is False there, so the key is
+    # correctly left untouched)
+    unlocked = do_open & locked & key_match
+    pocket = jnp.where(jnp.any(unlocked), EMPTY_POCKET_ID, player.pocket)
     player = jax.lax.cond(
-        jnp.any(can_unlock), lambda: player.replace(pocket=pocket), lambda: player
+        jnp.any(unlocked), lambda: player.replace(pocket=pocket), lambda: player
     )
 
     # update events

--- a/navix/environments/four_rooms.py
+++ b/navix/environments/four_rooms.py
@@ -57,7 +57,7 @@ class FourRooms(Environment):
             k1, shape=(), minval=self.height // 2 + 2, maxval=self.height
         )
         openings = jnp.stack([opening_1, opening_2])
-        wall_pos_vert = vertical_wall(grid, 9, openings)
+        wall_pos_vert = vertical_wall(grid, self.width // 2, openings)
 
         # horizontal partition
         opening_1 = jax.random.randint(k2, shape=(), minval=1, maxval=self.width // 2)
@@ -65,7 +65,7 @@ class FourRooms(Environment):
             k1, shape=(), minval=self.width // 2 + 2, maxval=self.width
         )
         openings = jnp.stack([opening_1, opening_2])
-        wall_pos_hor = horizontal_wall(grid, 9, openings)
+        wall_pos_hor = horizontal_wall(grid, self.height // 2, openings)
 
         walls_pos = jnp.concatenate([wall_pos_vert, wall_pos_hor])
         walls = Wall.create(position=walls_pos)

--- a/navix/environments/four_rooms.py
+++ b/navix/environments/four_rooms.py
@@ -54,7 +54,7 @@ class FourRooms(Environment):
         # vertical partition
         opening_1 = jax.random.randint(k1, shape=(), minval=1, maxval=self.height // 2)
         opening_2 = jax.random.randint(
-            k1, shape=(), minval=self.height // 2 + 2, maxval=self.height
+            k1, shape=(), minval=self.height // 2 + 2, maxval=self.height - 1
         )
         openings = jnp.stack([opening_1, opening_2])
         wall_pos_vert = vertical_wall(grid, self.width // 2, openings)
@@ -62,7 +62,7 @@ class FourRooms(Environment):
         # horizontal partition
         opening_1 = jax.random.randint(k2, shape=(), minval=1, maxval=self.width // 2)
         opening_2 = jax.random.randint(
-            k1, shape=(), minval=self.width // 2 + 2, maxval=self.width
+            k2, shape=(), minval=self.width // 2 + 2, maxval=self.width - 1
         )
         openings = jnp.stack([opening_1, opening_2])
         wall_pos_hor = horizontal_wall(grid, self.height // 2, openings)

--- a/navix/states.py
+++ b/navix/states.py
@@ -364,7 +364,9 @@ class State(struct.PyTreeNode):
 
     def get_walls(self) -> Wall:
         """Gets all the `WALL` entities from the state."""
-        return self.entities.get(Entities.WALL, Wall())  # type: ignore
+        if Entities.WALL in self.entities:
+            return self.entities[Entities.WALL]  # type: ignore
+        return Wall.create(position=jnp.zeros((0, 2), dtype=jnp.int32))
 
     def set_walls(self, walls: Wall) -> State:
         """Sets the `WALL` entities in the state."""

--- a/navix/states.py
+++ b/navix/states.py
@@ -364,9 +364,7 @@ class State(struct.PyTreeNode):
 
     def get_walls(self) -> Wall:
         """Gets all the `WALL` entities from the state."""
-        if Entities.WALL in self.entities:
-            return self.entities[Entities.WALL]  # type: ignore
-        return Wall.create(position=jnp.zeros((0, 2), dtype=jnp.int32))
+        return self.entities[Entities.WALL]  # type: ignore
 
     def set_walls(self, walls: Wall) -> State:
         """Sets the `WALL` entities in the state."""

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -454,6 +454,78 @@ def test_open():
     )
 
 
+def test_open_preserves_door_dtype():
+    # KeyCorridor and GoToDoor construct doors with an int `open` field
+    # (Door.create doesn't coerce it); DoorKey uses bool. `open()` must
+    # preserve whatever dtype it's given - if it silently coerces to bool,
+    # the door-toggle branch of the jax.lax.switch dispatch in
+    # transitions.py ends up with a different output dtype than every
+    # sibling action branch (forward, pickup, drop, ...), which raises a
+    # trace-time TypeError for any environment with an int-typed door.
+    height, width = 5, 5
+    grid = jnp.zeros((height - 2, width - 2), dtype=jnp.int32)
+    grid = jnp.pad(grid, pad_width=1, mode="constant", constant_values=1)
+    key = jax.random.PRNGKey(0)
+    player = nx.entities.Player(
+        position=jnp.asarray((1, 1)), direction=jnp.asarray(0), pocket=EMPTY_POCKET_ID
+    )
+    doors = nx.entities.Door(
+        position=jnp.asarray((1, 3)),
+        requires=jnp.asarray(-1),
+        open=jnp.asarray(0, dtype=jnp.int32),
+        colour=PALETTE.YELLOW,
+    )
+    cache = nx.rendering.cache.RenderingCache.init(grid)
+    entities = {
+        Entities.PLAYER: player[None],
+        Entities.DOOR: doors[None],
+    }
+    state = State(key=key, grid=grid, cache=cache, entities=entities)
+
+    state = nx.actions.forward(state)  # move player to (1, 2), facing the door at (1, 3)
+    state = nx.actions.open(state)
+    doors = state.get_doors()
+    assert doors.open.dtype == jnp.int32, "Expected door open dtype to remain {}, got {}".format(
+        jnp.int32, doors.open.dtype
+    )
+
+
+def test_open_does_not_consume_key_for_already_open_door():
+    # KeyCorridor constructs its target door already `open` (truthy) while
+    # still `requires`-ing a key (locked) - a deliberate quirk of its
+    # design, not a state open() should treat as "just unlocked". Standing
+    # in front of such a door with the matching key must not destroy it,
+    # since nothing is actually being unlocked (the door is already open).
+    height, width = 5, 5
+    grid = jnp.zeros((height - 2, width - 2), dtype=jnp.int32)
+    grid = jnp.pad(grid, pad_width=1, mode="constant", constant_values=1)
+    key = jax.random.PRNGKey(0)
+    player = nx.entities.Player(
+        position=jnp.asarray((1, 1)), direction=jnp.asarray(0), pocket=jnp.asarray(1)
+    )
+    doors = nx.entities.Door(
+        position=jnp.asarray((1, 3)),
+        requires=jnp.asarray(1),
+        open=jnp.asarray(2),  # already open, mirrors KeyCorridor's construction
+        colour=PALETTE.YELLOW,
+    )
+    cache = nx.rendering.cache.RenderingCache.init(grid)
+    entities = {
+        Entities.PLAYER: player[None],
+        Entities.DOOR: doors[None],
+    }
+    state = State(key=key, grid=grid, cache=cache, entities=entities)
+
+    state = nx.actions.forward(state)  # move player to (1, 2), facing the door at (1, 3)
+    state = nx.actions.open(state)
+    player = state.get_player()
+    expected_pocket = jnp.asarray(1)
+    assert jnp.array_equal(player.pocket, expected_pocket), (
+        "Expected key to be left untouched for an already-open door, "
+        "pocket to be {}, got {}".format(expected_pocket, player.pocket)
+    )
+
+
 if __name__ == "__main__":
     # test_rotation()
     # test_move()

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -112,6 +112,31 @@ def test_fourrooms_sizes_partition_walls_are_centred():
             "outside the grid"
         )
 
+        # each stripe (height-2 or width-2 long) should have exactly 2
+        # openings removed; an out-of-range opening index (previously
+        # possible - see below) can silently remove the wrong stripe cell
+        # instead, leaving the wall cell count unchanged but the room
+        # potentially unsolvable rather than actually split in four
+        expected_wall_count = (height - 4) + (width - 4)
+        assert positions.shape[0] == expected_wall_count, (
+            f"FourRooms {height}x{width}: expected {expected_wall_count} "
+            f"partition wall cells, got {positions.shape[0]}"
+        )
+
+    # opening_2's draw range used to allow an out-of-range index into the
+    # wall stripe (maxval was exclusive but one too high) - for 7x7 this was
+    # a ~50% chance per reset, so check it holds across several seeds
+    for seed in range(10):
+        env = nx.environments.FourRooms.create(
+            height=7, width=7, observation_fn=nx.observations.none
+        )
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        positions = timestep.state.get_walls().position
+        assert positions.shape[0] == 6, (
+            f"FourRooms 7x7 seed={seed}: expected 6 partition wall cells, "
+            f"got {positions.shape[0]}"
+        )
+
 
 def test_disable_autoreset():
     def make_env(disable):

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -89,6 +89,62 @@ def test_keydoor2():
     return
 
 
+def test_fourrooms_sizes_partition_walls_are_centred():
+    # the partition walls used to be hardcoded at row/col 9, which only
+    # matched the original 19x19 default; for the smaller registered sizes
+    # (7x7 .. 17x17) that put the wall out of bounds or off-centre, so the
+    # room was never actually split into four rooms
+    for height, width in ((7, 7), (9, 9), (11, 11), (13, 13), (15, 15), (17, 17)):
+        env = nx.environments.FourRooms.create(
+            height=height, width=width, observation_fn=nx.observations.none
+        )
+        timestep = env.reset(jax.random.PRNGKey(0))
+        positions = timestep.state.get_walls().position
+        rows, cols = positions[:, 0], positions[:, 1]
+
+        on_cross = (rows == height // 2) | (cols == width // 2)
+        assert jnp.all(on_cross), (
+            f"FourRooms {height}x{width}: partition walls {positions} are not "
+            f"centred at row={height // 2} / col={width // 2}"
+        )
+        assert jnp.all((rows >= 0) & (rows < height) & (cols >= 0) & (cols < width)), (
+            f"FourRooms {height}x{width}: partition walls {positions} fall "
+            "outside the grid"
+        )
+
+
+def test_disable_autoreset():
+    def make_env(disable):
+        return nx.environments.Room.create(
+            height=5,
+            width=5,
+            max_steps=2,
+            observation_fn=nx.observations.none,
+            disable_autoreset=disable,
+        )
+
+    key = jax.random.PRNGKey(0)
+
+    env = make_env(disable=True)
+    timestep = env.reset(key)
+    for _ in range(5):
+        timestep = env.step(timestep, jnp.asarray(0))
+    assert (
+        timestep.step_type > 0
+    ), "expected step_type to stay terminal/truncated when disable_autoreset=True"
+    assert (
+        timestep.t > env.max_steps
+    ), "expected t to keep advancing past max_steps instead of autoresetting"
+
+    env2 = make_env(disable=False)
+    timestep2 = env2.reset(key)
+    for _ in range(5):
+        timestep2 = env2.step(timestep2, jnp.asarray(0))
+    assert (
+        timestep2.t <= env2.max_steps
+    ), "expected autoreset to reset t back down by default"
+
+
 if __name__ == "__main__":
     # test_room()
     # jax.jit(test_room)()


### PR DESCRIPTION
## Summary
Addresses review findings from Claude on two open/merged PRs:

### 1. FourRooms partition wall hardcoded to position 9 ([review on #117](https://github.com/epignatelli/navix/pull/117#issuecomment-5299110931))
`FourRooms._reset()` hardcodes the partition wall position as `9` - correct only for the original `19x19` default. For the 6 smaller sizes #117 registered (`7x7` through `17x17`), position `9` is out of bounds or badly off-centre, so those rooms likely weren't actually split into four quadrants.

Traced the exact bug: `vertical_wall(grid, X, openings)`'s `X` is used internally as the fixed **column** for a wall spanning the full height, and `horizontal_wall(grid, Y, openings)`'s `Y` is the fixed **row** for a wall spanning the full width - the opposite of what the parameter names (`row_idx` / `col_idx`) suggest. Since the `19x19` default is square, `9 == 19 // 2` regardless of which dimension it's meant to track, which is exactly why this was never caught. Fixed as `vertical_wall(grid, self.width // 2, ...)` and `horizontal_wall(grid, self.height // 2, ...)`.

### 2. Two regressions in `open()` from #118 ([review on #118](https://github.com/epignatelli/navix/pull/118), already merged)

1. **Dtype regression**: writing back `is_open` (always bool) instead of `doors.open` (whatever dtype the constructing environment used - int for KeyCorridor/GoToDoor, bool for DoorKey) meant every door's `open` field silently became bool after toggling. `toggle()` is dispatched via `jax.lax.switch` alongside sibling actions that don't touch `doors.open` at all, and `lax.switch` requires identical output dtypes across every branch - so this raised a trace-time `TypeError` for any env with an int-typed door. DoorKey's tests didn't catch it because DoorKey already uses bool.
2. **Key-destruction regression**: `can_unlock` didn't check whether the door was already open, only that it was found/locked/key-matching. KeyCorridor's target door is constructed already open (`open=jnp.asarray(2)`) while still locked (`requires=key_id`) - a pre-existing quirk of its design. Standing in front of it with the matching key destroyed the key for nothing, since `do_open` was `False` (already open) but the pocket got cleared anyway. Before #118 this couldn't happen (the old code was a provable no-op), so this was a new regression, not a pre-existing bug.

Fix: `is_open` is now used only for the boolean predicate (`do_open`), never written back - the `replace()` call uses `doors.open` directly, so dtype is preserved via `jnp.where`'s weak-type promotion, matching pre-#118 behaviour. Key consumption is now gated on `do_open & locked & key_match` (an actual closed -> open transition on a locked, matching door), not the weaker `can_unlock`.

## Test plan
- [ ] CI passes
- `tests/test_environments.py::test_fourrooms_sizes_partition_walls_are_centred` - new; asserts every partition-wall cell sits on the `row=height//2` / `col=width//2` cross and stays in-bounds, for all 6 new sizes. Fails against the old hardcoded `9`, passes with this fix.
- `tests/test_environments.py::test_disable_autoreset` - new; closes another review-flagged coverage gap. Confirms `step_type` stays terminal past `max_steps` when enabled, and autoresets by default when not.
- `tests/test_actions.py::test_open_preserves_door_dtype` - new; an int-dtype door (KeyCorridor/GoToDoor-style) stays int-dtype after `open()`.
- `tests/test_actions.py::test_open_does_not_consume_key_for_already_open_door` - new; a door that's already open-but-locked (KeyCorridor's actual construction) leaves the key untouched.

## Not addressed
The review on #117 also suggested adding the 6 new size IDs to `docs/home/environments.md`. Skipped: that table is a strict MiniGrid-ID -> NAVIX-ID mapping, and these sizes have no MiniGrid equivalent, so adding them would misleadingly imply MiniGrid has these sizes too.