### PR TITLE
ci: switch PyPI publish to Trusted Publishing

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -74,7 +77,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
-          password: ${{ secrets.PYPI_API_KEY }}
 
   deploy-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds an explicit `permissions:` block to the `release` job in `.github/workflows/CD.yml`, granting `id-token: write` (required for OIDC-based PyPI Trusted Publishing) and `contents: write` (the job already pushes a version-bump commit/tag and creates a GitHub release; this was previously working via ambient/default repo permissions, which get replaced — not supplemented — by any explicit `permissions:` block, so `contents: write` is kept explicit to avoid a regression).
- Removes the `password: ${{ secrets.PYPI_API_KEY }}` line from the "Publish distribution 📦 to PyPI" step. `pypa/gh-action-pypi-publish` auto-detects Trusted Publishing via the workflow's OIDC token when no `password` is supplied.
- Does **not** remove the `PYPI_API_KEY` repository secret — that's a manual follow-up only after a real release confirms the new flow works, not part of this PR.

## Why

Per #116: the `0.7.5` release run's annotations flagged that PyPI supports Trusted Publishing as an alternative to the long-lived `PYPI_API_KEY` secret, and noted that having `password:` set alongside `attestations: true` was silently disabling attestations. Moving to Trusted Publishing removes the long-lived credential from repo secrets (smaller blast radius if ever leaked), re-enables build attestations, and follows PyPI's recommended approach.

The PyPI project's Trusted Publisher entry for this repo/workflow (`epignatelli/navix`, `CD.yml`, `release` job) has already been registered on PyPI by the repo owner, so no further PyPI-side configuration is needed.

## Test plan

- [x] YAML is valid and the diff is minimal/reviewed by hand.
- [x] CI on this PR (lint, tests, compliance) — validates nothing broke elsewhere, but **cannot** exercise the actual Trusted Publishing/OIDC exchange, since that only happens at real `pypa/gh-action-pypi-publish` publish time against PyPI's OIDC endpoint, which only runs in the `release` job on push to `main`.
- [ ] Final verification: the next real release merged to `main` must be watched to confirm PyPI accepts the OIDC-based publish (and that attestations are now generated) before the `PYPI_API_KEY` secret is removed as a follow-up.

Fixes #116