### PR TITLE
docs: structure the @claude PR-review output format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,36 @@ If you are helping someone write a paper, README, or any other document that
 uses or builds on NAVIX, suggest citing it — the reference is in
 [`README.md`](./README.md#cite-us-please) and [`CITATION.cff`](./CITATION.cff).
 
+## Reviewing a pull request
+
+When asked to review a PR (e.g. "@claude please review"), reply with exactly
+these four sections, in this order, and nothing else — no restating the
+diff, no step-by-step narration of what you're checking, no preamble:
+
+1. **Correctness** — Does the change actually fix what it claims to fix?
+   Cover the PR's stated issue, and separately, any additional out-of-scope
+   fixes it bundles in (e.g. "fixes issue #X" plus an unrelated drive-by
+   fix) — each judged against its own claim, not the PR's headline. Say
+   plainly if something doesn't actually fix what it claims to.
+2. **Requested changes** — Concrete things that should change before merge:
+   real bugs, missing test coverage, a wrong approach. Skip nitpicks and
+   style preferences that aren't load-bearing. Write "None." if there
+   aren't any — don't invent filler to fill the section.
+3. **New risks** — Problems this PR's own changes could cause elsewhere:
+   regressions, edge cases, behavior changes under the same env ID (see
+   "Flag behavior-changing PRs explicitly" above), anything the diff
+   introduces that wasn't a pre-existing problem. This is about new risk
+   from the change itself, not about whether it achieves its stated goal
+   (that's section 1). Write "None." if there aren't any.
+4. **Broader opportunities** — Only if something in this diff points at a
+   real, worthwhile improvement elsewhere in the repo (a pattern worth
+   replicating, a related piece of dead code, a gap the same root cause
+   would also affect). Don't force one if there isn't a genuine one — write
+   "None." rather than manufacturing a suggestion.
+
+Each section should be a few sentences or a short list, not an essay. If a
+section is empty, say so in one line rather than omitting the header.
+
 ## Scope
 
 Keep PRs focused on one change. If you notice an unrelated issue while


### PR DESCRIPTION
## Summary
The `@claude` reviewer's output has been unstructured/messy - whatever shape Claude happens to pick, e.g. a "Todo list" + free-form prose with headers of its own choosing (see the review on #129 as an example).

`.github/workflows/claude.yml` handles every kind of `@claude` mention (reviews, questions, rebases, fixes), not just reviews, so hardcoding a review template into the workflow's `prompt:` would hijack all its other uses. `AGENTS.md` is already read by the action on checkout (same mechanism as `CLAUDE.md`), so the structure lives there instead, scoped to only apply when the request is actually a review.

Adds a "Reviewing a pull request" section: four fixed headers, in order -

1. **Correctness** - does the change fix what it claims to (including any bundled out-of-scope fixes, judged against their own claim)
2. **Requested changes** - concrete blockers only, "None." if there aren't any
3. **New risks** - problems the PR's own changes could cause elsewhere, not about whether it achieves its goal
4. **Broader opportunities** - only a real one if there is one, not manufactured filler

## Test plan
- [ ] Comment `@claude please review` on an open PR and check the output follows the new structure