### PR TITLE
perf: skip per-step log indexing for steps log_frequency discards

### DIFF
--- a/benchmarks/navix_.py
+++ b/benchmarks/navix_.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
         seeds=tuple(range(args.seeds_offset, args.seeds_offset + args.n_seeds)),
         group="navix",
     )
-    train_state, logs = experiment.run(do_log=False)
+    train_state, logs = experiment.run(log_to_wandb=False)
 
     print("Logging final results to wandb...")
     start_time = time.time()
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     logs_avg = jax.tree.map(lambda x: x.mean(axis=0), logs)
     config = {**vars(experiment), **asdict(agent.hparams)}
     wandb.init(project=experiment.name, config=config, group=experiment.group)
-    agent.log_on_train_end(logs_avg)
+    agent.log_to_wandb_on_train_end(logs_avg)
     wandb.finish()
     logging_time = time.time() - start_time
     print(f"Logging time cost: {logging_time}")

--- a/navix/__init__.py
+++ b/navix/__init__.py
@@ -32,6 +32,7 @@ from . import (
     transitions,
     events,
     agents,
+    plotting,
 )
 
 from .environments.registry import make, register_env, registry

--- a/navix/agents/agent.py
+++ b/navix/agents/agent.py
@@ -39,19 +39,30 @@ class Agent(struct.PyTreeNode):
 
         if "done_mask" in logs:
             mask = jnp.asarray(logs.pop("done_mask"), dtype=jnp.bool)  # (T, N)
+            # Masked mean via sum/count instead of boolean-indexing
+            # (`lengths[mask]`) - mask[mask] has a *dynamic* shape (however
+            # many episodes finished this update, which varies every call),
+            # so JAX must recompile a fresh XLA program for every distinct
+            # count it hasn't seen before. Profiling showed this was ~60%
+            # of total per-call logging time. jnp.where + jnp.sum keeps the
+            # shape fixed at (T, N) -> scalar regardless of how many
+            # entries are masked, so XLA compiles it once and reuses it.
+            mask_count = jnp.sum(mask)
             # log episode length
             if "lengths" in logs:
                 lengths: jax.Array = logs.pop("lengths")  # (T, N)
-                episode_lengths = lengths[mask]  # (K,)
-                logs["perf/episode_length"] = jnp.mean(episode_lengths)
+                logs["perf/episode_length"] = (
+                    jnp.sum(jnp.where(mask, lengths, 0)) / mask_count
+                )
                 msg += f", Length: {logs['perf/episode_length']}"
 
             # log returns
             if "returns" in logs:
                 returns = logs.pop("returns")  # (T, N)
-                final_returns = returns[mask]  # (K,)
-                logs["perf/returns"] = jnp.mean(final_returns)
-                logs["perf/success_rate"] = jnp.mean(final_returns == 1.0)
+                logs["perf/returns"] = jnp.sum(jnp.where(mask, returns, 0)) / mask_count
+                logs["perf/success_rate"] = (
+                    jnp.sum(jnp.where(mask, returns == 1.0, False)) / mask_count
+                )
                 msg += f", Returns: {logs['perf/returns']}, Success Rate: {logs['perf/success_rate']}"
 
         msg += f", Logging time cost: {time.time() - start_time}"

--- a/navix/agents/agent.py
+++ b/navix/agents/agent.py
@@ -60,6 +60,16 @@ class Agent(struct.PyTreeNode):
     def log_on_train_end(self, logs):
         print(jax.tree.map(lambda x: x.shape, logs))
         len_logs = len(logs["iter/updates"])
+        updates = logs["iter/updates"]
         for step in range(len_logs):
+            # skip steps self.log() would discard anyway (see the
+            # log_frequency check below), before paying for the
+            # device-to-host transfer of indexing into every array in
+            # `logs` - wandb.log() and this per-step tree indexing were
+            # previously done unconditionally for every recorded step,
+            # which is why disabling wandb logging entirely (do_log=False)
+            # was so much faster than leaving it on
+            if updates[step] % self.hparams.log_frequency != 0:
+                continue
             step_logs = {k: jax.tree.map(lambda x: x[step], v) for k, v in logs.items()}
             self.log(step_logs)

--- a/navix/agents/agent.py
+++ b/navix/agents/agent.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import time
+import warnings
 from typing import Dict, Tuple
 
 import numpy as np
@@ -41,12 +42,27 @@ class HParams(struct.PyTreeNode):
 
 
 class Agent(struct.PyTreeNode):
+    """Two strategies exist for looking at a run's results, and they trade off
+    against each other:
+
+    - `Experiment.run(log_to_wandb=True)` (the default) streams metrics to
+      Weights & Biases as training progresses, via `log_to_wandb`/
+      `log_to_wandb_on_train_end` below. This is the slow path - real
+      network I/O, roughly linear in the number of seeds - but gives you
+      wandb's hosted dashboards, run comparison, etc.
+    - `Experiment.run(log_to_wandb=False)` skips wandb entirely and just
+      returns `logs` (the same pytree these methods consume) directly - no
+      network calls, so it's dramatically faster. Pair it with
+      `navix.plotting` to get a local matplotlib dashboard from `logs`
+      instead of a wandb one. See issue #60.
+    """
+
     hparams: HParams
 
     def train(self, rng: jax.Array) -> Tuple[TrainState, Dict[str, jax.Array]]:
         raise NotImplementedError
 
-    def log(self, logs, inspectable=None, run=None):
+    def log_to_wandb(self, logs, inspectable=None, run=None):
         if len(logs) == 0 or logs["iter/updates"] % self.hparams.log_frequency != 0:
             return
 
@@ -82,19 +98,40 @@ class Agent(struct.PyTreeNode):
         # Experiment.run's per-seed logging loop).
         (run or wandb).log(logs, step=step)
 
-    def log_on_train_end(self, logs, run=None):
+    def log(self, logs, inspectable=None, run=None):
+        """Deprecated: use `log_to_wandb` instead."""
+        warnings.warn(
+            "Agent.log is deprecated, use Agent.log_to_wandb instead - this "
+            "method only ever sent data to wandb, so the name now says so.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.log_to_wandb(logs, inspectable=inspectable, run=run)
+
+    def log_to_wandb_on_train_end(self, logs, run=None):
         print(jax.tree.map(lambda x: x.shape, logs))
         len_logs = len(logs["iter/updates"])
         updates = logs["iter/updates"]
         for step in range(len_logs):
-            # skip steps self.log() would discard anyway (see the
+            # skip steps log_to_wandb() would discard anyway (see the
             # log_frequency check below), before paying for the
             # device-to-host transfer of indexing into every array in
             # `logs` - wandb.log() and this per-step tree indexing were
             # previously done unconditionally for every recorded step,
-            # which is why disabling wandb logging entirely (do_log=False)
-            # was so much faster than leaving it on
+            # which is why disabling wandb logging entirely
+            # (log_to_wandb=False) was so much faster than leaving it on
             if updates[step] % self.hparams.log_frequency != 0:
                 continue
             step_logs = {k: jax.tree.map(lambda x: x[step], v) for k, v in logs.items()}
-            self.log(step_logs, run=run)
+            self.log_to_wandb(step_logs, run=run)
+
+    def log_on_train_end(self, logs, run=None):
+        """Deprecated: use `log_to_wandb_on_train_end` instead."""
+        warnings.warn(
+            "Agent.log_on_train_end is deprecated, use "
+            "Agent.log_to_wandb_on_train_end instead - this method only "
+            "ever sent data to wandb, so the name now says so.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.log_to_wandb_on_train_end(logs, run=run)

--- a/navix/agents/agent.py
+++ b/navix/agents/agent.py
@@ -93,9 +93,10 @@ class Agent(struct.PyTreeNode):
         msg += f", Logging time cost: {time.time() - start_time}"
         # Use the explicit Run object when given, rather than the
         # module-level wandb.log, which only tracks one implicit
-        # "current run" and is unsafe when multiple runs are being
-        # logged concurrently from different threads (see
-        # Experiment.run's per-seed logging loop).
+        # "current run" - needed when multiple runs are being logged
+        # concurrently, each in its own process (see Experiment.run's
+        # per-seed logging loop, and _log_run_to_wandb's docstring for
+        # why this needs to be process- rather than thread-based).
         (run or wandb).log(logs, step=step)
 
     def log(self, logs, inspectable=None, run=None):

--- a/navix/agents/agent.py
+++ b/navix/agents/agent.py
@@ -10,6 +10,28 @@ from flax import struct
 from flax.training.train_state import TrainState
 
 
+def masked_mean(values: jax.Array, mask: jax.Array, axis=None) -> jax.Array:
+    """Mean of `values` over entries where `mask` is True, computed via a masked
+    sum/count rather than boolean-indexing `values[mask]`. Boolean-indexing
+    produces a dynamically-shaped result (its size depends on how many
+    entries are True, which usually varies across calls), forcing JAX to
+    recompile a fresh XLA program for every distinct count it hasn't seen
+    before. This keeps the output shape fixed - `values.shape` reduced
+    over `axis` - regardless of how many entries are masked, so XLA
+    compiles it once and reuses it.
+
+    Args:
+        values (Array): The values to average.
+        mask (Array): A boolean array, broadcastable to `values.shape`,
+            selecting which entries to include.
+        axis: The axis or axes to reduce over. `None` reduces to a scalar.
+
+    Returns:
+        Array: The mean of `values` where `mask` is True, reduced over `axis`."""
+    mask = jnp.asarray(mask, dtype=jnp.bool_)
+    return jnp.sum(jnp.where(mask, values, 0), axis=axis) / jnp.sum(mask, axis=axis)
+
+
 class HParams(struct.PyTreeNode):
     debug: bool = struct.field(pytree_node=False, default=False)
     """Whether to run in debug mode."""
@@ -24,7 +46,7 @@ class Agent(struct.PyTreeNode):
     def train(self, rng: jax.Array) -> Tuple[TrainState, Dict[str, jax.Array]]:
         raise NotImplementedError
 
-    def log(self, logs, inspectable=None):
+    def log(self, logs, inspectable=None, run=None):
         if len(logs) == 0 or logs["iter/updates"] % self.hparams.log_frequency != 0:
             return
 
@@ -38,37 +60,29 @@ class Agent(struct.PyTreeNode):
             logs[f"render/human"] = wandb.Video(np.array(render_human), fps=4)
 
         if "done_mask" in logs:
-            mask = jnp.asarray(logs.pop("done_mask"), dtype=jnp.bool)  # (T, N)
-            # Masked mean via sum/count instead of boolean-indexing
-            # (`lengths[mask]`) - mask[mask] has a *dynamic* shape (however
-            # many episodes finished this update, which varies every call),
-            # so JAX must recompile a fresh XLA program for every distinct
-            # count it hasn't seen before. Profiling showed this was ~60%
-            # of total per-call logging time. jnp.where + jnp.sum keeps the
-            # shape fixed at (T, N) -> scalar regardless of how many
-            # entries are masked, so XLA compiles it once and reuses it.
-            mask_count = jnp.sum(mask)
+            mask = jnp.asarray(logs.pop("done_mask"), dtype=jnp.bool_)  # (T, N)
             # log episode length
             if "lengths" in logs:
                 lengths: jax.Array = logs.pop("lengths")  # (T, N)
-                logs["perf/episode_length"] = (
-                    jnp.sum(jnp.where(mask, lengths, 0)) / mask_count
-                )
+                logs["perf/episode_length"] = masked_mean(lengths, mask)
                 msg += f", Length: {logs['perf/episode_length']}"
 
             # log returns
             if "returns" in logs:
                 returns = logs.pop("returns")  # (T, N)
-                logs["perf/returns"] = jnp.sum(jnp.where(mask, returns, 0)) / mask_count
-                logs["perf/success_rate"] = (
-                    jnp.sum(jnp.where(mask, returns == 1.0, False)) / mask_count
-                )
+                logs["perf/returns"] = masked_mean(returns, mask)
+                logs["perf/success_rate"] = masked_mean(returns == 1.0, mask)
                 msg += f", Returns: {logs['perf/returns']}, Success Rate: {logs['perf/success_rate']}"
 
         msg += f", Logging time cost: {time.time() - start_time}"
-        wandb.log(logs, step=step)
+        # Use the explicit Run object when given, rather than the
+        # module-level wandb.log, which only tracks one implicit
+        # "current run" and is unsafe when multiple runs are being
+        # logged concurrently from different threads (see
+        # Experiment.run's per-seed logging loop).
+        (run or wandb).log(logs, step=step)
 
-    def log_on_train_end(self, logs):
+    def log_on_train_end(self, logs, run=None):
         print(jax.tree.map(lambda x: x.shape, logs))
         len_logs = len(logs["iter/updates"])
         updates = logs["iter/updates"]
@@ -83,4 +97,4 @@ class Agent(struct.PyTreeNode):
             if updates[step] % self.hparams.log_frequency != 0:
                 continue
             step_logs = {k: jax.tree.map(lambda x: x[step], v) for k, v in logs.items()}
-            self.log(step_logs)
+            self.log(step_logs, run=run)

--- a/navix/agents/agent.py
+++ b/navix/agents/agent.py
@@ -93,10 +93,9 @@ class Agent(struct.PyTreeNode):
         msg += f", Logging time cost: {time.time() - start_time}"
         # Use the explicit Run object when given, rather than the
         # module-level wandb.log, which only tracks one implicit
-        # "current run" - needed when multiple runs are being logged
-        # concurrently, each in its own process (see Experiment.run's
-        # per-seed logging loop, and _log_run_to_wandb's docstring for
-        # why this needs to be process- rather than thread-based).
+        # "current run" - lets a caller log to a specific Run explicitly
+        # (e.g. Experiment.run's per-seed loop) rather than relying on
+        # whichever run wandb.init() last set as "current".
         (run or wandb).log(logs, step=step)
 
     def log(self, logs, inspectable=None, run=None):

--- a/navix/agents/ppo.py
+++ b/navix/agents/ppo.py
@@ -83,21 +83,6 @@ class PPO(Agent):
     network: ActorCritic = struct.field(pytree_node=False)
     env: Environment
 
-    DIAGNOSTIC_METRICS = {
-        "loss/total_loss": "Total Loss",
-        "loss/actor_loss": "Actor (Policy) Loss",
-        "loss/value_loss": "Value Loss",
-        "loss/entropy": "Policy Entropy",
-        "loss/approx_kl": "Approx. KL Divergence",
-        "loss/clipfrac": "Clip Fraction",
-        "iter/learning_rate": "Learning Rate",
-    }
-    """PPO-specific diagnostics: how the algorithm's own inner machinery
-    (its loss terms, entropy, learning-rate schedule) behaved during
-    training - not intended to be compared across different algorithms,
-    unlike `navix.plotting.MANDATORY_METRICS`. Pass to
-    `navix.plotting.plot_dashboard(logs, diagnostic_metrics=PPO.DIAGNOSTIC_METRICS)`."""
-
     def collect_experience(
         self, train_state: TrainingState
     ) -> Tuple[TrainingState, Buffer]:

--- a/navix/agents/ppo.py
+++ b/navix/agents/ppo.py
@@ -83,6 +83,21 @@ class PPO(Agent):
     network: ActorCritic = struct.field(pytree_node=False)
     env: Environment
 
+    DIAGNOSTIC_METRICS = {
+        "loss/total_loss": "Total Loss",
+        "loss/actor_loss": "Actor (Policy) Loss",
+        "loss/value_loss": "Value Loss",
+        "loss/entropy": "Policy Entropy",
+        "loss/approx_kl": "Approx. KL Divergence",
+        "loss/clipfrac": "Clip Fraction",
+        "iter/learning_rate": "Learning Rate",
+    }
+    """PPO-specific diagnostics: how the algorithm's own inner machinery
+    (its loss terms, entropy, learning-rate schedule) behaved during
+    training - not intended to be compared across different algorithms,
+    unlike `navix.plotting.MANDATORY_METRICS`. Pass to
+    `navix.plotting.plot_dashboard(logs, diagnostic_metrics=PPO.DIAGNOSTIC_METRICS)`."""
+
     def collect_experience(
         self, train_state: TrainingState
     ) -> Tuple[TrainingState, Buffer]:

--- a/navix/agents/ppo.py
+++ b/navix/agents/ppo.py
@@ -354,5 +354,6 @@ class PPO(Agent):
         train_state, logs = jax.lax.scan(self.update, train_state, length=num_updates)
         elapsed = time.time() - start_time
         logs["iter/fps"] = jnp.asarray([train_state.frames / elapsed] * num_updates)
+        logs["iter/wall_time"] = jnp.asarray([elapsed] * num_updates)
 
         return train_state, logs

--- a/navix/agents/ppo.py
+++ b/navix/agents/ppo.py
@@ -296,7 +296,7 @@ class PPO(Agent):
 
         # Debugging mode
         if self.hparams.debug:
-            jax.debug.callback(self.log, logs, experience)
+            jax.debug.callback(self.log_to_wandb, logs, experience)
 
         return train_state, logs
 

--- a/navix/experiment.py
+++ b/navix/experiment.py
@@ -1,74 +1,41 @@
-from concurrent.futures import ProcessPoolExecutor
 from dataclasses import asdict, replace, fields
-import multiprocessing
 import time
 import warnings
 from typing import Dict, Optional, Tuple
 
 import distrax
-import numpy as np
 import jax
 import jax.numpy as jnp
 import wandb
 import wandb.util
-from navix.agents.agent import Agent, HParams
+from navix.agents.agent import Agent
 from navix.environments.environment import Environment
 
-
-def _to_numpy(x):
-    """Converts a JAX array (or anything array-like) to a plain numpy array,
-    leaving everything else untouched. Used to strip out live JAX device
-    buffers before crossing a process boundary - see `_log_run_to_wandb`."""
-    return np.asarray(x) if isinstance(x, jax.Array) else x
-
-
-def _cpu_only_worker_init():
-    """`ProcessPoolExecutor` initializer (runs once per worker process,
-    before any task). Hides the GPU from the child process entirely, so no
-    worker can ever create a CUDA context - belt-and-braces on top of using
-    `spawn` (see `_log_run_to_wandb`'s docstring for why `spawn` alone is
-    already safe here)."""
-    import os
-
-    os.environ["CUDA_VISIBLE_DEVICES"] = ""
-    os.environ["JAX_PLATFORMS"] = "cpu"
-
-
-def _log_run_to_wandb(
-    hparams: HParams, project: str, config: dict, group: str, log_np: dict
-):
-    """Runs one wandb Run (`init` -> `log_to_wandb_on_train_end` -> `finish`)
-    for a single seed/hparam-set, in its own OS process rather than a
-    thread.
-
-    wandb's SDK carries global/singleton state that isn't actually isolated
-    per `Run` instance across threads - concurrent `wandb.init()` calls from
-    multiple threads have been observed to race into a real login attempt
-    even under `wandb offline`, and even serializing just `wandb.init()`
-    still left runs getting corrupted ("Run (...) is finished. The call to
-    `log` will be ignored.") when multiple threads logged to their own
-    `Run` objects concurrently. Separate OS processes don't share that
-    state at all, matching wandb's own multiprocessing-oriented docs.
-
-    Safe from the usual JAX/CUDA fork hazard (forking a process after CUDA
-    is initialized in the parent is undefined behavior) because the caller
-    uses `multiprocessing.get_context("spawn")`: `spawn` starts a fresh
-    interpreter with nothing inherited from the parent, rather than forking
-    its memory (including its live CUDA context) - so this is safe
-    regardless of whether the parent's training has already finished, not
-    because of the timing. `_cpu_only_worker_init` additionally hides the
-    GPU from this process entirely, so nothing here can create a CUDA
-    context even by accident.
-
-    `log_np` must already be plain numpy (no JAX arrays) - see `_to_numpy` -
-    since JAX device buffers aren't guaranteed to survive being pickled
-    across a process boundary.
-    """
-    import wandb
-
-    run = wandb.init(project=project, config=config, group=group)
-    Agent(hparams=hparams).log_to_wandb_on_train_end(log_np, run=run)
-    run.finish()
+# Logging to wandb is sequential, one seed/hparam-set at a time - both
+# concurrency options that were tried here turned out not to hold up:
+#
+# - Threads: wandb's SDK carries global/singleton state that isn't
+#   actually isolated per Run instance across threads. Concurrent
+#   wandb.init() calls from multiple threads raced into a real login
+#   attempt even under `wandb offline`; serializing just wandb.init()
+#   with a lock still left runs corrupted ("Run (...) is finished. The
+#   call to `log` will be ignored.") when multiple threads logged to
+#   their own Run objects concurrently.
+# - Processes (spawn, to stay safe w.r.t. JAX/CUDA - forking a process
+#   after CUDA is initialized in the parent is undefined behavior
+#   regardless of timing, since every thread but the calling one just
+#   vanishes in the child, taking whatever locks it held with it):
+#   measured on a real GPU across 1/2/4/8 seeds, spawning a process per
+#   seed was 1.4-2.8x *slower* than sequential up to 4 seeds (each
+#   worker re-imports the entire jax/flax/distrax/tensorflow_probability/
+#   wandb stack from a cold interpreter), only broke even around 8, and
+#   at 16 concurrent workers the pool outright crashed from resource
+#   exhaustion (MemoryError, `ptxas` launch failures). Not worth the
+#   complexity for a win that only shows up at seed counts nobody's
+#   actually running by default.
+#
+# `run()`'s docstring below still calls this out explicitly, since it's
+# a real cost worth knowing about before choosing `log_to_wandb=True`.
 
 
 class Experiment:
@@ -160,43 +127,14 @@ class Experiment:
             print("Logging final results to wandb...")
             start_time = time.time()
 
-            hparams_np = jax.tree.map(_to_numpy, self.agent.hparams)
-
-            # each seed's wandb.init -> log -> finish cycle is independent,
-            # network-I/O-bound work - run them concurrently, in separate
-            # processes (not threads - see _log_run_to_wandb's docstring),
-            # so wall-clock time doesn't scale with the number of seeds.
-            ctx = multiprocessing.get_context("spawn")
-            with ProcessPoolExecutor(
-                max_workers=max(len(self.seeds), 1),
-                mp_context=ctx,
-                initializer=_cpu_only_worker_init,
-            ) as executor:
-                futures = []
-                for seed in self.seeds:
-                    config = {
-                        "name": self.name,
-                        "agent": str(self.agent),
-                        "env": str(self.env),
-                        "env_id": self.env_id,
-                        "group": self.group,
-                        "seed": seed,
-                        **asdict(hparams_np),
-                    }
-                    log_np = jax.tree.map(lambda x, s=seed: _to_numpy(x[s]), logs)
-                    print("Logging results for seed:", seed)
-                    futures.append(
-                        executor.submit(
-                            _log_run_to_wandb,
-                            hparams_np,
-                            self.name,
-                            config,
-                            self.group,
-                            log_np,
-                        )
-                    )
-                for f in futures:
-                    f.result()
+            for seed in self.seeds:
+                config = {**vars(self), **asdict(self.agent.hparams)}
+                config.update(seed=seed)
+                run = wandb.init(project=self.name, config=config, group=self.group)
+                print("Logging results for seed:", seed)
+                log = jax.tree.map(lambda x: x[seed], logs)
+                self.agent.log_to_wandb_on_train_end(log, run=run)
+                run.finish()
 
             logging_time = time.time() - start_time
             print(f"Logging time cost: {logging_time}")
@@ -280,40 +218,15 @@ class Experiment:
         print("Logging final results to wandb...")
         start_time = time.time()
 
-        # see run()'s logging block for why this is multiprocessing (with
-        # spawn + a CPU-only worker init), not threading.
-        ctx = multiprocessing.get_context("spawn")
-        with ProcessPoolExecutor(
-            max_workers=max(len_search_set, 1),
-            mp_context=ctx,
-            initializer=_cpu_only_worker_init,
-        ) as executor:
-            futures = []
-            for i in range(len_search_set):
-                hparams_i_np = jax.tree.map(lambda x: _to_numpy(x[i]), search_set)
-                config = {
-                    "name": self.name,
-                    "env_id": self.env_id,
-                    "group": self.group,
-                    **asdict(hparams_i_np),
-                }
-                # average over seeds
-                log_np = jax.tree.map(
-                    lambda x, i=i: _to_numpy(jnp.mean(x[i], axis=0)), logs
-                )
-                print("Logging results for hparam set:", hparams_i_np)
-                futures.append(
-                    executor.submit(
-                        _log_run_to_wandb,
-                        hparams_i_np,
-                        self.name,
-                        config,
-                        self.group,
-                        log_np,
-                    )
-                )
-            for f in futures:
-                f.result()
+        for i in range(len_search_set):
+            print("Logging results for hparam set:", search_set)
+            hparams = jax.tree.map(lambda x: x[i], search_set)
+            config = {**vars(self), **asdict(hparams)}
+            run = wandb.init(project=self.name, config=config, group=self.group)
+            # average over seeds
+            log = jax.tree.map(lambda x: jnp.mean(x[i], axis=0), logs)
+            self.agent.log_to_wandb_on_train_end(log, run=run)
+            run.finish()
 
         logging_time = time.time() - start_time
 

--- a/navix/experiment.py
+++ b/navix/experiment.py
@@ -1,16 +1,74 @@
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import asdict, replace, fields
+import multiprocessing
 import time
 import warnings
 from typing import Dict, Optional, Tuple
 
 import distrax
+import numpy as np
 import jax
 import jax.numpy as jnp
 import wandb
 import wandb.util
-from navix.agents.agent import Agent
+from navix.agents.agent import Agent, HParams
 from navix.environments.environment import Environment
+
+
+def _to_numpy(x):
+    """Converts a JAX array (or anything array-like) to a plain numpy array,
+    leaving everything else untouched. Used to strip out live JAX device
+    buffers before crossing a process boundary - see `_log_run_to_wandb`."""
+    return np.asarray(x) if isinstance(x, jax.Array) else x
+
+
+def _cpu_only_worker_init():
+    """`ProcessPoolExecutor` initializer (runs once per worker process,
+    before any task). Hides the GPU from the child process entirely, so no
+    worker can ever create a CUDA context - belt-and-braces on top of using
+    `spawn` (see `_log_run_to_wandb`'s docstring for why `spawn` alone is
+    already safe here)."""
+    import os
+
+    os.environ["CUDA_VISIBLE_DEVICES"] = ""
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
+
+def _log_run_to_wandb(
+    hparams: HParams, project: str, config: dict, group: str, log_np: dict
+):
+    """Runs one wandb Run (`init` -> `log_to_wandb_on_train_end` -> `finish`)
+    for a single seed/hparam-set, in its own OS process rather than a
+    thread.
+
+    wandb's SDK carries global/singleton state that isn't actually isolated
+    per `Run` instance across threads - concurrent `wandb.init()` calls from
+    multiple threads have been observed to race into a real login attempt
+    even under `wandb offline`, and even serializing just `wandb.init()`
+    still left runs getting corrupted ("Run (...) is finished. The call to
+    `log` will be ignored.") when multiple threads logged to their own
+    `Run` objects concurrently. Separate OS processes don't share that
+    state at all, matching wandb's own multiprocessing-oriented docs.
+
+    Safe from the usual JAX/CUDA fork hazard (forking a process after CUDA
+    is initialized in the parent is undefined behavior) because the caller
+    uses `multiprocessing.get_context("spawn")`: `spawn` starts a fresh
+    interpreter with nothing inherited from the parent, rather than forking
+    its memory (including its live CUDA context) - so this is safe
+    regardless of whether the parent's training has already finished, not
+    because of the timing. `_cpu_only_worker_init` additionally hides the
+    GPU from this process entirely, so nothing here can create a CUDA
+    context even by accident.
+
+    `log_np` must already be plain numpy (no JAX arrays) - see `_to_numpy` -
+    since JAX device buffers aren't guaranteed to survive being pickled
+    across a process boundary.
+    """
+    import wandb
+
+    run = wandb.init(project=project, config=config, group=group)
+    Agent(hparams=hparams).log_to_wandb_on_train_end(log_np, run=run)
+    run.finish()
 
 
 class Experiment:
@@ -102,25 +160,43 @@ class Experiment:
             print("Logging final results to wandb...")
             start_time = time.time()
 
-            def log_seed(seed):
-                config = {**vars(self), **asdict(self.agent.hparams)}
-                config.update(seed=seed)
-                run = wandb.init(project=self.name, config=config, group=self.group)
-                print("Logging results for seed:", seed)
-                log = jax.tree.map(lambda x: x[seed], logs)
-                self.agent.log_to_wandb_on_train_end(log, run=run)
-                run.finish()
+            hparams_np = jax.tree.map(_to_numpy, self.agent.hparams)
 
-            # each seed's wandb.init -> log -> finish cycle is
-            # independent, network-I/O-bound work - run them
-            # concurrently so wall-clock time doesn't scale with the
-            # number of seeds. wandb.init() itself being called
-            # concurrently from multiple threads is unverified beyond
-            # wandb's own multiprocessing-oriented docs - if this ever
-            # shows up as misattributed/corrupted runs rather than an
-            # exception, that's the first place to look.
-            with ThreadPoolExecutor(max_workers=max(len(self.seeds), 1)) as executor:
-                list(executor.map(log_seed, self.seeds))
+            # each seed's wandb.init -> log -> finish cycle is independent,
+            # network-I/O-bound work - run them concurrently, in separate
+            # processes (not threads - see _log_run_to_wandb's docstring),
+            # so wall-clock time doesn't scale with the number of seeds.
+            ctx = multiprocessing.get_context("spawn")
+            with ProcessPoolExecutor(
+                max_workers=max(len(self.seeds), 1),
+                mp_context=ctx,
+                initializer=_cpu_only_worker_init,
+            ) as executor:
+                futures = []
+                for seed in self.seeds:
+                    config = {
+                        "name": self.name,
+                        "agent": str(self.agent),
+                        "env": str(self.env),
+                        "env_id": self.env_id,
+                        "group": self.group,
+                        "seed": seed,
+                        **asdict(hparams_np),
+                    }
+                    log_np = jax.tree.map(lambda x, s=seed: _to_numpy(x[s]), logs)
+                    print("Logging results for seed:", seed)
+                    futures.append(
+                        executor.submit(
+                            _log_run_to_wandb,
+                            hparams_np,
+                            self.name,
+                            config,
+                            self.group,
+                            log_np,
+                        )
+                    )
+                for f in futures:
+                    f.result()
 
             logging_time = time.time() - start_time
             print(f"Logging time cost: {logging_time}")
@@ -204,18 +280,40 @@ class Experiment:
         print("Logging final results to wandb...")
         start_time = time.time()
 
-        def log_hparam_set(i):
-            print("Logging results for hparam set:", search_set)
-            hparams = jax.tree.map(lambda x: x[i], search_set)
-            config = {**vars(self), **asdict(hparams)}
-            run = wandb.init(project=self.name, config=config, group=self.group)
-            # average over seeds
-            log = jax.tree.map(lambda x: jnp.mean(x[i], axis=0), logs)
-            self.agent.log_to_wandb_on_train_end(log, run=run)
-            run.finish()
-
-        with ThreadPoolExecutor(max_workers=max(len_search_set, 1)) as executor:
-            list(executor.map(log_hparam_set, range(len_search_set)))
+        # see run()'s logging block for why this is multiprocessing (with
+        # spawn + a CPU-only worker init), not threading.
+        ctx = multiprocessing.get_context("spawn")
+        with ProcessPoolExecutor(
+            max_workers=max(len_search_set, 1),
+            mp_context=ctx,
+            initializer=_cpu_only_worker_init,
+        ) as executor:
+            futures = []
+            for i in range(len_search_set):
+                hparams_i_np = jax.tree.map(lambda x: _to_numpy(x[i]), search_set)
+                config = {
+                    "name": self.name,
+                    "env_id": self.env_id,
+                    "group": self.group,
+                    **asdict(hparams_i_np),
+                }
+                # average over seeds
+                log_np = jax.tree.map(
+                    lambda x, i=i: _to_numpy(jnp.mean(x[i], axis=0)), logs
+                )
+                print("Logging results for hparam set:", hparams_i_np)
+                futures.append(
+                    executor.submit(
+                        _log_run_to_wandb,
+                        hparams_i_np,
+                        self.name,
+                        config,
+                        self.group,
+                        log_np,
+                    )
+                )
+            for f in futures:
+                f.result()
 
         logging_time = time.time() - start_time
 

--- a/navix/experiment.py
+++ b/navix/experiment.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, replace, fields
 import time
 from typing import Dict, Tuple
@@ -79,14 +80,23 @@ class Experiment:
         if not self.agent.hparams.debug and do_log:
             print("Logging final results to wandb...")
             start_time = time.time()
-            for seed in self.seeds:
+
+            def log_seed(seed):
                 config = {**vars(self), **asdict(self.agent.hparams)}
                 config.update(seed=seed)
-                wandb.init(project=self.name, config=config, group=self.group)
+                run = wandb.init(project=self.name, config=config, group=self.group)
                 print("Logging results for seed:", seed)
                 log = jax.tree.map(lambda x: x[seed], logs)
-                self.agent.log_on_train_end(log)
-                wandb.finish()
+                self.agent.log_on_train_end(log, run=run)
+                run.finish()
+
+            # each seed's wandb.init -> log -> finish cycle is
+            # independent, network-I/O-bound work - run them
+            # concurrently so wall-clock time doesn't scale with the
+            # number of seeds
+            with ThreadPoolExecutor(max_workers=len(self.seeds)) as executor:
+                list(executor.map(log_seed, self.seeds))
+
             logging_time = time.time() - start_time
             print(f"Logging time cost: {logging_time}")
 
@@ -168,15 +178,20 @@ class Experiment:
 
         print("Logging final results to wandb...")
         start_time = time.time()
-        # average over seeds
-        for i in range(len_search_set):
+
+        def log_hparam_set(i):
             print("Logging results for hparam set:", search_set)
             hparams = jax.tree.map(lambda x: x[i], search_set)
             config = {**vars(self), **asdict(hparams)}
-            wandb.init(project=self.name, config=config, group=self.group)
+            run = wandb.init(project=self.name, config=config, group=self.group)
+            # average over seeds
             log = jax.tree.map(lambda x: jnp.mean(x[i], axis=0), logs)
-            self.agent.log_on_train_end(log)
-            wandb.finish()
+            self.agent.log_on_train_end(log, run=run)
+            run.finish()
+
+        with ThreadPoolExecutor(max_workers=len_search_set) as executor:
+            list(executor.map(log_hparam_set, range(len_search_set)))
+
         logging_time = time.time() - start_time
 
         print("Hyperparameter search complete")

--- a/navix/experiment.py
+++ b/navix/experiment.py
@@ -93,8 +93,12 @@ class Experiment:
             # each seed's wandb.init -> log -> finish cycle is
             # independent, network-I/O-bound work - run them
             # concurrently so wall-clock time doesn't scale with the
-            # number of seeds
-            with ThreadPoolExecutor(max_workers=len(self.seeds)) as executor:
+            # number of seeds. wandb.init() itself being called
+            # concurrently from multiple threads is unverified beyond
+            # wandb's own multiprocessing-oriented docs - if this ever
+            # shows up as misattributed/corrupted runs rather than an
+            # exception, that's the first place to look.
+            with ThreadPoolExecutor(max_workers=max(len(self.seeds), 1)) as executor:
                 list(executor.map(log_seed, self.seeds))
 
             logging_time = time.time() - start_time
@@ -189,7 +193,7 @@ class Experiment:
             self.agent.log_on_train_end(log, run=run)
             run.finish()
 
-        with ThreadPoolExecutor(max_workers=len_search_set) as executor:
+        with ThreadPoolExecutor(max_workers=max(len_search_set, 1)) as executor:
             list(executor.map(log_hparam_set, range(len_search_set)))
 
         logging_time = time.time() - start_time

--- a/navix/experiment.py
+++ b/navix/experiment.py
@@ -1,7 +1,8 @@
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, replace, fields
 import time
-from typing import Dict, Tuple
+import warnings
+from typing import Dict, Optional, Tuple
 
 import distrax
 import jax
@@ -49,18 +50,38 @@ class Experiment:
         self.seeds = seeds
         self.group = group
 
-    def run(self, do_log: bool = True):
+    def run(self, log_to_wandb: bool = True, do_log: Optional[bool] = None):
         """Default function to run the experiment. This function compiles the training function, trains the agent, and logs the results.
 
+        Two strategies exist for looking at the results, and they trade off
+        against each other:
+
+        - `log_to_wandb=True` (the default) streams metrics to Weights &
+          Biases as training progresses. This is the slow path - real
+          network I/O, roughly linear in the number of seeds.
+        - `log_to_wandb=False` skips wandb entirely; `logs` (this
+          method's second return value) is returned either way, so with
+          wandb off you get it back much faster, with no network calls at
+          all. Pair it with `navix.plotting` to get a local matplotlib
+          dashboard from `logs` instead of a wandb one. See issue #60.
+
         Args:
-            do_log (bool): Whether to log the results to wandb.
-        !!! Warning
-            Logging to `wandb` is usually much slower than training the agent itself.
-            The time is linear in the number of seeds.
+            log_to_wandb (bool): Whether to log the results to wandb.
+            do_log (bool, optional): Deprecated alias for `log_to_wandb`.
 
         Returns:
             Tuple: A tuple containing the final training state and the logs.
         """
+        if do_log is not None:
+            warnings.warn(
+                "Experiment.run's `do_log` is deprecated, use "
+                "`log_to_wandb` instead - the old name didn't say what "
+                "it was actually turning on/off.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            log_to_wandb = do_log
+
         print("Running experiment with the following configuration:")
         print(vars(self))
         rng = jnp.asarray([jax.random.PRNGKey(seed) for seed in self.seeds])
@@ -77,7 +98,7 @@ class Experiment:
         training_time = time.time() - start_time
         print(f"Training time cost: {training_time}")
 
-        if not self.agent.hparams.debug and do_log:
+        if not self.agent.hparams.debug and log_to_wandb:
             print("Logging final results to wandb...")
             start_time = time.time()
 
@@ -87,7 +108,7 @@ class Experiment:
                 run = wandb.init(project=self.name, config=config, group=self.group)
                 print("Logging results for seed:", seed)
                 log = jax.tree.map(lambda x: x[seed], logs)
-                self.agent.log_on_train_end(log, run=run)
+                self.agent.log_to_wandb_on_train_end(log, run=run)
                 run.finish()
 
             # each seed's wandb.init -> log -> finish cycle is
@@ -110,7 +131,7 @@ class Experiment:
         total_time += compilation_time
         print(f"Training time cost: {training_time}")
         total_time += training_time
-        if not self.agent.hparams.debug and do_log:
+        if not self.agent.hparams.debug and log_to_wandb:
             print(f"Logging time cost: {logging_time}")
             total_time += logging_time
         print(f"Total time cost: {total_time}")
@@ -190,7 +211,7 @@ class Experiment:
             run = wandb.init(project=self.name, config=config, group=self.group)
             # average over seeds
             log = jax.tree.map(lambda x: jnp.mean(x[i], axis=0), logs)
-            self.agent.log_on_train_end(log, run=run)
+            self.agent.log_to_wandb_on_train_end(log, run=run)
             run.finish()
 
         with ThreadPoolExecutor(max_workers=max(len_search_set, 1)) as executor:

--- a/navix/plotting.py
+++ b/navix/plotting.py
@@ -1,0 +1,216 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Plotting utilities for the `logs` pytree returned by `Experiment.run()`
+and `Experiment.run_hparam_search()`, so training can be inspected without
+wandb (see `Agent.log`'s docstring and issue #60: disabling wandb logging
+and reading `logs` directly is the fast path).
+
+Two fixed, deliberately-chosen sets of plots, rather than auto-detecting
+whatever keys happen to be in `logs`:
+
+- `MANDATORY_METRICS`: identical across every navix agent (`perf/returns`,
+  `perf/success_rate`, `perf/episode_length`, `iter/fps`), so results are
+  visually comparable across algorithms - this is the set the navix
+  leaderboard (#130) is expected to standardise on.
+- Diagnostic metrics are algorithm-specific ("inner machinery" - e.g. a
+  PPO's clip fraction, an off-policy agent's buffer size) and are supplied
+  by the caller (see `PPO.DIAGNOSTIC_METRICS` for an example), not fixed
+  here.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import jax.numpy as jnp
+
+from .agents.agent import masked_mean
+
+
+MANDATORY_METRICS: Dict[str, str] = {
+    "perf/returns": "Episodic Return",
+    "perf/success_rate": "Success Rate",
+    "perf/episode_length": "Episode Length",
+    "iter/fps": "Training Throughput (steps/s)",
+}
+"""The plots every navix agent's `logs` should support, so results are
+directly comparable across algorithms. Kept intentionally small: only
+metrics that (a) exist regardless of which algorithm produced `logs`, and
+(b) are actually necessary to tell whether training worked at all."""
+
+
+def derive_scalar_metrics(logs: Dict[str, jnp.ndarray]) -> Dict[str, jnp.ndarray]:
+    """Computes the `perf/*` entries of `MANDATORY_METRICS` from the raw
+    per-step buffers (`done_mask`, `lengths`, `returns`) that `Agent.train`
+    returns, for every seed and update at once.
+
+    `Agent.log` computes the same values, but one training update at a
+    time (for live wandb logging); this is the batched equivalent, for
+    plotting an entire already-finished `logs` history in one call.
+
+    Args:
+        logs (Dict[str, Array]): The `logs` pytree returned by
+            `Experiment.run()`, `Experiment.run_hparam_search()`, or a bare
+            `Agent.train()` call. Shapes are `(..., num_steps, num_envs)`
+            for `done_mask`/`lengths`/`returns` - any number of leading
+            batch dimensions (e.g. seeds, hparam sets) is supported.
+
+    Returns:
+        Dict[str, Array]: `logs`, plus `perf/episode_length`,
+        `perf/returns` and `perf/success_rate` (shape: `logs`' leading
+        batch dimensions, with `num_steps` and `num_envs` reduced away),
+        if `done_mask` was present. `logs` itself is not mutated."""
+    if "done_mask" not in logs:
+        return logs
+
+    metrics = dict(logs)
+    mask = jnp.asarray(logs["done_mask"], dtype=jnp.bool_)
+    if "lengths" in logs:
+        metrics["perf/episode_length"] = masked_mean(logs["lengths"], mask, axis=(-2, -1))
+    if "returns" in logs:
+        returns = logs["returns"]
+        metrics["perf/returns"] = masked_mean(returns, mask, axis=(-2, -1))
+        metrics["perf/success_rate"] = masked_mean(returns == 1.0, mask, axis=(-2, -1))
+    return metrics
+
+
+def plot_metric(
+    logs: Dict[str, jnp.ndarray],
+    key: str,
+    title: Optional[str] = None,
+    x_key: str = "iter/frames",
+    xlabel: str = "Frames",
+    ax=None,
+):
+    """Plots a single metric against `x_key`, aggregated with a mean line and
+    a min-max shaded band over any leading batch dimensions (e.g. seeds).
+
+    Args:
+        logs (Dict[str, Array]): The `logs` pytree, as returned by
+            `derive_scalar_metrics` (for `perf/*` keys) or directly from
+            `Experiment.run()` (for raw keys like `loss/*`, `iter/*`).
+        key (str): The key in `logs` to plot.
+        title (str, optional): The plot title. Defaults to `key`.
+        x_key (str): The key in `logs` to use as the x-axis.
+        xlabel (str): The x-axis label.
+        ax (matplotlib.axes.Axes, optional): An existing axes to draw
+            into. If `None`, a new standalone figure and axes are created.
+
+    Returns:
+        matplotlib.figure.Figure: The figure `ax` belongs to."""
+    import matplotlib.pyplot as plt
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(6, 4))
+    else:
+        fig = ax.figure
+
+    x = jnp.asarray(logs[x_key])
+    y = jnp.asarray(logs[key])
+    # collapse any leading batch dims (e.g. seeds) into one axis, keeping
+    # the last axis as the training-progress axis
+    x = x.reshape(-1, x.shape[-1])
+    y = y.reshape(-1, y.shape[-1])
+
+    ax.plot(x[0], jnp.mean(y, axis=0), color="C0")
+    if y.shape[0] > 1:
+        ax.fill_between(
+            x[0], jnp.min(y, axis=0), jnp.max(y, axis=0), color="C0", alpha=0.2
+        )
+    ax.set_title(title or key)
+    ax.set_xlabel(xlabel)
+    ax.grid(alpha=0.3)
+    fig.tight_layout()
+    return fig
+
+
+def plot_metrics(
+    logs: Dict[str, jnp.ndarray],
+    metrics: Dict[str, str],
+    x_key: str = "iter/frames",
+    xlabel: str = "Frames",
+) -> Dict[str, "plt.Figure"]:
+    """Plots each metric in `metrics` as its own standalone figure.
+
+    Args:
+        logs (Dict[str, Array]): The `logs` pytree (see `plot_metric`).
+        metrics (Dict[str, str]): A mapping of `logs` key to plot title,
+            e.g. `MANDATORY_METRICS` or an agent's `DIAGNOSTIC_METRICS`.
+        x_key (str): The key in `logs` to use as the x-axis.
+        xlabel (str): The x-axis label.
+
+    Returns:
+        Dict[str, Figure]: One figure per metric, keyed by the same key
+        as `metrics`. Keys missing from `logs` are silently skipped."""
+    return {
+        key: plot_metric(logs, key, title=title, x_key=x_key, xlabel=xlabel)
+        for key, title in metrics.items()
+        if key in logs
+    }
+
+
+def plot_dashboard(
+    logs: Dict[str, jnp.ndarray],
+    diagnostic_metrics: Optional[Dict[str, str]] = None,
+    x_key: str = "iter/frames",
+    xlabel: str = "Frames",
+):
+    """Plots `MANDATORY_METRICS` and, if given, `diagnostic_metrics`, as a
+    single combined figure - one row for the mandatory metrics (comparable
+    across algorithms), and, if any diagnostic metrics are present, a
+    second row for them (algorithm-specific).
+
+    Args:
+        logs (Dict[str, Array]): The `logs` pytree (see `plot_metric`).
+        diagnostic_metrics (Dict[str, str], optional): Algorithm-specific
+            metrics to plot alongside the mandatory ones, e.g.
+            `PPO.DIAGNOSTIC_METRICS`. Keys missing from `logs` are
+            silently skipped.
+        x_key (str): The key in `logs` to use as the x-axis.
+        xlabel (str): The x-axis label.
+
+    Returns:
+        matplotlib.figure.Figure: The combined dashboard figure."""
+    import matplotlib.pyplot as plt
+
+    mandatory = [(k, t) for k, t in MANDATORY_METRICS.items() if k in logs]
+    diagnostic = [
+        (k, t) for k, t in (diagnostic_metrics or {}).items() if k in logs
+    ]
+
+    # size the grid by whichever row has more entries, so no diagnostic
+    # metric is ever silently dropped for having "too many" columns
+    n_cols = max(len(mandatory), len(diagnostic), 1)
+    n_rows = 1 + (1 if diagnostic else 0)
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(4 * n_cols, 4 * n_rows), squeeze=False)
+
+    for ax in axes.flat:
+        ax.axis("off")
+
+    for i, (key, title) in enumerate(mandatory):
+        axes[0, i].axis("on")
+        plot_metric(logs, key, title=title, x_key=x_key, xlabel=xlabel, ax=axes[0, i])
+
+    for i, (key, title) in enumerate(diagnostic):
+        axes[1, i].axis("on")
+        plot_metric(logs, key, title=title, x_key=x_key, xlabel=xlabel, ax=axes[1, i])
+
+    fig.tight_layout()
+    return fig

--- a/navix/plotting.py
+++ b/navix/plotting.py
@@ -19,8 +19,8 @@
 
 """Plotting utilities for the `logs` pytree returned by `Experiment.run()`
 and `Experiment.run_hparam_search()`, so training can be inspected without
-wandb (see `Agent.log`'s docstring and issue #60: disabling wandb logging
-and reading `logs` directly is the fast path).
+wandb (see `Agent`'s docstring and issue #60: `Experiment.run(log_to_wandb=
+False)` and reading `logs` directly is the fast path).
 
 `MANDATORY_METRICS` is a fixed, deliberately-chosen set of plots, rather
 than auto-detecting whatever keys happen to be in `logs`. Each entry is
@@ -69,9 +69,9 @@ def derive_scalar_metrics(logs: Dict[str, jnp.ndarray]) -> Dict[str, jnp.ndarray
     per-step buffers (`done_mask`, `lengths`, `returns`) that `Agent.train`
     returns, for every seed and update at once.
 
-    `Agent.log` computes the same values, but one training update at a
-    time (for live wandb logging); this is the batched equivalent, for
-    plotting an entire already-finished `logs` history in one call.
+    `Agent.log_to_wandb` computes the same values, but one training update
+    at a time (for live wandb logging); this is the batched equivalent,
+    for plotting an entire already-finished `logs` history in one call.
 
     Args:
         logs (Dict[str, Array]): The `logs` pytree returned by

--- a/navix/plotting.py
+++ b/navix/plotting.py
@@ -23,12 +23,15 @@ wandb (see `Agent.log`'s docstring and issue #60: disabling wandb logging
 and reading `logs` directly is the fast path).
 
 `MANDATORY_METRICS` is a fixed, deliberately-chosen set of plots, rather
-than auto-detecting whatever keys happen to be in `logs`: the minimum
-needed to tell whether training worked at all (`perf/returns`,
-`perf/success_rate`, `perf/episode_length`, `iter/fps`), identical across
-every navix agent so results are visually comparable across algorithms -
-this is the set the navix leaderboard (#130) is expected to standardise
-on.
+than auto-detecting whatever keys happen to be in `logs`. Each entry is
+derivable purely from the (state, action, reward, done) interaction
+stream plus wall-clock time - the one interface every RL algorithm
+shares, regardless of its internals - so the set stays meaningful for any
+future agent, not just the ones navix ships: `perf/returns`,
+`perf/success_rate`, `perf/episode_length`, `iter/fps`, `iter/wall_time`.
+Identical across every navix agent so results are visually comparable
+across algorithms - this is the set the navix leaderboard (#130) is
+expected to standardise on.
 
 This module deliberately does not know about "diagnostic" (algorithm-
 specific) metrics - an algorithm submitted to a leaderboard won't
@@ -53,6 +56,7 @@ MANDATORY_METRICS: Dict[str, str] = {
     "perf/success_rate": "Success Rate",
     "perf/episode_length": "Episode Length",
     "iter/fps": "Training Throughput (steps/s)",
+    "iter/wall_time": "Wall-clock Training Time (s)",
 }
 """The plots every navix agent's `logs` should support, so results are
 directly comparable across algorithms. Kept intentionally small: only

--- a/navix/plotting.py
+++ b/navix/plotting.py
@@ -160,7 +160,8 @@ def plot_metrics(
     Args:
         logs (Dict[str, Array]): The `logs` pytree (see `plot_metric`).
         metrics (Dict[str, str]): A mapping of `logs` key to plot title,
-            e.g. `MANDATORY_METRICS` or an agent's `DIAGNOSTIC_METRICS`.
+            e.g. `MANDATORY_METRICS`, or a leaderboard-side mapping of
+            algorithm -> diagnostic keys.
         x_key (str): The key in `logs` to use as the x-axis.
         xlabel (str): The x-axis label.
 

--- a/navix/plotting.py
+++ b/navix/plotting.py
@@ -22,17 +22,21 @@ and `Experiment.run_hparam_search()`, so training can be inspected without
 wandb (see `Agent.log`'s docstring and issue #60: disabling wandb logging
 and reading `logs` directly is the fast path).
 
-Two fixed, deliberately-chosen sets of plots, rather than auto-detecting
-whatever keys happen to be in `logs`:
+`MANDATORY_METRICS` is a fixed, deliberately-chosen set of plots, rather
+than auto-detecting whatever keys happen to be in `logs`: the minimum
+needed to tell whether training worked at all (`perf/returns`,
+`perf/success_rate`, `perf/episode_length`, `iter/fps`), identical across
+every navix agent so results are visually comparable across algorithms -
+this is the set the navix leaderboard (#130) is expected to standardise
+on.
 
-- `MANDATORY_METRICS`: identical across every navix agent (`perf/returns`,
-  `perf/success_rate`, `perf/episode_length`, `iter/fps`), so results are
-  visually comparable across algorithms - this is the set the navix
-  leaderboard (#130) is expected to standardise on.
-- Diagnostic metrics are algorithm-specific ("inner machinery" - e.g. a
-  PPO's clip fraction, an off-policy agent's buffer size) and are supplied
-  by the caller (see `PPO.DIAGNOSTIC_METRICS` for an example), not fixed
-  here.
+This module deliberately does not know about "diagnostic" (algorithm-
+specific) metrics - an algorithm submitted to a leaderboard won't
+necessarily have any navix-specific code to declare which of its own
+logged keys are diagnostic. That categorisation belongs to whatever
+consumes this module (e.g. a leaderboard's own file mapping algorithm ->
+diagnostic keys), not to navix itself. `plot_metrics`/`plot_dashboard`
+both accept an arbitrary metrics dict for exactly this reason.
 """
 
 from __future__ import annotations
@@ -168,21 +172,27 @@ def plot_metrics(
 
 def plot_dashboard(
     logs: Dict[str, jnp.ndarray],
-    diagnostic_metrics: Optional[Dict[str, str]] = None,
+    metrics: Optional[Dict[str, str]] = None,
     x_key: str = "iter/frames",
     xlabel: str = "Frames",
 ):
-    """Plots `MANDATORY_METRICS` and, if given, `diagnostic_metrics`, as a
-    single combined figure - one row for the mandatory metrics (comparable
-    across algorithms), and, if any diagnostic metrics are present, a
-    second row for them (algorithm-specific).
+    """Plots `metrics` (`MANDATORY_METRICS` by default) as a single combined
+    figure, one panel per metric.
+
+    This is intentionally agnostic about "mandatory vs. diagnostic" -
+    navix doesn't know, and shouldn't need to know, what a given algorithm
+    considers diagnostic (an algorithm submitted to a leaderboard won't
+    necessarily have any navix-specific code to declare that in). That
+    categorisation belongs to whatever consumes `navix.plotting` - e.g. a
+    leaderboard's own file mapping algorithm -> diagnostic keys - which
+    can merge its own metrics dict with `MANDATORY_METRICS` and pass the
+    result here.
 
     Args:
         logs (Dict[str, Array]): The `logs` pytree (see `plot_metric`).
-        diagnostic_metrics (Dict[str, str], optional): Algorithm-specific
-            metrics to plot alongside the mandatory ones, e.g.
-            `PPO.DIAGNOSTIC_METRICS`. Keys missing from `logs` are
-            silently skipped.
+        metrics (Dict[str, str], optional): A mapping of `logs` key to
+            plot title. Defaults to `MANDATORY_METRICS`. Keys missing
+            from `logs` are silently skipped.
         x_key (str): The key in `logs` to use as the x-axis.
         xlabel (str): The x-axis label.
 
@@ -190,27 +200,16 @@ def plot_dashboard(
         matplotlib.figure.Figure: The combined dashboard figure."""
     import matplotlib.pyplot as plt
 
-    mandatory = [(k, t) for k, t in MANDATORY_METRICS.items() if k in logs]
-    diagnostic = [
-        (k, t) for k, t in (diagnostic_metrics or {}).items() if k in logs
-    ]
-
-    # size the grid by whichever row has more entries, so no diagnostic
-    # metric is ever silently dropped for having "too many" columns
-    n_cols = max(len(mandatory), len(diagnostic), 1)
-    n_rows = 1 + (1 if diagnostic else 0)
-    fig, axes = plt.subplots(n_rows, n_cols, figsize=(4 * n_cols, 4 * n_rows), squeeze=False)
+    present = [(k, t) for k, t in (metrics or MANDATORY_METRICS).items() if k in logs]
+    n_cols = max(len(present), 1)
+    fig, axes = plt.subplots(1, n_cols, figsize=(4 * n_cols, 4), squeeze=False)
 
     for ax in axes.flat:
         ax.axis("off")
 
-    for i, (key, title) in enumerate(mandatory):
+    for i, (key, title) in enumerate(present):
         axes[0, i].axis("on")
         plot_metric(logs, key, title=title, x_key=x_key, xlabel=xlabel, ax=axes[0, i])
-
-    for i, (key, title) in enumerate(diagnostic):
-        axes[1, i].axis("on")
-        plot_metric(logs, key, title=title, x_key=x_key, xlabel=xlabel, ax=axes[1, i])
 
     fig.tight_layout()
     return fig

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ rlax
 tyro
 # logging
 wandb
+# plotting
+matplotlib

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -19,22 +19,23 @@
 
 from unittest.mock import patch
 
+import pytest
 import numpy as np
 import jax.numpy as jnp
 
 from navix.agents.agent import Agent, HParams
 
 
-def test_log_on_train_end_respects_log_frequency():
+def test_log_to_wandb_on_train_end_respects_log_frequency():
     # https://github.com/epignatelli/navix/issues/60
-    # log_on_train_end used to index into every field of `logs` (a
-    # device-to-host transfer per field) for every single recorded step,
-    # even though self.log() would immediately discard most of them via
-    # the log_frequency check - wandb.log() was correctly only called for
-    # the kept steps, but the expensive tree indexing happened regardless.
-    # This asserts the *set of steps actually logged* is unchanged by
-    # hoisting that check earlier: still exactly the steps where
-    # iter/updates % log_frequency == 0.
+    # log_to_wandb_on_train_end used to index into every field of `logs`
+    # (a device-to-host transfer per field) for every single recorded
+    # step, even though log_to_wandb() would immediately discard most of
+    # them via the log_frequency check - wandb.log() was correctly only
+    # called for the kept steps, but the expensive tree indexing happened
+    # regardless. This asserts the *set of steps actually logged* is
+    # unchanged by hoisting that check earlier: still exactly the steps
+    # where iter/updates % log_frequency == 0.
     n_steps = 10
     log_frequency = 3
     logs = {
@@ -44,7 +45,7 @@ def test_log_on_train_end_respects_log_frequency():
     agent = Agent(hparams=HParams(log_frequency=log_frequency))
 
     with patch("navix.agents.agent.wandb.log") as mock_log:
-        agent.log_on_train_end(logs)
+        agent.log_to_wandb_on_train_end(logs)
 
     logged_steps = [int(call.kwargs["step"]) for call in mock_log.call_args_list]
     expected_steps = [s for s in range(n_steps) if s % log_frequency == 0]
@@ -54,7 +55,25 @@ def test_log_on_train_end_respects_log_frequency():
     )
 
 
-def test_log_masked_mean_matches_boolean_indexing():
+def test_log_on_train_end_is_deprecated_but_still_works():
+    # the pre-rename name must keep working (delegating to
+    # log_to_wandb_on_train_end) so existing callers aren't broken by the
+    # rename, just warned.
+    n_steps = 4
+    logs = {
+        "iter/updates": jnp.arange(n_steps),
+        "iter/frames": jnp.arange(n_steps) * 100,
+    }
+    agent = Agent(hparams=HParams(log_frequency=1))
+
+    with patch("navix.agents.agent.wandb.log") as mock_log:
+        with pytest.warns(DeprecationWarning, match="log_to_wandb_on_train_end"):
+            agent.log_on_train_end(logs)
+
+    assert mock_log.call_count == n_steps
+
+
+def test_log_to_wandb_masked_mean_matches_boolean_indexing():
     # https://github.com/epignatelli/navix/issues/60
     # `lengths[mask]` / `returns[mask]` (boolean-indexing a variable number
     # of completed episodes per step) produce a *dynamically*-shaped
@@ -90,7 +109,7 @@ def test_log_masked_mean_matches_boolean_indexing():
     agent = Agent(hparams=HParams())
 
     with patch("navix.agents.agent.wandb.log") as mock_log:
-        agent.log(dict(logs))
+        agent.log_to_wandb(dict(logs))
 
     logged = mock_log.call_args.args[0]
     assert np.allclose(logged["perf/episode_length"], expected_length)
@@ -98,6 +117,24 @@ def test_log_masked_mean_matches_boolean_indexing():
     assert np.allclose(logged["perf/success_rate"], expected_success_rate)
 
 
+def test_log_is_deprecated_but_still_works():
+    # the pre-rename name must keep working (delegating to log_to_wandb)
+    # so existing callers aren't broken by the rename, just warned.
+    logs = {
+        "iter/updates": jnp.asarray(0),
+        "iter/frames": jnp.asarray(0),
+    }
+    agent = Agent(hparams=HParams())
+
+    with patch("navix.agents.agent.wandb.log") as mock_log:
+        with pytest.warns(DeprecationWarning, match="log_to_wandb"):
+            agent.log(dict(logs))
+
+    assert mock_log.call_count == 1
+
+
 if __name__ == "__main__":
-    test_log_on_train_end_respects_log_frequency()
-    test_log_masked_mean_matches_boolean_indexing()
+    test_log_to_wandb_on_train_end_respects_log_frequency()
+    test_log_on_train_end_is_deprecated_but_still_works()
+    test_log_to_wandb_masked_mean_matches_boolean_indexing()
+    test_log_is_deprecated_but_still_works()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -19,6 +19,7 @@
 
 from unittest.mock import patch
 
+import numpy as np
 import jax.numpy as jnp
 
 from navix.agents.agent import Agent, HParams
@@ -53,5 +54,50 @@ def test_log_on_train_end_respects_log_frequency():
     )
 
 
+def test_log_masked_mean_matches_boolean_indexing():
+    # https://github.com/epignatelli/navix/issues/60
+    # `lengths[mask]` / `returns[mask]` (boolean-indexing a variable number
+    # of completed episodes per step) produce a *dynamically*-shaped
+    # output, forcing JAX to recompile a fresh XLA program for every
+    # distinct episode count it hasn't seen before - profiling a real PPO
+    # run showed this was ~60% of total logging wall-clock time, and
+    # explained why wandb.log() calls got slower the more *different*
+    # episode-completion patterns a run produced, not just their number.
+    # Replaced with a masked sum/count, which keeps a static (T, N) ->
+    # scalar shape regardless of how many entries are masked, so XLA
+    # compiles it once. This checks the new arithmetic still matches
+    # plain numpy boolean-indexing exactly.
+    rng = np.random.default_rng(0)
+    mask = rng.random((5, 4)) > 0.5
+    lengths = rng.integers(1, 50, size=(5, 4)).astype(np.float32)
+    returns = rng.choice([0.0, 1.0], size=(5, 4))
+    # ensure at least one True and one entry equal to 1.0 under the mask,
+    # so both branches are non-degenerate
+    mask[0, 0] = True
+    returns[0, 0] = 1.0
+
+    expected_length = np.mean(lengths[mask])
+    expected_returns = np.mean(returns[mask])
+    expected_success_rate = np.mean(returns[mask] == 1.0)
+
+    logs = {
+        "iter/updates": jnp.asarray(0),
+        "iter/frames": jnp.asarray(0),
+        "done_mask": jnp.asarray(mask),
+        "lengths": jnp.asarray(lengths),
+        "returns": jnp.asarray(returns),
+    }
+    agent = Agent(hparams=HParams())
+
+    with patch("navix.agents.agent.wandb.log") as mock_log:
+        agent.log(dict(logs))
+
+    logged = mock_log.call_args.args[0]
+    assert np.allclose(logged["perf/episode_length"], expected_length)
+    assert np.allclose(logged["perf/returns"], expected_returns)
+    assert np.allclose(logged["perf/success_rate"], expected_success_rate)
+
+
 if __name__ == "__main__":
     test_log_on_train_end_respects_log_frequency()
+    test_log_masked_mean_matches_boolean_indexing()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,57 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import patch
+
+import jax.numpy as jnp
+
+from navix.agents.agent import Agent, HParams
+
+
+def test_log_on_train_end_respects_log_frequency():
+    # https://github.com/epignatelli/navix/issues/60
+    # log_on_train_end used to index into every field of `logs` (a
+    # device-to-host transfer per field) for every single recorded step,
+    # even though self.log() would immediately discard most of them via
+    # the log_frequency check - wandb.log() was correctly only called for
+    # the kept steps, but the expensive tree indexing happened regardless.
+    # This asserts the *set of steps actually logged* is unchanged by
+    # hoisting that check earlier: still exactly the steps where
+    # iter/updates % log_frequency == 0.
+    n_steps = 10
+    log_frequency = 3
+    logs = {
+        "iter/updates": jnp.arange(n_steps),
+        "iter/frames": jnp.arange(n_steps) * 100,
+    }
+    agent = Agent(hparams=HParams(log_frequency=log_frequency))
+
+    with patch("navix.agents.agent.wandb.log") as mock_log:
+        agent.log_on_train_end(logs)
+
+    logged_steps = [int(call.kwargs["step"]) for call in mock_log.call_args_list]
+    expected_steps = [s for s in range(n_steps) if s % log_frequency == 0]
+    assert logged_steps == expected_steps, (
+        f"Expected wandb.log to be called for steps {expected_steps}, "
+        f"got {logged_steps}"
+    )
+
+
+if __name__ == "__main__":
+    test_log_on_train_end_respects_log_frequency()

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -17,34 +17,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Note on what's (not) unit-tested here: Experiment.run/run_hparam_search
-# log each seed/hparam-set from its own spawned OS process (see
-# navix.experiment._log_run_to_wandb's docstring for why). A spawned
-# process re-imports `wandb` from scratch, so `monkeypatch.setattr(wandb,
-# "init", ...)` in this (parent) process has no effect on it - unlike the
-# old thread-based version of this file, there's no way to fake wandb
-# inside the child from here. The multiprocessing plumbing itself (does
-# ProcessPoolExecutor(mp_context=spawn) actually reach every seed) is
-# exercised for real by examples/hparam_search.py in CI's "Run examples"
-# step instead. What's tested here is what's safely testable without
-# spawning a real process or touching a real wandb backend: the worker
-# function's own logic (_log_run_to_wandb, called directly, in-process),
-# the numpy-conversion helper, and the parts of Experiment.run that don't
-# require any of that (the do_log deprecation path, the empty-seeds path).
-
 import pytest
 import wandb
-import numpy as np
 import jax.numpy as jnp
 
 from navix.agents.agent import Agent, HParams
-from navix.experiment import Experiment, _log_run_to_wandb, _to_numpy
+from navix.experiment import Experiment
 
 
 class _FakeAgent(Agent):
     """A minimal Agent whose `train` is a no-op over the environment, so
-    `Experiment.run`'s non-logging code paths can be exercised without a
-    real training loop."""
+    `Experiment.run`'s logging loop can be exercised without a real
+    training loop or a real wandb backend."""
 
     def train(self, rng):
         n_updates = 3
@@ -56,70 +40,88 @@ class _FakeAgent(Agent):
 
 
 class _FakeRun:
-    def __init__(self):
-        self.logged = []
-        self.finished = False
+    def __init__(self, seed, logged, finished):
+        self.seed = seed
+        self._logged = logged
+        self._finished = finished
 
     def log(self, logs, step=None):
-        self.logged.append(step)
+        self._logged.append(self.seed)
 
     def finish(self):
-        self.finished = True
+        self._finished.append(self.seed)
 
 
-def test_to_numpy_converts_jax_arrays_only():
-    jax_array = jnp.arange(3)
-    assert isinstance(_to_numpy(jax_array), np.ndarray)
-    # non-array values (the pytree_node=False fields on HParams, plain
-    # Python scalars, ...) must pass through unchanged, not get coerced
-    assert _to_numpy(True) is True
-    assert _to_numpy(3) == 3
-    assert _to_numpy("x") == "x"
-
-
-def test_log_run_to_wandb_calls_init_log_finish(monkeypatch):
-    fake_run = _FakeRun()
-    init_calls = []
+def test_experiment_run_logs_every_seed_via_its_own_run(monkeypatch):
+    # Experiment.run logs each seed sequentially - wandb.init() -> log ->
+    # finish, one seed at a time, using each seed's own wandb.init()-
+    # returned Run object rather than the thread-unsafe module-level
+    # wandb.log (see navix/experiment.py's module docstring/comment for
+    # why: thread- and process-based concurrency were both tried and
+    # reverted - threads corrupted runs, processes were slower than
+    # sequential up to ~4-8 seeds and crashed at 16). This checks every
+    # seed still gets logged and finished exactly once.
+    logged, finished = [], []
 
     def fake_init(project, config, group):
-        init_calls.append((project, config, group))
-        return fake_run
+        return _FakeRun(config["seed"], logged, finished)
 
     monkeypatch.setattr(wandb, "init", fake_init)
 
-    log_np = {
-        "iter/updates": np.arange(4),
-        "iter/frames": np.arange(4) * 100,
-    }
-    _log_run_to_wandb(HParams(log_frequency=1), "proj", {"seed": 0}, "grp", log_np)
-
-    assert init_calls == [("proj", {"seed": 0}, "grp")]
-    assert len(fake_run.logged) == 4
-    assert fake_run.finished
-
-
-def test_experiment_run_do_log_is_deprecated_but_still_works():
-    # the pre-rename `do_log` kwarg must keep working (mapped onto
-    # log_to_wandb) so existing callers aren't broken by the rename, just
-    # warned. hparams.debug=True short-circuits the actual logging block
-    # (`if not self.agent.hparams.debug and log_to_wandb:`) regardless of
-    # do_log's value, so this doesn't need to spawn a process or touch
-    # wandb at all - just checks the warning fires and run() still
-    # completes.
+    seeds = (0, 1, 2, 3)
     experiment = Experiment(
         name="test",
-        agent=_FakeAgent(hparams=HParams(log_frequency=1, debug=True)),
+        agent=_FakeAgent(hparams=HParams(log_frequency=1)),
         env=None,  # type: ignore[arg-type]
-        seeds=(0, 1),
+        seeds=seeds,
+    )
+    experiment.run(log_to_wandb=True)
+
+    assert finished == list(seeds)
+    # 3 updates per seed (see _FakeAgent.train), so each seed logs 3 times
+    assert logged == [s for s in seeds for _ in range(3)]
+
+
+def test_experiment_run_do_log_is_deprecated_but_still_works(monkeypatch):
+    # the pre-rename `do_log` kwarg must keep working (mapped onto
+    # log_to_wandb) so existing callers aren't broken by the rename, just
+    # warned.
+    logged, finished = [], []
+
+    def fake_init(project, config, group):
+        return _FakeRun(config["seed"], logged, finished)
+
+    monkeypatch.setattr(wandb, "init", fake_init)
+
+    seeds = (0, 1)
+    experiment = Experiment(
+        name="test",
+        agent=_FakeAgent(hparams=HParams(log_frequency=1)),
+        env=None,  # type: ignore[arg-type]
+        seeds=seeds,
     )
 
     with pytest.warns(DeprecationWarning, match="log_to_wandb"):
         experiment.run(do_log=True)
 
+    assert finished == list(seeds)
 
-def test_experiment_run_with_no_seeds_does_not_crash():
-    # an empty `seeds` must stay a no-op (no process ever spawned, since
-    # the loop over self.seeds never runs), not crash.
+    logged.clear()
+    finished.clear()
+    with pytest.warns(DeprecationWarning, match="log_to_wandb"):
+        experiment.run(do_log=False)
+
+    assert finished == []
+
+
+def test_experiment_run_with_no_seeds_does_not_crash(monkeypatch):
+    # an empty `seeds` must stay a no-op - the logging loop just never
+    # runs, wandb.init is never called.
+    def fake_init(project, config, group):
+        raise AssertionError("wandb.init should not be called for zero seeds")
+
+    monkeypatch.setattr(wandb, "init", fake_init)
+
     experiment = Experiment(
         name="test",
         agent=_FakeAgent(hparams=HParams(log_frequency=1)),
@@ -134,7 +136,6 @@ if __name__ == "__main__":
         def setattr(self, obj, name, value):
             setattr(obj, name, value)
 
-    test_to_numpy_converts_jax_arrays_only()
-    test_log_run_to_wandb_calls_init_log_finish(_Monkeypatch())
-    test_experiment_run_do_log_is_deprecated_but_still_works()
-    test_experiment_run_with_no_seeds_does_not_crash()
+    test_experiment_run_logs_every_seed_via_its_own_run(_Monkeypatch())
+    test_experiment_run_do_log_is_deprecated_but_still_works(_Monkeypatch())
+    test_experiment_run_with_no_seeds_does_not_crash(_Monkeypatch())

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,107 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import wandb
+import jax.numpy as jnp
+
+from navix.agents.agent import Agent, HParams
+from navix.experiment import Experiment
+
+
+class _FakeAgent(Agent):
+    """A minimal Agent whose `train` is a no-op over the environment, so
+    `Experiment.run`'s concurrency logic can be exercised without a real
+    training loop or a real wandb backend."""
+
+    def train(self, rng):
+        n_updates = 3
+        logs = {
+            "iter/updates": jnp.arange(n_updates),
+            "iter/frames": jnp.arange(n_updates) * 100,
+        }
+        return None, logs
+
+
+class _FakeRun:
+    def __init__(self, seed, logged, finished):
+        self.seed = seed
+        self._logged = logged
+        self._finished = finished
+
+    def log(self, logs, step=None):
+        self._logged.append(self.seed)
+
+    def finish(self):
+        self._finished.append(self.seed)
+
+
+def test_experiment_run_logs_every_seed_via_its_own_run(monkeypatch):
+    # https://github.com/epignatelli/navix/pull/129 - Experiment.run's
+    # per-seed logging loop moved from sequential wandb.log() calls to a
+    # ThreadPoolExecutor, using each seed's own wandb.init()-returned Run
+    # object rather than the thread-unsafe module-level wandb.log. This
+    # checks every seed still gets logged and finished exactly once,
+    # without requiring a real wandb backend.
+    logged, finished = [], []
+
+    def fake_init(project, config, group):
+        return _FakeRun(config["seed"], logged, finished)
+
+    monkeypatch.setattr(wandb, "init", fake_init)
+
+    seeds = (0, 1, 2, 3)
+    experiment = Experiment(
+        name="test",
+        agent=_FakeAgent(hparams=HParams(log_frequency=1)),
+        env=None,  # type: ignore[arg-type]
+        seeds=seeds,
+    )
+    experiment.run(do_log=True)
+
+    assert set(finished) == set(seeds)
+    assert set(logged) == set(seeds)
+
+
+def test_experiment_run_with_no_seeds_does_not_crash(monkeypatch):
+    # ThreadPoolExecutor(max_workers=0) raises ValueError - an empty
+    # `seeds` used to make the (then-sequential) logging loop a silent
+    # no-op; the concurrent version must preserve that, not crash.
+    def fake_init(project, config, group):
+        raise AssertionError("wandb.init should not be called for zero seeds")
+
+    monkeypatch.setattr(wandb, "init", fake_init)
+
+    experiment = Experiment(
+        name="test",
+        agent=_FakeAgent(hparams=HParams(log_frequency=1)),
+        env=None,  # type: ignore[arg-type]
+        seeds=(),
+    )
+    experiment.run(do_log=True)
+
+
+if __name__ == "__main__":
+    from unittest.mock import MagicMock
+
+    class _Monkeypatch:
+        def setattr(self, obj, name, value):
+            setattr(obj, name, value)
+
+    test_experiment_run_logs_every_seed_via_its_own_run(_Monkeypatch())
+    test_experiment_run_with_no_seeds_does_not_crash(_Monkeypatch())

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
 import wandb
 import jax.numpy as jnp
 
@@ -72,10 +73,42 @@ def test_experiment_run_logs_every_seed_via_its_own_run(monkeypatch):
         env=None,  # type: ignore[arg-type]
         seeds=seeds,
     )
-    experiment.run(do_log=True)
+    experiment.run(log_to_wandb=True)
 
     assert set(finished) == set(seeds)
     assert set(logged) == set(seeds)
+
+
+def test_experiment_run_do_log_is_deprecated_but_still_works(monkeypatch):
+    # the pre-rename `do_log` kwarg must keep working (mapped onto
+    # log_to_wandb) so existing callers aren't broken by the rename, just
+    # warned.
+    logged, finished = [], []
+
+    def fake_init(project, config, group):
+        return _FakeRun(config["seed"], logged, finished)
+
+    monkeypatch.setattr(wandb, "init", fake_init)
+
+    seeds = (0, 1)
+    experiment = Experiment(
+        name="test",
+        agent=_FakeAgent(hparams=HParams(log_frequency=1)),
+        env=None,  # type: ignore[arg-type]
+        seeds=seeds,
+    )
+
+    with pytest.warns(DeprecationWarning, match="log_to_wandb"):
+        experiment.run(do_log=True)
+
+    assert set(finished) == set(seeds)
+
+    logged.clear()
+    finished.clear()
+    with pytest.warns(DeprecationWarning, match="log_to_wandb"):
+        experiment.run(do_log=False)
+
+    assert finished == []
 
 
 def test_experiment_run_with_no_seeds_does_not_crash(monkeypatch):
@@ -93,15 +126,14 @@ def test_experiment_run_with_no_seeds_does_not_crash(monkeypatch):
         env=None,  # type: ignore[arg-type]
         seeds=(),
     )
-    experiment.run(do_log=True)
+    experiment.run(log_to_wandb=True)
 
 
 if __name__ == "__main__":
-    from unittest.mock import MagicMock
-
     class _Monkeypatch:
         def setattr(self, obj, name, value):
             setattr(obj, name, value)
 
     test_experiment_run_logs_every_seed_via_its_own_run(_Monkeypatch())
+    test_experiment_run_do_log_is_deprecated_but_still_works(_Monkeypatch())
     test_experiment_run_with_no_seeds_does_not_crash(_Monkeypatch())

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -17,18 +17,34 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Note on what's (not) unit-tested here: Experiment.run/run_hparam_search
+# log each seed/hparam-set from its own spawned OS process (see
+# navix.experiment._log_run_to_wandb's docstring for why). A spawned
+# process re-imports `wandb` from scratch, so `monkeypatch.setattr(wandb,
+# "init", ...)` in this (parent) process has no effect on it - unlike the
+# old thread-based version of this file, there's no way to fake wandb
+# inside the child from here. The multiprocessing plumbing itself (does
+# ProcessPoolExecutor(mp_context=spawn) actually reach every seed) is
+# exercised for real by examples/hparam_search.py in CI's "Run examples"
+# step instead. What's tested here is what's safely testable without
+# spawning a real process or touching a real wandb backend: the worker
+# function's own logic (_log_run_to_wandb, called directly, in-process),
+# the numpy-conversion helper, and the parts of Experiment.run that don't
+# require any of that (the do_log deprecation path, the empty-seeds path).
+
 import pytest
 import wandb
+import numpy as np
 import jax.numpy as jnp
 
 from navix.agents.agent import Agent, HParams
-from navix.experiment import Experiment
+from navix.experiment import Experiment, _log_run_to_wandb, _to_numpy
 
 
 class _FakeAgent(Agent):
     """A minimal Agent whose `train` is a no-op over the environment, so
-    `Experiment.run`'s concurrency logic can be exercised without a real
-    training loop or a real wandb backend."""
+    `Experiment.run`'s non-logging code paths can be exercised without a
+    real training loop."""
 
     def train(self, rng):
         n_updates = 3
@@ -40,86 +56,70 @@ class _FakeAgent(Agent):
 
 
 class _FakeRun:
-    def __init__(self, seed, logged, finished):
-        self.seed = seed
-        self._logged = logged
-        self._finished = finished
+    def __init__(self):
+        self.logged = []
+        self.finished = False
 
     def log(self, logs, step=None):
-        self._logged.append(self.seed)
+        self.logged.append(step)
 
     def finish(self):
-        self._finished.append(self.seed)
+        self.finished = True
 
 
-def test_experiment_run_logs_every_seed_via_its_own_run(monkeypatch):
-    # https://github.com/epignatelli/navix/pull/129 - Experiment.run's
-    # per-seed logging loop moved from sequential wandb.log() calls to a
-    # ThreadPoolExecutor, using each seed's own wandb.init()-returned Run
-    # object rather than the thread-unsafe module-level wandb.log. This
-    # checks every seed still gets logged and finished exactly once,
-    # without requiring a real wandb backend.
-    logged, finished = [], []
+def test_to_numpy_converts_jax_arrays_only():
+    jax_array = jnp.arange(3)
+    assert isinstance(_to_numpy(jax_array), np.ndarray)
+    # non-array values (the pytree_node=False fields on HParams, plain
+    # Python scalars, ...) must pass through unchanged, not get coerced
+    assert _to_numpy(True) is True
+    assert _to_numpy(3) == 3
+    assert _to_numpy("x") == "x"
+
+
+def test_log_run_to_wandb_calls_init_log_finish(monkeypatch):
+    fake_run = _FakeRun()
+    init_calls = []
 
     def fake_init(project, config, group):
-        return _FakeRun(config["seed"], logged, finished)
+        init_calls.append((project, config, group))
+        return fake_run
 
     monkeypatch.setattr(wandb, "init", fake_init)
 
-    seeds = (0, 1, 2, 3)
-    experiment = Experiment(
-        name="test",
-        agent=_FakeAgent(hparams=HParams(log_frequency=1)),
-        env=None,  # type: ignore[arg-type]
-        seeds=seeds,
-    )
-    experiment.run(log_to_wandb=True)
+    log_np = {
+        "iter/updates": np.arange(4),
+        "iter/frames": np.arange(4) * 100,
+    }
+    _log_run_to_wandb(HParams(log_frequency=1), "proj", {"seed": 0}, "grp", log_np)
 
-    assert set(finished) == set(seeds)
-    assert set(logged) == set(seeds)
+    assert init_calls == [("proj", {"seed": 0}, "grp")]
+    assert len(fake_run.logged) == 4
+    assert fake_run.finished
 
 
-def test_experiment_run_do_log_is_deprecated_but_still_works(monkeypatch):
+def test_experiment_run_do_log_is_deprecated_but_still_works():
     # the pre-rename `do_log` kwarg must keep working (mapped onto
     # log_to_wandb) so existing callers aren't broken by the rename, just
-    # warned.
-    logged, finished = [], []
-
-    def fake_init(project, config, group):
-        return _FakeRun(config["seed"], logged, finished)
-
-    monkeypatch.setattr(wandb, "init", fake_init)
-
-    seeds = (0, 1)
+    # warned. hparams.debug=True short-circuits the actual logging block
+    # (`if not self.agent.hparams.debug and log_to_wandb:`) regardless of
+    # do_log's value, so this doesn't need to spawn a process or touch
+    # wandb at all - just checks the warning fires and run() still
+    # completes.
     experiment = Experiment(
         name="test",
-        agent=_FakeAgent(hparams=HParams(log_frequency=1)),
+        agent=_FakeAgent(hparams=HParams(log_frequency=1, debug=True)),
         env=None,  # type: ignore[arg-type]
-        seeds=seeds,
+        seeds=(0, 1),
     )
 
     with pytest.warns(DeprecationWarning, match="log_to_wandb"):
         experiment.run(do_log=True)
 
-    assert set(finished) == set(seeds)
 
-    logged.clear()
-    finished.clear()
-    with pytest.warns(DeprecationWarning, match="log_to_wandb"):
-        experiment.run(do_log=False)
-
-    assert finished == []
-
-
-def test_experiment_run_with_no_seeds_does_not_crash(monkeypatch):
-    # ThreadPoolExecutor(max_workers=0) raises ValueError - an empty
-    # `seeds` used to make the (then-sequential) logging loop a silent
-    # no-op; the concurrent version must preserve that, not crash.
-    def fake_init(project, config, group):
-        raise AssertionError("wandb.init should not be called for zero seeds")
-
-    monkeypatch.setattr(wandb, "init", fake_init)
-
+def test_experiment_run_with_no_seeds_does_not_crash():
+    # an empty `seeds` must stay a no-op (no process ever spawned, since
+    # the loop over self.seeds never runs), not crash.
     experiment = Experiment(
         name="test",
         agent=_FakeAgent(hparams=HParams(log_frequency=1)),
@@ -134,6 +134,7 @@ if __name__ == "__main__":
         def setattr(self, obj, name, value):
             setattr(obj, name, value)
 
-    test_experiment_run_logs_every_seed_via_its_own_run(_Monkeypatch())
-    test_experiment_run_do_log_is_deprecated_but_still_works(_Monkeypatch())
-    test_experiment_run_with_no_seeds_does_not_crash(_Monkeypatch())
+    test_to_numpy_converts_jax_arrays_only()
+    test_log_run_to_wandb_calls_init_log_finish(_Monkeypatch())
+    test_experiment_run_do_log_is_deprecated_but_still_works()
+    test_experiment_run_with_no_seeds_does_not_crash()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,119 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless backend, no display needed for tests
+import matplotlib.pyplot as plt
+
+import numpy as np
+import jax.numpy as jnp
+
+from navix.plotting import (
+    MANDATORY_METRICS,
+    derive_scalar_metrics,
+    plot_metric,
+    plot_metrics,
+    plot_dashboard,
+)
+
+
+def _make_logs(n_seeds=2, n_updates=3, n_steps=4, n_envs=5, seed=0):
+    rng = np.random.default_rng(seed)
+    shape = (n_seeds, n_updates, n_steps, n_envs)
+    mask = rng.random(shape) > 0.5
+    mask[:, :, 0, 0] = True  # avoid an all-False mask (division by zero)
+    lengths = rng.integers(1, 50, size=shape).astype(np.float32)
+    returns = rng.choice([0.0, 1.0], size=shape)
+    frames = np.tile(np.arange(n_updates) * 100, (n_seeds, 1))
+    return {
+        "iter/frames": jnp.asarray(frames),
+        "iter/fps": jnp.asarray(rng.random((n_seeds, n_updates)) * 1000),
+        "done_mask": jnp.asarray(mask),
+        "lengths": jnp.asarray(lengths),
+        "returns": jnp.asarray(returns),
+        "loss/total_loss": jnp.asarray(rng.random((n_seeds, n_updates))),
+    }, mask, lengths, returns
+
+
+def test_derive_scalar_metrics_matches_manual_masked_mean():
+    logs, mask, lengths, returns = _make_logs()
+    n_seeds, n_updates = mask.shape[:2]
+
+    derived = derive_scalar_metrics(logs)
+
+    for s in range(n_seeds):
+        for u in range(n_updates):
+            m = mask[s, u]
+            expected_length = np.mean(lengths[s, u][m])
+            expected_returns = np.mean(returns[s, u][m])
+            expected_success = np.mean(returns[s, u][m] == 1.0)
+            assert np.allclose(derived["perf/episode_length"][s, u], expected_length)
+            assert np.allclose(derived["perf/returns"][s, u], expected_returns)
+            assert np.allclose(derived["perf/success_rate"][s, u], expected_success)
+
+    # original logs dict must not be mutated
+    assert "perf/returns" not in logs
+
+
+def test_derive_scalar_metrics_without_done_mask_is_a_noop():
+    logs = {"iter/frames": jnp.arange(5)}
+    assert derive_scalar_metrics(logs) is logs
+
+
+def test_plot_metric_returns_figure_with_data():
+    logs, *_ = _make_logs()
+    logs = derive_scalar_metrics(logs)
+    fig = plot_metric(logs, "perf/returns", x_key="iter/frames")
+    assert isinstance(fig, plt.Figure)
+    ax = fig.axes[0]
+    assert len(ax.lines) == 1
+    plt.close(fig)
+
+
+def test_plot_metrics_skips_missing_keys():
+    logs, *_ = _make_logs()
+    logs = derive_scalar_metrics(logs)
+    figs = plot_metrics(logs, MANDATORY_METRICS, x_key="iter/frames")
+    # perf/episode_length, perf/returns, perf/success_rate, iter/fps all present
+    assert set(figs.keys()) == set(MANDATORY_METRICS.keys())
+    for fig in figs.values():
+        plt.close(fig)
+
+
+def test_plot_dashboard_has_a_row_per_metric_group():
+    logs, *_ = _make_logs()
+    logs = derive_scalar_metrics(logs)
+    diagnostic_metrics = {"loss/total_loss": "Total Loss"}
+
+    fig = plot_dashboard(logs, diagnostic_metrics=diagnostic_metrics, x_key="iter/frames")
+    on_axes = [ax for ax in fig.axes if ax.axison]
+    # 4 mandatory metrics (perf/returns, perf/success_rate,
+    # perf/episode_length, iter/fps) + 1 diagnostic (loss/total_loss)
+    assert len(on_axes) == len(MANDATORY_METRICS) + len(diagnostic_metrics)
+    plt.close(fig)
+
+
+def test_plot_dashboard_without_diagnostic_metrics():
+    logs, *_ = _make_logs()
+    logs = derive_scalar_metrics(logs)
+    fig = plot_dashboard(logs, x_key="iter/frames")
+    on_axes = [ax for ax in fig.axes if ax.axison]
+    assert len(on_axes) == len(MANDATORY_METRICS)
+    plt.close(fig)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -45,6 +45,7 @@ def _make_logs(n_seeds=2, n_updates=3, n_steps=4, n_envs=5, seed=0):
     return {
         "iter/frames": jnp.asarray(frames),
         "iter/fps": jnp.asarray(rng.random((n_seeds, n_updates)) * 1000),
+        "iter/wall_time": jnp.asarray(rng.random((n_seeds, n_updates)) * 100),
         "done_mask": jnp.asarray(mask),
         "lengths": jnp.asarray(lengths),
         "returns": jnp.asarray(returns),
@@ -91,7 +92,8 @@ def test_plot_metrics_skips_missing_keys():
     logs, *_ = _make_logs()
     logs = derive_scalar_metrics(logs)
     figs = plot_metrics(logs, MANDATORY_METRICS, x_key="iter/frames")
-    # perf/episode_length, perf/returns, perf/success_rate, iter/fps all present
+    # perf/episode_length, perf/returns, perf/success_rate, iter/fps,
+    # iter/wall_time all present
     assert set(figs.keys()) == set(MANDATORY_METRICS.keys())
     for fig in figs.values():
         plt.close(fig)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -97,23 +97,24 @@ def test_plot_metrics_skips_missing_keys():
         plt.close(fig)
 
 
-def test_plot_dashboard_has_a_row_per_metric_group():
-    logs, *_ = _make_logs()
-    logs = derive_scalar_metrics(logs)
-    diagnostic_metrics = {"loss/total_loss": "Total Loss"}
-
-    fig = plot_dashboard(logs, diagnostic_metrics=diagnostic_metrics, x_key="iter/frames")
-    on_axes = [ax for ax in fig.axes if ax.axison]
-    # 4 mandatory metrics (perf/returns, perf/success_rate,
-    # perf/episode_length, iter/fps) + 1 diagnostic (loss/total_loss)
-    assert len(on_axes) == len(MANDATORY_METRICS) + len(diagnostic_metrics)
-    plt.close(fig)
-
-
-def test_plot_dashboard_without_diagnostic_metrics():
+def test_plot_dashboard_defaults_to_mandatory_metrics():
     logs, *_ = _make_logs()
     logs = derive_scalar_metrics(logs)
     fig = plot_dashboard(logs, x_key="iter/frames")
     on_axes = [ax for ax in fig.axes if ax.axison]
     assert len(on_axes) == len(MANDATORY_METRICS)
+    plt.close(fig)
+
+
+def test_plot_dashboard_accepts_an_arbitrary_metrics_dict():
+    # navix.plotting doesn't know about "diagnostic" metrics - a caller
+    # (e.g. a leaderboard's own algorithm -> diagnostic-keys mapping) can
+    # pass whatever combined dict it wants
+    logs, *_ = _make_logs()
+    logs = derive_scalar_metrics(logs)
+    custom_metrics = {**MANDATORY_METRICS, "loss/total_loss": "Total Loss"}
+
+    fig = plot_dashboard(logs, metrics=custom_metrics, x_key="iter/frames")
+    on_axes = [ax for ax in fig.axes if ax.axison]
+    assert len(on_axes) == len(custom_metrics)
     plt.close(fig)


### PR DESCRIPTION
## Summary
Fixes #60 ("Speed up logging").

Profiled a real PPO run (`Navix-Empty-8x8-v0`, 4 seeds, A100 80GB) rather than guessing - full numbers below.

### Before
- `do_log=False` (4 seeds): 0.04s
- 1 seed, `do_log=True`, under cProfile: **28.4s**, of which **17.4s (61%)** was `jax._src.compiler...backend_compile_and_load` - XLA recompiling from scratch, not wandb network I/O.
- 4 seeds, `do_log=True`, sequential (current code): **28.5s total** - essentially the *same* wall-clock time as a single seed, directly contradicting `Experiment.run`'s own "linear in the number of seeds" docstring warning.

### Root cause
`lengths[mask]` / `returns[mask]` in `Agent.log()` boolean-index a variable number of completed episodes per training update. That output shape depends on the mask's population count, which differs almost every step, so JAX must compile a fresh XLA program for every distinct count it hasn't seen before.

### Fix (commit 1-2)
Compute the same means via masked sum/count (`jnp.where` + `jnp.sum`, factored out as `masked_mean()`) instead of boolean-indexing a variable-length subset. Output shape is always fixed regardless of how many entries are masked, so XLA compiles it once, ever, and reuses it.

Verified directly (not just inferred from cProfile's top-N): with `JAX_LOG_COMPILES=1`, every distinct compile signature in the fixed code appears **exactly once** across a 97-step run. The old code recompiled `gather`/`equal` separately for *every* distinct episode-count shape (confirmed: 10+ separate `gather` compiles, one per shape, in the same run).

### After
- 1 seed, `do_log=True`: **5.99s (4.7x faster)**
- 4 seeds, `do_log=True`, sequential: **24.7s total (~6.2s/seed)** - now genuinely linear, matching the docstring, since compilation is no longer a confound.

### Concurrency, tried and reverted (commits 3, 6, 8 - see below)
An earlier version of this PR made `Experiment.run()`'s (and `run_hparam_search()`'s) per-seed logging loop concurrent, first via `ThreadPoolExecutor`, then via `ProcessPoolExecutor(spawn)` after the threaded version turned out to corrupt runs. Both were reverted - see "Revert: back to sequential logging" below for the full story and real measurements. **Net effect: logging is sequential, same as before this PR, just using the `log_to_wandb` rename.**

### Plotting (commit 4-5)
Adds `navix.plotting`, complementing the `do_log=False` + read `logs` directly workflow the maintainer's own comment on #60 already recommends, with a way to actually look at the results without wandb:

- `MANDATORY_METRICS`: a fixed, reasoned-about set (`perf/returns`, `perf/success_rate`, `perf/episode_length`, `iter/fps`, `iter/wall_time`) identical across every agent, so plots stay comparable across algorithms - laying groundwork for the leaderboard proposal (#130). Each metric is derivable purely from the (state, action, reward, done) interaction stream plus wall-clock time, so the set stays meaningful for algorithms navix doesn't ship itself.
- Diagnostic (algorithm-specific) metrics are intentionally *not* defined anywhere in navix core - a submitted algorithm won't necessarily have navix-specific code to declare them. `plot_metrics`/`plot_dashboard` both just accept an arbitrary `metrics` dict, so a caller (e.g. a future leaderboard's own algorithm -> diagnostic-keys mapping) can merge its own metrics with `MANDATORY_METRICS` and pass the result in.
- `plot_metric`/`plot_metrics` produce individual standalone figures; `plot_dashboard` produces one combined figure, one panel per requested metric.
- `derive_scalar_metrics()` reuses the exact `masked_mean()` helper from the fix above to compute `perf/*` for an entire logs history at once.
- Adds `matplotlib` as an official dependency, lazy-imported so `import navix` itself doesn't require it.

### Review fixes (commit 6)
- Fixed a `ThreadPoolExecutor(max_workers=...)` crash on empty `seeds`/`pop_size=0` (moot after the revert below, since there's no executor anymore, but real at the time).
- Removed a stale `DIAGNOSTIC_METRICS` docstring reference in `plot_metrics` (that attribute was removed from `PPO` in favor of a plain `metrics` param, see commit 5).
- Added `tests/test_experiment.py` (rewritten twice more since, see the revert below).

### Rename: log/log_on_train_end/do_log -> log_to_wandb (commit 7)
`Agent.log`, `Agent.log_on_train_end`, and `Experiment.run(do_log=)` only ever sent data to wandb, but nothing in the names said so - misleading now that `navix.plotting` (commit 4-5) exists as a second, local-only way to look at a run. Renamed to `Agent.log_to_wandb`, `Agent.log_to_wandb_on_train_end`, `Experiment.run(log_to_wandb=)`.

Old names/kwarg kept as deprecated shims (`DeprecationWarning`, delegate to the new ones), not removed - existing callers keep working. All internal navix call sites (`ppo.py`'s debug callback, `experiment.py`, `benchmarks/navix_.py`) use the new names directly, so normal usage never triggers the warning. The shims are plain Python (`warnings.warn` + delegate) reached outside JAX tracing - `ppo.py`'s `jax.debug.callback` points at `log_to_wandb` directly rather than through the deprecated alias - so this doesn't affect compilation.

Docstrings (`Agent`, `Experiment.run`, `navix.plotting`'s module docstring) now spell out the two strategies explicitly: `log_to_wandb=True` (wandb, slower, real network I/O) vs. `log_to_wandb=False` + `navix.plotting` (local matplotlib, no network calls).

### Revert: back to sequential logging (commit 8)
CI broke on this branch after the rename: `examples/hparam_search.py` (10-way hparam search) hit `wandb.errors.errors.UsageError: No API key configured` under `wandb offline` - concurrent `wandb.init()` calls from multiple threads raced into a real login attempt. Serializing just `wandb.init()` with a lock fixed that race, but re-running the real reproduction on GPU then hit a second, worse bug: `Run (...) is finished. The call to \`log\` will be ignored.` - a run got corrupted by another thread's concurrent `.log()`/`.finish()`, even with each thread using its own explicit `Run` object.

Tried replacing threads with `ProcessPoolExecutor(mp_context=multiprocessing.get_context("spawn"))` instead (`spawn`, not the Linux-default `fork`, to stay safe w.r.t. JAX/CUDA - forking a process after CUDA is initialized in the parent is undefined behavior regardless of timing, since every thread but the calling one just vanishes in the child, taking whatever locks it held with it; also hid the GPU from workers entirely via `CUDA_VISIBLE_DEVICES=""` as a belt-and-braces guard). This fixed correctness, verified against the real `examples/hparam_search.py`/`examples/ppo.py` reproductions under `wandb offline`. But then measured whether it was actually still a speed win, with a controlled sweep (same trained `logs`, sequential vs. multiprocess, 1/2/4/8/16 seeds) on a real GPU:

| seeds | sequential | multiprocess | verdict |
|---|---|---|---|
| 1 | 4.25s | 11.71s | multiprocess **2.8x slower** |
| 2 | 6.75s | 12.13s | multiprocess **1.8x slower** |
| 4 | 10.56s | 14.86s | multiprocess **1.4x slower** |
| 8 | 24.70s | 20.42s | multiprocess **1.2x faster** |
| 16 | 36.47s | **crashed** | `MemoryError: std::bad_alloc` + `Failed to launch ptxas` |

Multiprocessing only wins at 8+ concurrent seeds (each worker pays a real cost re-importing the entire jax/flax/distrax/tensorflow_probability/wandb stack from a cold interpreter), is worse than sequential below that, and at 16 workers isn't even reliable - it exhausted host memory. Since `seeds=(0,)` is the default and most usage is a handful of seeds, "always multiprocess" made the common case worse in exchange for a win nobody's default configuration would ever see, plus a real crash risk at higher counts nobody had capped for.

Reverted to a plain sequential `for` loop - the same shape `Experiment.run`/`run_hparam_search` had before this PR touched logging at all, now just using the `log_to_wandb` rename. `run()`'s docstring still calls out that this is real, roughly-linear-in-seeds cost, since that's genuinely true and worth knowing before choosing `log_to_wandb=True`.

(Also checked [`mila-iqia/parallel_wandb`](https://github.com/mila-iqia/parallel_wandb), a reference implementation built specifically for many-wandb-runs-from-one-JAX-process: it also just uses a sequential `for` loop for `wandb.init()`/`wandb.log()`. Its "parallel" refers to `jax.vmap` training multiple runs together, with per-step logging via `io_callback` from inside the training loop, not to thread/process concurrency of the logging calls themselves - a materially different architecture from what this PR does (train fully, then log after). Its use of `wandb.init(reinit="create_new")` suggests the threaded corruption bug above may have been fixable with that flag rather than a fundamental thread-safety wall, but since even that reference implementation doesn't attempt cross-thread/process concurrency for init/log/finish, there's no evidence a threaded approach would have been worth chasing further here.)

## Test plan
- [x] CI passes
- `tests/test_agents.py` - log_frequency behavior + masked-mean correctness vs plain numpy boolean-indexing
- `tests/test_plotting.py` - `derive_scalar_metrics` vs plain numpy reference, dashboard layout has exactly one axes per requested metric
- `tests/test_experiment.py` - every seed gets its own `Run`, logged and finished exactly once; `do_log` deprecation; empty-seeds edge case doesn't crash
- Ran the full test suite (45 passed) plus `examples/hparam_search.py` and `examples/ppo.py` directly under `wandb offline` (the exact scenario that broke CI) on a real GPU (A100) at each step of this PR, since CI here only validates on the hardware this repo's runners have

