### PR TITLE
fix: walking into a ball now records a ball_hit event

### DIFF
--- a/navix/states.py
+++ b/navix/states.py
@@ -121,6 +121,8 @@ class EventsManager(struct.PyTreeNode):
             return self.record_wall_hit(entity, position)
         elif isinstance(entity, Lava):
             return self.record_lava_fall(entity, position)
+        elif isinstance(entity, Ball):
+            return self.record_ball_hit(entity)
         return self
 
     def record_pickup(self, entity: Entity, position: Array) -> EventsManager:

--- a/navix/states.py
+++ b/navix/states.py
@@ -122,7 +122,8 @@ class EventsManager(struct.PyTreeNode):
         elif isinstance(entity, Lava):
             return self.record_lava_fall(entity, position)
         elif isinstance(entity, Ball):
-            return self.record_ball_hit(entity)
+            idx = jnp.where(entity.position == position, size=1)[0][0]
+            return self.record_ball_hit(entity[idx])
         return self
 
     def record_pickup(self, entity: Entity, position: Array) -> EventsManager:

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -24,6 +24,11 @@ import jax.numpy as jnp
 
 import navix as nx
 from navix import observations
+from navix.components import EMPTY_POCKET_ID
+from navix.entities import Ball, Entities, Player
+from navix.rendering.cache import RenderingCache
+from navix.rendering.registry import PALETTE
+from navix.states import State
 
 
 def test_82():
@@ -49,5 +54,46 @@ def test_82():
     assert jnp.array_equal(prev_pos, pos)
 
 
+def test_91():
+    # https://github.com/epignatelli/navix/issues/91
+    # walking into a ball must record a ball_hit event (and so terminate,
+    # via the default on_ball_hit termination), matching MiniGrid's
+    # DynamicObstacles semantics. record_walk_into previously only handled
+    # Goal/Wall/Lava, so the player's own move into a ball was silently a
+    # no-op: blocked (Ball.walkable=False) but no event recorded.
+    height, width = 5, 5
+    grid = jnp.zeros((height - 2, width - 2), dtype=jnp.int32)
+    grid = jnp.pad(grid, pad_width=1, mode="constant", constant_values=1)
+    player = Player(
+        position=jnp.asarray((1, 1)), direction=jnp.asarray(0), pocket=EMPTY_POCKET_ID
+    )
+    ball = Ball.create(
+        position=jnp.asarray((1, 2)),
+        colour=PALETTE.BLUE,
+        probability=jnp.asarray(0.0),
+    )
+    cache = RenderingCache.init(grid)
+    state = State(
+        key=jax.random.PRNGKey(0),
+        grid=grid,
+        cache=cache,
+        entities={
+            Entities.PLAYER: player[None],
+            Entities.BALL: ball[None],
+        },
+    )
+
+    state = nx.actions.forward(state)  # player attempts to walk into the ball
+
+    player = state.get_player()
+    assert jnp.array_equal(player.position, jnp.asarray((1, 1))), (
+        "Expected the player to remain in place, since balls are not walkable"
+    )
+    assert state.events.ball_hit.happened, (
+        "Expected walking into a ball to record a ball_hit event"
+    )
+
+
 if __name__ == "__main__":
     test_82()
+    test_91()


### PR DESCRIPTION
## Summary
Fixes #91 (partially - see below).

`record_walk_into` in `states.py` only handled `Goal`/`Wall`/`Lava`, so when the player's own action moved them into a ball, the move was correctly blocked (`Ball.walkable=False`) but no `ball_hit` event was ever recorded - meaning `DEFAULT_TERMINATION`'s `on_ball_hit` never fired for this case, unlike MiniGrid's `DynamicObstacles`, where stepping onto an obstacle terminates the episode. Adds the missing `Ball` branch, dispatching to the already-existing `record_ball_hit`.

## What's not touched
The issue described two bugs. The second - balls spawning onto/through the agent without registering a hit - doesn't reproduce against current `main`: `transitions.py`'s `_can_spawn_there` already blocks a ball from moving onto the agent's cell and correctly records the hit when it tries. That logic appears to have already been fixed since the issue was filed (2024), so this PR only addresses the first bug.

## Test plan
- [ ] CI passes
- `tests/test_issues.py::test_91` - new; constructs a player next to a ball, calls `forward()`, asserts the player stays in place (blocked) and `state.events.ball_hit.happened` is `True`. Fails against the old code (event never set), passes with the fix.

Note: `tests/issue_92.py` and `tests/issue_95.py` exist in this repo as a per-issue test convention but don't match pytest's default `test_*.py` discovery pattern, so they're not actually collected/run - pre-existing and unrelated to this PR, not touched here. Followed `tests/test_issues.py` (which *is* collected) instead.