### PR TITLE
ci: move pylint output to job summaries instead of a PR comment

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,12 @@ jobs:
           pip install pylint
           MESSAGE=$(pylint -ry $(git ls-files '*.py') ||:)
           echo "$MESSAGE"
+          {
+            echo "## Pylint report (full codebase)"
+            echo '```'
+            echo "$MESSAGE"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Run unit tests with pytest
         run: |
           wandb offline
@@ -55,12 +61,10 @@ jobs:
           else
             MESSAGE=$(pylint -ry --disable=E0401 $CURRENT_DIFF ||:)
           fi
-          echo 'MESSAGE<<EOF' >> $GITHUB_ENV
-          echo "<pre><code>$MESSAGE</code></pre>" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-          echo "Printing PR message: $MESSAGE"
-      - uses: mshick/add-pr-comment@v2
-        with:
-          issue: ${{ github.event.pull_request.number }}
-          message: ${{ env.MESSAGE }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          echo "$MESSAGE"
+          {
+            echo "## Pylint report (changed files)"
+            echo '```'
+            echo "$MESSAGE"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
`Compliance` posted its diff-scoped pylint output as a bot PR comment on every push (via `mshick/add-pr-comment@v2`), which needed `repo-token` write access for something purely informational. Moved both `Compliance`'s and `Test`'s pylint output to `$GITHUB_STEP_SUMMARY` instead - GitHub renders this directly on the workflow run page, same visibility, no PR comment noise, no write permission needed for `Compliance` anymore.

## Test plan
- [ ] CI passes
- [ ] Confirm the pylint report shows up under each job's Summary tab on the workflow run page, and no bot comment gets posted on this PR