### PR TITLE
fix: picked-up entities no longer ghost into categorical/symbolic obs

### DIFF
--- a/navix/observations.py
+++ b/navix/observations.py
@@ -101,7 +101,19 @@ def categorical_first_person(state: State) -> Array:
     transparency_map = jnp.where(state.grid == 0, 1, 0)
     positions = state.get_positions()
     transparent = state.get_transparency()
-    transparency_map = transparency_map.at[tuple(positions.T)].set(transparent)
+    # a picked-up entity's position (DISCARD_PILE_COORDS = (0, -1)) is
+    # off-grid - .at[].set()'s default mode wraps negative components
+    # around (numpy semantics) rather than dropping them, silently
+    # overwriting a real cell (see categorical()/symbolic() for the
+    # same bug, fixed the same way). Push off-grid positions to be
+    # explicitly out of bounds first, so mode="drop" discards those
+    # writes instead.
+    H, W = state.grid.shape
+    row, col = positions[..., 0], positions[..., 1]
+    on_grid = (row >= 0) & (row < H) & (col >= 0) & (col < W)
+    row = jnp.where(on_grid, row, H)
+    col = jnp.where(on_grid, col, W)
+    transparency_map = transparency_map.at[row, col].set(transparent, mode="drop")
 
     # apply view mask
     player = state.get_player()
@@ -109,7 +121,7 @@ def categorical_first_person(state: State) -> Array:
 
     # get categorical representation
     tags = state.get_tags()
-    obs = state.grid.at[tuple(positions.T)].set(tags) * view
+    obs = state.grid.at[row, col].set(tags, mode="drop") * view
 
     # crop grid to agent's view
     obs = crop(obs, player.position, player.direction, RADIUS)

--- a/navix/observations.py
+++ b/navix/observations.py
@@ -73,15 +73,16 @@ def categorical(state: State) -> Array:
     indices = idx_from_coordinates(state.grid, state.get_positions())
     # get tags corresponding to the entities
     tags = state.get_tags()
-    # set tags on the flat set of patches. Append a discard-pile sink
-    # cell first: a picked-up entity's position (DISCARD_PILE_COORDS)
-    # maps to flat index -1, which .at[].set() wraps around to the
-    # *last* element rather than dropping - same pattern as rgb()'s
-    # cache.patches, so that wraparound lands on this dedicated extra
-    # cell instead of a real grid cell.
+    # set tags on the flat set of patches
     shape = state.grid.shape
-    grid = jnp.append(state.grid.reshape(-1), 0).at[indices].set(tags)
-    grid = grid[:DISCARD_PILE_IDX]  # drop the sink cell
+    num_cells = shape[0] * shape[1]
+    # a picked-up entity's position (DISCARD_PILE_COORDS) maps to flat
+    # index -1 - .at[].set()'s default mode wraps negative indices
+    # around (numpy semantics) rather than dropping them, silently
+    # overwriting a real cell. Push negative indices to be explicitly
+    # out of bounds first, so mode="drop" discards those writes instead.
+    indices = jnp.where(indices < 0, num_cells, indices)
+    grid = state.grid.reshape(-1).at[indices].set(tags, mode="drop")
     # unflatten patches to reconstruct the grid
     return grid.reshape(shape)
 
@@ -137,13 +138,6 @@ def symbolic(state: State) -> Array:
     floor_symbol = jnp.array([EntityIds.FLOOR, 0, 0], dtype=jnp.uint8)
     obs = jnp.where(state.grid[..., None] == -1, wall_symbol, floor_symbol)
 
-    # append a discard-pile sink column: a picked-up entity's position
-    # (DISCARD_PILE_COORDS = (0, -1)) has its column wrap around to the
-    # *last* column rather than being dropped - same pattern as rgb()'s
-    # cache.patches, so that wraparound lands on this dedicated extra
-    # column instead of the real top-right cell.
-    obs = jnp.pad(obs, ((0, 0), (0, 1), (0, 0)))
-
     # place entities
     for entity_class in state.entities:
         entity = state.entities[entity_class]
@@ -159,8 +153,18 @@ def symbolic(state: State) -> Array:
 
         # collate
         entity_symbol = jnp.stack([tag, colour, entity_state], axis=-1, dtype=jnp.uint8)
-        obs = obs.at[tuple(entity.position.T)].set(entity_symbol)
-    return obs[:, :W]  # drop the sink column
+        # a picked-up entity's position (DISCARD_PILE_COORDS = (0, -1))
+        # is off-grid - .at[].set()'s default mode wraps negative
+        # components around (numpy semantics) rather than dropping
+        # them, silently overwriting a real cell. Push off-grid
+        # positions to be explicitly out of bounds first, so
+        # mode="drop" discards those writes instead.
+        row, col = entity.position[..., 0], entity.position[..., 1]
+        on_grid = (row >= 0) & (row < H) & (col >= 0) & (col < W)
+        row = jnp.where(on_grid, row, H)
+        col = jnp.where(on_grid, col, W)
+        obs = obs.at[row, col].set(entity_symbol, mode="drop")
+    return obs
 
 
 def symbolic_first_person(state: State) -> Array:

--- a/navix/observations.py
+++ b/navix/observations.py
@@ -73,9 +73,15 @@ def categorical(state: State) -> Array:
     indices = idx_from_coordinates(state.grid, state.get_positions())
     # get tags corresponding to the entities
     tags = state.get_tags()
-    # set tags on the flat set of patches
+    # set tags on the flat set of patches. Append a discard-pile sink
+    # cell first: a picked-up entity's position (DISCARD_PILE_COORDS)
+    # maps to flat index -1, which .at[].set() wraps around to the
+    # *last* element rather than dropping - same pattern as rgb()'s
+    # cache.patches, so that wraparound lands on this dedicated extra
+    # cell instead of a real grid cell.
     shape = state.grid.shape
-    grid = state.grid.reshape(-1).at[indices].set(tags)
+    grid = jnp.append(state.grid.reshape(-1), 0).at[indices].set(tags)
+    grid = grid[:DISCARD_PILE_IDX]  # drop the sink cell
     # unflatten patches to reconstruct the grid
     return grid.reshape(shape)
 
@@ -131,6 +137,13 @@ def symbolic(state: State) -> Array:
     floor_symbol = jnp.array([EntityIds.FLOOR, 0, 0], dtype=jnp.uint8)
     obs = jnp.where(state.grid[..., None] == -1, wall_symbol, floor_symbol)
 
+    # append a discard-pile sink column: a picked-up entity's position
+    # (DISCARD_PILE_COORDS = (0, -1)) has its column wrap around to the
+    # *last* column rather than being dropped - same pattern as rgb()'s
+    # cache.patches, so that wraparound lands on this dedicated extra
+    # column instead of the real top-right cell.
+    obs = jnp.pad(obs, ((0, 0), (0, 1), (0, 0)))
+
     # place entities
     for entity_class in state.entities:
         entity = state.entities[entity_class]
@@ -147,7 +160,7 @@ def symbolic(state: State) -> Array:
         # collate
         entity_symbol = jnp.stack([tag, colour, entity_state], axis=-1, dtype=jnp.uint8)
         obs = obs.at[tuple(entity.position.T)].set(entity_symbol)
-    return obs
+    return obs[:, :W]  # drop the sink column
 
 
 def symbolic_first_person(state: State) -> Array:

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -24,8 +24,8 @@ import jax.numpy as jnp
 
 import navix as nx
 from navix import observations
-from navix.components import EMPTY_POCKET_ID
-from navix.entities import Ball, Entities, Goal, Player
+from navix.components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
+from navix.entities import Ball, Entities, EntityIds, Goal, Key, Player
 from navix.rendering.cache import RenderingCache
 from navix.rendering.registry import PALETTE
 from navix.states import State
@@ -118,7 +118,58 @@ def test_98():
     assert jnp.all(goal.walkable), "Expected the Goal to be walkable"
 
 
+def test_135():
+    # https://github.com/epignatelli/navix/issues/135
+    # a picked-up entity's position is moved to DISCARD_PILE_COORDS =
+    # (0, -1). categorical()/symbolic() scatter-write the entity's
+    # tag/symbol at its position without checking whether that position
+    # is actually on the grid - JAX's negative-index wraparound then
+    # writes it into a real cell instead of dropping it, producing a
+    # "ghost" duplicate of the picked-up item: categorical()'s flat
+    # index -1 wraps to the bottom-right corner, symbolic()'s (0, -1)
+    # wraps to the top-right corner. Both should remain untouched
+    # (still showing the real wall there), since a picked-up entity is
+    # carried, not on the grid.
+    height, width = 5, 5
+    grid = jnp.zeros((height - 2, width - 2), dtype=jnp.int32)
+    grid = jnp.pad(grid, pad_width=1, mode="constant", constant_values=-1)
+    player = Player(
+        position=jnp.asarray((1, 1)), direction=jnp.asarray(0), pocket=EMPTY_POCKET_ID
+    )
+    key = Key.create(
+        position=DISCARD_PILE_COORDS,  # picked up
+        colour=PALETTE.BLUE,
+        id=jnp.asarray(0),
+    )
+    cache = RenderingCache.init(grid)
+    state = State(
+        key=jax.random.PRNGKey(0),
+        grid=grid,
+        cache=cache,
+        entities={
+            Entities.PLAYER: player[None],
+            Entities.KEY: key[None],
+        },
+    )
+
+    categorical_obs = observations.categorical(state)
+    assert categorical_obs[height - 1, width - 1] == -1, (
+        "Expected the picked-up key not to wrap around into the "
+        "bottom-right corner of categorical(), got tag "
+        f"{categorical_obs[height - 1, width - 1]} instead of the wall (-1)"
+    )
+
+    symbolic_obs = observations.symbolic(state)
+    wall_symbol = jnp.array([EntityIds.WALL, 5, 0], dtype=jnp.uint8)
+    assert jnp.array_equal(symbolic_obs[0, width - 1], wall_symbol), (
+        "Expected the picked-up key not to wrap around into the "
+        "top-right corner of symbolic(), got "
+        f"{symbolic_obs[0, width - 1]} instead of the wall symbol {wall_symbol}"
+    )
+
+
 if __name__ == "__main__":
     test_82()
     test_91()
     test_98()
+    test_135()

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -168,8 +168,60 @@ def test_135():
     )
 
 
+def test_146():
+    # https://github.com/epignatelli/navix/issues/146
+    # same bug class as #135, but in categorical_first_person():
+    # transparency_map/state.grid are scattered via raw entity
+    # positions without validating they're on-grid, so a picked-up
+    # entity at DISCARD_PILE_COORDS = (0, -1) wraps into row 0's last
+    # column instead of being dropped. A correctly-handled picked-up
+    # entity should have zero effect on the observation (matching
+    # MiniGrid: picked-up items are removed from the grid entirely),
+    # so compare against an otherwise-identical state with no key
+    # entity at all - avoids having to hand-compute exactly which
+    # cell of crop()'s pad/roll/rotate/slice output the wraparound
+    # would land in.
+    height, width = 5, 5
+    grid = jnp.zeros((height - 2, width - 2), dtype=jnp.int32)
+    grid = jnp.pad(grid, pad_width=1, mode="constant", constant_values=-1)
+    player = Player(
+        position=jnp.asarray((2, 2)), direction=jnp.asarray(0), pocket=EMPTY_POCKET_ID
+    )
+    key = Key.create(
+        position=DISCARD_PILE_COORDS,  # picked up
+        colour=PALETTE.BLUE,
+        id=jnp.asarray(0),
+    )
+    cache = RenderingCache.init(grid)
+
+    state_with_key = State(
+        key=jax.random.PRNGKey(0),
+        grid=grid,
+        cache=cache,
+        entities={
+            Entities.PLAYER: player[None],
+            Entities.KEY: key[None],
+        },
+    )
+    state_without_key = State(
+        key=jax.random.PRNGKey(0),
+        grid=grid,
+        cache=cache,
+        entities={Entities.PLAYER: player[None]},
+    )
+
+    obs_with_key = observations.categorical_first_person(state_with_key)
+    obs_without_key = observations.categorical_first_person(state_without_key)
+    assert jnp.array_equal(obs_with_key, obs_without_key), (
+        "Expected a picked-up key to have no effect on "
+        "categorical_first_person(), since it should be treated as "
+        f"off-grid - got\n{obs_with_key}\ninstead of\n{obs_without_key}"
+    )
+
+
 if __name__ == "__main__":
     test_82()
     test_91()
     test_98()
     test_135()
+    test_146()


### PR DESCRIPTION
## Summary
Fixes #135 and #146 (item 1 of the port-tracking master issue #134).

When an entity is picked up, its position moves to `DISCARD_PILE_COORDS = (0, -1)`. `categorical()`/`symbolic()` scatter-write the entity's tag/symbol at its position without checking whether that position is actually on the grid - JAX's negative-index wraparound then writes it into a real cell instead of dropping it, producing a "ghost" duplicate of the picked-up item: `categorical()`'s flat index `-1` wraps to the bottom-right corner, `symbolic()`'s `(0, -1)` wraps to the top-right corner.

`rgb()`/`rgb_first_person()` already solve a version of this problem: `state.cache.patches` has one extra "sink" cell that a discarded entity's wraparound lands in, then `patches[:DISCARD_PILE_IDX]` drops it. An initial version of this PR mirrored that pattern for `categorical()`/`symbolic()`, but there's a simpler fix that doesn't need an extra allocated cell at all: `.at[].set(..., mode="drop")` already exists specifically to discard out-of-bounds writes - it just doesn't trigger on negative indices by default, since JAX normalizes those via numpy wraparound semantics *before* the bounds check (verified empirically: `.at[-1].set(x, mode="drop")` on a length-N array still wraps to index N-1, it does not drop). Pushing invalid indices/positions to be explicitly `>= size` first, then using `mode="drop"`, avoids needing to resize/pad the array and slice a sink cell back off afterward:
- `categorical()`: remaps any negative flat index to `num_cells` (one past the end) before the scatter.
- `symbolic()`: remaps any off-grid `(row, col)` to `(H, W)` before the scatter (checked via a proper `0 <= row < H and 0 <= col < W` validity check, not just the column, so it's not narrowly tied to the exact `(0, -1)` sentinel).

## Verification

- `tests/test_issues.py::test_135` - a direct `State` construction with a picked-up key at `DISCARD_PILE_COORDS`. Fails on pre-fix code (`categorical()`'s bottom-right corner reads the KEY tag instead of the wall); passes after the fix.
- A real `Navix-DoorKey-8x8-v0` rollout: picked up the key (`[rotate_cw, forward, pickup]`), checked both observation functions directly. Pre-fix, both ghost the key into their respective corners; post-fix both correctly show the wall.
- Explicitly re-checked under both `jax.jit` and `jax.vmap` (observations get called from inside jitted/vmapped training, not just eagerly) - both clean.
- Full test suite (46 passed) and `examples/*.py` (both exit cleanly) verified on a real GPU.

## categorical_first_person (added per review, #146)

Review feedback caught that `categorical_first_person` has the identical bug: `transparency_map`/`state.grid` are scattered via raw entity positions without checking they're on-grid, same failure mode as `categorical()`/`symbolic()`. Originally filed as a separate follow-up issue (#146) since it was out of #135's original scope, but folded into this PR instead since it's the same fix pattern and touches the same file.

Fixed with the same `mode="drop"` + explicit out-of-bounds remap. `tests/test_issues.py::test_146` uses a differential check (compare against an otherwise-identical state with no key entity at all) rather than hand-computing which cell of `crop()`'s pad/roll/rotate/slice output the wraparound lands in - empirically verified this actually catches the bug (at every radius from 3 to 20 tried) before finalizing the test, so it's not accidentally vacuous.

## Attribution

`categorical()`/`symbolic()` ported from [`arahosu/navix_minigrid:fix/ghost-key-observations`](https://github.com/arahosu/navix_minigrid/tree/fix/ghost-key-observations), found and reference-validated against Farama MiniGrid by Joonsu Gha ([@arahosu](https://github.com/arahosu)) - see the fork's `notebooks/VALIDATION_REPORT.md` (linked from #135) for the full investigation, including a separate case where a *different*, previously-documented "fix" for a different bug turned out to be wrong on closer inspection (independently verified by viewing the notebook's comparison images directly, not just the text summary). `categorical_first_person`'s fix (#146) is this repo's own follow-up, same bug class, not part of the fork's original report.

## Test plan
- [ ] CI passes
- `tests/test_issues.py::test_135`, `test_146` - direct repro + regression tests
- Full suite (47 passed) + examples verified on real GPU (see above)

