### PR TITLE
fix: categorical_first_person no longer inverts entity transparency

### DIFF
--- a/navix/observations.py
+++ b/navix/observations.py
@@ -94,7 +94,7 @@ def categorical_first_person(state: State) -> Array:
     transparency_map = jnp.where(state.grid == 0, 1, 0)
     positions = state.get_positions()
     transparent = state.get_transparency()
-    transparency_map = transparency_map.at[tuple(positions.T)].set(~transparent)
+    transparency_map = transparency_map.at[tuple(positions.T)].set(transparent)
 
     # apply view mask
     player = state.get_player()

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 
 import navix as nx
 from navix.states import State
-from navix.entities import Entities, Player, Goal, Key, Door
+from navix.entities import Entities, EntityIds, Player, Goal, Key, Door
 from navix.components import EMPTY_POCKET_ID
 from navix.rendering.cache import RenderingCache, TILE_SIZE
 from navix.rendering.registry import SPRITES_REGISTRY, PALETTE
@@ -131,6 +131,44 @@ def test_categorical_first_person():
 
     obs = nx.observations.categorical_first_person(state)
     print(obs)
+
+
+def test_categorical_first_person_transparency_matches_rgb():
+    # regression test for #112: categorical_first_person negated
+    # transparency (`~transparent`) while rgb_first_person did not, so a
+    # transparent entity (e.g. a Key, which Entity.transparent documents as
+    # True) incorrectly blocked vision under categorical_first_person while
+    # correctly letting it through under rgb_first_person - the two
+    # observation types disagreed about which entities occlude vision.
+    height, width = 10, 10
+    grid = jnp.zeros((height - 2, width - 2), dtype=jnp.int32)
+    grid = jnp.pad(grid, 1, mode="constant", constant_values=-1)
+
+    player = Player(
+        position=jnp.asarray((1, 1)), direction=jnp.asarray(0), pocket=EMPTY_POCKET_ID
+    )
+    # a transparent entity directly in front of the player...
+    key = Key(position=jnp.asarray((1, 2)), id=jnp.asarray(0), colour=PALETTE.YELLOW)
+    # ...must not hide what's behind it
+    goal = Goal.create(position=jnp.asarray((1, 3)), probability=jnp.asarray(1.0))
+
+    entities = {
+        Entities.PLAYER: player[None],
+        Entities.KEY: key[None],
+        Entities.GOAL: goal[None],
+    }
+    state = State(
+        key=jax.random.PRNGKey(0),
+        grid=grid,
+        cache=RenderingCache.init(grid),
+        entities=entities,
+    )
+
+    obs = nx.observations.categorical_first_person(state)
+    assert jnp.any(obs == EntityIds.GOAL), (
+        "Expected the Goal to be visible through the transparent Key, "
+        "got observation:\n{}".format(obs)
+    )
 
 
 def test_rgb_first_person():


### PR DESCRIPTION
## Summary
Fixes #112.

\`categorical_first_person\` and \`rgb_first_person\` built the same view-cone transparency map with opposite conventions:

\`\`\`python
# categorical_first_person
transparency_map = transparency_map.at[tuple(positions.T)].set(~transparent)

# rgb_first_person
transparency_map = transparency_map.at[tuple(positions.T)].set(transparent)
\`\`\`

The map's own construction (\`jnp.where(state.grid == 0, 1, 0)\`) writes floor as \`1\` and walls as \`0\` — i.e. **1 = light passes, 0 = blocks** — matching \`view_cone\`'s diffusion, which multiplies by the map and stops propagation at \`0\`. \`Entity.get_transparency()\` means "light passes through this entity", so writing it un-negated (\`rgb_first_person\`'s way) matches the convention; negating it (\`categorical_first_person\`'s way) inverted every entity's occlusion — a closed door blocked vision under \`rgb_first_person\` but *let it through* under \`categorical_first_person\`, and vice versa for open doors/other entities.

Confirmed against MiniGrid 3.1.0 per the issue: only \`Wall.see_behind()\` returns \`False\`; \`Ball\`/\`Box\`/\`Key\` all return \`True\` — matching the un-negated convention, not the negated one.

## Test plan
- [x] CI passes
- \`tests/test_observations.py::test_categorical_first_person_transparency_matches_rgb\` — new; places a transparent \`Key\` directly in front of the player with a \`Goal\` one cell further, asserts the \`Goal\` is visible through the \`Key\`. Fails against the old negated code, passes with the fix.

## Note on impact
Per the issue: this changes every \`categorical_first_person\` observation in the library (entities now correctly let vision through instead of blocking it, and vice versa) — anyone with agents trained on this observation type will see a behavior change. Worth calling out in release notes.