### PR TITLE
ci: require manual approval for the Test matrix on every push

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   Test:
     runs-on: ${{ matrix.os }}-latest
+    environment: ci-approval
     strategy:
       fail-fast: false
       max-parallel: 5


### PR DESCRIPTION
## Summary
You wanted a way to avoid the Test matrix running automatically on every commit - a manual "approve to run" gate, like the one that already applies to first-time external contributors, but for every push.

Created a \`ci-approval\` GitHub Environment (required reviewer: you, no branch restriction) and set the \`Test\` job to require it. \`Compliance\` and \`claude-code-review.yml\`'s \`claude-review\` stay automatic (fast/cheap, per your scope choice).

## How it'll look
After this merges, every push to a PR will show the \`Test\` matrix jobs sitting in "Waiting" until you click approve on the run's "Review pending deployments" prompt - one approval action covers all 3 Python versions in that push, not three separate clicks.

## Note
The environment has \`can_admins_bypass: true\` (GitHub's default) - as a repo admin you technically have a bypass option in the approval UI, but the pending-approval prompt still shows up for every run.

## Test plan
- [ ] Merge, then push a follow-up commit to any open PR and confirm the Test jobs sit pending until manually approved