### PR TITLE
fix: first-person view only saw half its claimed radius, black padding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,8 +101,11 @@ diff, no step-by-step narration of what you're checking, no preamble:
 1. **Correctness** — Does the change actually fix what it claims to fix?
    Cover the PR's stated issue, and separately, any additional out-of-scope
    fixes it bundles in (e.g. "fixes issue #X" plus an unrelated drive-by
-   fix) — each judged against its own claim, not the PR's headline. Say
-   plainly if something doesn't actually fix what it claims to.
+   fix) — each judged against its own claim, not the PR's headline. Give
+   each claim its own bullet point, prefixed with ✅ if it holds up or ❌ if
+   it doesn't, so an incorrect claim is visible at a glance without reading
+   the prose. Say plainly if something doesn't actually fix what it claims
+   to.
 2. **Requested changes** — Concrete things that should change before merge:
    real bugs, missing test coverage, a wrong approach. Skip nitpicks and
    style preferences that aren't load-bearing. Write "None." if there

--- a/navix/grid.py
+++ b/navix/grid.py
@@ -456,12 +456,13 @@ def draw_grid_lines(
     (e.g. `~32`, empirically matched against a real MiniGrid render -
     see `rendering/cache.py::render_background`) to compensate.
 
-    `corner_luminosity`, if given, fills just the `line_thickness` x
-    `line_thickness` corner block with a separate value. In MiniGrid,
-    the top and left line strips are drawn independently and both get
-    anti-aliased, so the corner - covered by both - ends up brighter
-    than either strip alone; a single flat `luminosity` for the whole
-    line can't reproduce that without also being tuned to a
+    `corner_luminosity` fills just the `line_thickness` x
+    `line_thickness` corner block with a separate value, defaulting to
+    `luminosity` (i.e. no distinct corner treatment) when omitted. In
+    MiniGrid, the top and left line strips are drawn independently and
+    both get anti-aliased, so the corner - covered by both - ends up
+    brighter than either strip alone; a single flat `luminosity` for
+    the whole line can't reproduce that without also being tuned to a
     higher value at just the corner.
 
     Args:
@@ -478,10 +479,10 @@ def draw_grid_lines(
     # raises `TypeError: Only integer scalar arrays can be converted
     # to a scalar index`).
     line_thickness = math.ceil(TILE_SIZE * 0.031)
+    corner_luminosity = luminosity if corner_luminosity is None else corner_luminosity
     tile = tile.at[:line_thickness, :].set(luminosity)
     tile = tile.at[:, :line_thickness].set(luminosity)
-    if corner_luminosity is not None:
-        tile = tile.at[:line_thickness, :line_thickness].set(corner_luminosity)
+    tile = tile.at[:line_thickness, :line_thickness].set(corner_luminosity)
     return tile
 
 

--- a/navix/grid.py
+++ b/navix/grid.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 from functools import partial
+import math
 
 
 from typing import Callable, Dict, List, Tuple
@@ -440,6 +441,17 @@ def apply_minigrid_opacity(image: Array, opacity: Array = jnp.asarray(0.7)) -> A
 def draw_grid_lines(tile: Array, luminosity: Array = jnp.asarray(100)) -> Array:
     """Draws grid lines on the given tile.
 
+    `luminosity` defaults to MiniGrid's own raw grey constant
+    (`COLORS["grey"]`), used as-is for e.g. walls. But MiniGrid's grid
+    lines specifically are drawn as a sub-pixel-width, anti-aliased
+    strip - at typical tile sizes only *partially* covered by that raw
+    colour, blending it with the background - whereas this function
+    does a hard, fully-opaque fill of `line_thickness` whole pixels
+    with no antialiasing. Using the raw `100` here renders visibly
+    bolder/brighter than MiniGrid's actual output; pass a lower value
+    (e.g. `~32`, empirically matched against a real MiniGrid render -
+    see `rendering/cache.py::render_background`) to compensate.
+
     Args:
         tile (Array): The input tile to which grid lines are drawn.
 
@@ -447,8 +459,13 @@ def draw_grid_lines(tile: Array, luminosity: Array = jnp.asarray(100)) -> Array:
         Array: The tile with drawn grid lines.
     """
     # Draw lines (top and left edges) at 3.1% of the tile size as per
-    # minigrid.core.Grid.render_tile
-    line_thickness = jnp.ceil(TILE_SIZE * 0.031)
+    # minigrid.core.Grid.render_tile. TILE_SIZE is a static Python int
+    # (not a runtime/traced value), so line_thickness must be a plain
+    # Python int too - jnp.ceil() returns a float-dtype array, which
+    # can't be used as a slice bound (`tile.at[:line_thickness, :]`
+    # raises `TypeError: Only integer scalar arrays can be converted
+    # to a scalar index`).
+    line_thickness = math.ceil(TILE_SIZE * 0.031)
     tile = tile.at[:line_thickness, :].set(luminosity)
     tile = tile.at[:, :line_thickness].set(luminosity)
     return tile

--- a/navix/grid.py
+++ b/navix/grid.py
@@ -438,7 +438,11 @@ def apply_minigrid_opacity(image: Array, opacity: Array = jnp.asarray(0.7)) -> A
     return jax.numpy.asarray(255 - opacity * (255 - image), dtype=jax.numpy.uint8)
 
 
-def draw_grid_lines(tile: Array, luminosity: Array = jnp.asarray(100)) -> Array:
+def draw_grid_lines(
+    tile: Array,
+    luminosity: Array = jnp.asarray(100),
+    corner_luminosity: Array | None = None,
+) -> Array:
     """Draws grid lines on the given tile.
 
     `luminosity` defaults to MiniGrid's own raw grey constant
@@ -451,6 +455,14 @@ def draw_grid_lines(tile: Array, luminosity: Array = jnp.asarray(100)) -> Array:
     bolder/brighter than MiniGrid's actual output; pass a lower value
     (e.g. `~32`, empirically matched against a real MiniGrid render -
     see `rendering/cache.py::render_background`) to compensate.
+
+    `corner_luminosity`, if given, fills just the `line_thickness` x
+    `line_thickness` corner block with a separate value. In MiniGrid,
+    the top and left line strips are drawn independently and both get
+    anti-aliased, so the corner - covered by both - ends up brighter
+    than either strip alone; a single flat `luminosity` for the whole
+    line can't reproduce that without also being tuned to a
+    higher value at just the corner.
 
     Args:
         tile (Array): The input tile to which grid lines are drawn.
@@ -468,6 +480,8 @@ def draw_grid_lines(tile: Array, luminosity: Array = jnp.asarray(100)) -> Array:
     line_thickness = math.ceil(TILE_SIZE * 0.031)
     tile = tile.at[:line_thickness, :].set(luminosity)
     tile = tile.at[:, :line_thickness].set(luminosity)
+    if corner_luminosity is not None:
+        tile = tile.at[:line_thickness, :line_thickness].set(corner_luminosity)
     return tile
 
 

--- a/navix/grid.py
+++ b/navix/grid.py
@@ -501,6 +501,20 @@ def view_cone(transparency_map: Array, origin: Array, radius: int) -> Array:
     def fin_diff(array, _):
         array = jnp.roll(array, -1, axis=0) + array + jnp.roll(array, +1, axis=0)
         array = jnp.roll(array, -1, axis=1) + array + jnp.roll(array, +1, axis=1)
+        # this accumulates path *counts*, not just reachability - each
+        # step lets every unit of mass split into up to 9 copies of
+        # itself (a 3x3 neighbourhood sum), so the total grows ~9x per
+        # step and only the downstream `view > 0` threshold is ever
+        # read. In an open area, that overflows int32 (~2.1e9) by
+        # cone radius 12 - beyond that, a wrapped-negative cell is
+        # indistinguishable from a genuinely unreachable one, so
+        # overflow silently *removes* visibility rather than erroring.
+        # Clamping to a boolean flood (min with 1) after every step is
+        # behaviour-preserving below the overflow threshold (verified:
+        # identical `> 0` masks at every radius that doesn't overflow)
+        # and immune to it above, since a boolean value can never
+        # overflow regardless of radius.
+        array = jnp.minimum(array, 1)
         return array * transparency_map, ()
 
     # initialise the field to all zeros, except at the source (agent's position)

--- a/navix/observations.py
+++ b/navix/observations.py
@@ -115,9 +115,13 @@ def categorical_first_person(state: State) -> Array:
     col = jnp.where(on_grid, col, W)
     transparency_map = transparency_map.at[row, col].set(transparent, mode="drop")
 
-    # apply view mask
+    # apply view mask. crop() places the agent at the *bottom* row of
+    # the 2*RADIUS+1 view, so the far row is 2*RADIUS cells forward of
+    # the agent, not RADIUS - view_cone's diffusion needs to reach that
+    # far, or the forward half of the view is permanently marked
+    # unseen regardless of whether real walls are there.
     player = state.get_player()
-    view = view_cone(transparency_map, player.position, RADIUS)
+    view = view_cone(transparency_map, player.position, RADIUS * 2)
 
     # get categorical representation
     tags = state.get_tags()
@@ -282,13 +286,21 @@ def rgb_first_person(state: State) -> Array:
     # apply minigrid opacity
     patchwork = apply_minigrid_opacity(patchwork)
 
-    # apply fov
-    dark_cell_colour = 0  # dark color for unseen tiles
+    # apply fov. Unseen/out-of-map tiles use MiniGrid's wall grey
+    # (100, 100, 100) rather than black - a scalar works for both the
+    # jnp.where fill below and crop()'s padding_value, since grey has
+    # equal R/G/B and both broadcast it across the full (..., 3) tile.
+    dark_cell_colour = 100
     transparency_map = jnp.where(state.grid == 0, 1, 0)  # (H, W)
     positions = state.get_positions()
     transparent = state.get_transparency()
     transparency_map = transparency_map.at[tuple(positions.T)].set(transparent)
-    view = view_cone(transparency_map, player.position, RADIUS)  # (H, W)
+    # crop() places the agent at the *bottom* row of the 2*RADIUS+1
+    # view, so the far row is 2*RADIUS cells forward of the agent, not
+    # RADIUS - view_cone's diffusion needs to reach that far, or the
+    # forward half of the view is permanently marked unseen regardless
+    # of whether real walls are there.
+    view = view_cone(transparency_map, player.position, RADIUS * 2)  # (H, W)
     view = jnp.asarray(view, dtype=jnp.bool)
     patchwork = jnp.where(view[..., None, None, None], patchwork, dark_cell_colour)
 

--- a/navix/observations.py
+++ b/navix/observations.py
@@ -286,11 +286,18 @@ def rgb_first_person(state: State) -> Array:
     # apply minigrid opacity
     patchwork = apply_minigrid_opacity(patchwork)
 
-    # apply fov. Unseen/out-of-map tiles use MiniGrid's wall grey
-    # (100, 100, 100) rather than black - a scalar works for both the
-    # jnp.where fill below and crop()'s padding_value, since grey has
-    # equal R/G/B and both broadcast it across the full (..., 3) tile.
-    dark_cell_colour = 100
+    # apply fov. Unseen/out-of-map tiles use the *opacity-adjusted*
+    # wall grey, not the raw (100, 100, 100) constant: every other
+    # cell in `patchwork` already went through apply_minigrid_opacity
+    # above, but dark_cell_colour is inserted as a flat literal after
+    # that, bypassing it - using the raw constant here made real,
+    # visible walls (opacity-adjusted, ~146) visually inconsistent
+    # with the unseen/padding fill (100) in the same image, a seam
+    # that isn't in MiniGrid's own rendering. A scalar still works for
+    # both the jnp.where fill below and crop()'s padding_value, since
+    # grey has equal R/G/B and both broadcast it across the full
+    # (..., 3) tile.
+    dark_cell_colour = apply_minigrid_opacity(jnp.asarray(100, dtype=jnp.uint8))
     transparency_map = jnp.where(state.grid == 0, 1, 0)  # (H, W)
     positions = state.get_positions()
     transparent = state.get_transparency()

--- a/navix/observations.py
+++ b/navix/observations.py
@@ -30,7 +30,6 @@ from .states import State
 from .grid import (
     apply_minigrid_opacity,
     align,
-    draw_grid_lines,
     idx_from_coordinates,
     crop,
     view_cone,
@@ -267,8 +266,13 @@ def rgb_first_person(state: State) -> Array:
     sprites = state.get_sprites_first_person()  # (n_sprites, TILE_SIZE, TILE_SIZE, 3)
     # sprites = jax.vmap(lambda x: align(x, jnp.asarray(0), alignment_direction))(sprites)
 
-    # draw grid lines on tiles
-    # sprites = jax.vmap(lambda x: draw_grid_lines(x))(sprites)
+    # Grid lines are drawn once on the floor tile in
+    # rendering/cache.py's render_background(), not here - `sprites` is
+    # per-entity (player, keys, balls, doors, ...), and MiniGrid's own
+    # grid lines are drawn under objects, not over them (Wall.render()
+    # fully covers its tile, so grid lines never show through walls
+    # either). Drawing lines directly on these entity sprites would
+    # incorrectly overlay a line across their artwork instead.
 
     # update current patchwork
     indices = idx_from_coordinates(state.grid, state.get_positions())

--- a/navix/rendering/cache.py
+++ b/navix/rendering/cache.py
@@ -73,10 +73,17 @@ def render_background(
     # border (a different colour, from before this fix) gets
     # overwritten by this rather than drawn alongside it. luminosity=32
     # (not draw_grid_lines' default of 100, MiniGrid's raw grey
-    # constant) empirically matches a real MiniGrid render - see that
-    # function's docstring for why the raw constant renders too bold.
+    # constant) and corner_luminosity=54 empirically match a real
+    # MiniGrid render - see draw_grid_lines' docstring for why the raw
+    # constant renders too bold, and why the corner needs its own,
+    # brighter value.
     floor_tile = tile_grid(
-        grid, draw_grid_lines(sprites_registry["floor"], luminosity=jnp.asarray(32))
+        grid,
+        draw_grid_lines(
+            sprites_registry["floor"],
+            luminosity=jnp.asarray(32),
+            corner_luminosity=jnp.asarray(54),
+        ),
     )
     background = jnp.where(mask[..., None], wall_tile, floor_tile)
     return background

--- a/navix/rendering/cache.py
+++ b/navix/rendering/cache.py
@@ -27,6 +27,7 @@ from jax import Array
 import jax.numpy as jnp
 from flax import struct
 
+from ..grid import draw_grid_lines
 from .registry import TILE_SIZE, SPRITES_REGISTRY
 
 
@@ -65,7 +66,18 @@ def render_background(
     mask = jnp.asarray(grid_resized, dtype=bool)  # 0 = floor, 1 = wall
     # index by [entity_type, direction, open/closed, y, x, channel]
     wall_tile = tile_grid(grid, sprites_registry["wall"])
-    floor_tile = tile_grid(grid, sprites_registry["floor"])
+    # draw grid lines on the floor tile only, matching MiniGrid: its
+    # Wall.render() fills the whole tile opaquely, completely covering
+    # whatever grid line was drawn underneath, so walls never actually
+    # show one - only empty/floor cells do. floor.png's own baked-in
+    # border (a different colour, from before this fix) gets
+    # overwritten by this rather than drawn alongside it. luminosity=32
+    # (not draw_grid_lines' default of 100, MiniGrid's raw grey
+    # constant) empirically matches a real MiniGrid render - see that
+    # function's docstring for why the raw constant renders too bold.
+    floor_tile = tile_grid(
+        grid, draw_grid_lines(sprites_registry["floor"], luminosity=jnp.asarray(32))
+    )
     background = jnp.where(mask[..., None], wall_tile, floor_tile)
     return background
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,6 +1,7 @@
 import jax
 import jax.numpy as jnp
 import navix as nx
+from navix.grid import view_cone
 
 
 def test_grid_from_ascii():
@@ -91,9 +92,47 @@ def test_position_equal():
     assert jnp.array_equal(nx.grid.positions_equal(b + 1, a), jnp.array([False, False]))
 
 
+def test_view_cone_does_not_overflow_at_large_radius():
+    # view_cone's fin_diff accumulates path *counts* (each step lets
+    # every unit of "mass" split into up to 9 copies of itself, a 3x3
+    # neighbourhood sum), not just reachability - the total grows
+    # ~9x per step and only `view > 0` is ever read downstream. In an
+    # open area this overflows int32 (~2.1e9) at cone radius 12; past
+    # that, a wrapped-negative cell is indistinguishable from a
+    # genuinely unreachable one, so overflow silently *removes*
+    # visibility instead of erroring. Found and verified independently
+    # by @Near32 on PR #148, who proposed clamping to a boolean flood
+    # (min with 1) after every step, since the magnitude is discarded
+    # by the `> 0` threshold anyway.
+    #
+    # For an open room with the origin far enough from every wall that
+    # the whole diffusion stays in-bounds, a `radius`-step king-move
+    # flood should reach exactly a (2*radius+1) x (2*radius+1) square -
+    # verified against that closed form, rather than a fixed magic
+    # number, so the assertion holds at any radius.
+    for radius in [10, 11, 12, 13, 14, 24]:  # straddles the old radius=12 overflow
+        n = 4 * radius + 9  # room comfortably larger than the flood's reach
+        transparency_map = jnp.ones((n, n), dtype=jnp.int32)
+        transparency_map = (
+            transparency_map.at[0, :].set(0)
+            .at[-1, :].set(0)
+            .at[:, 0].set(0)
+            .at[:, -1].set(0)
+        )
+        origin = jnp.asarray([n // 2, n // 2])
+        view = view_cone(transparency_map, origin, radius)
+        expected = (2 * radius + 1) ** 2
+        assert int(view.sum()) == expected, (
+            f"radius={radius}: expected a full {2 * radius + 1}x{2 * radius + 1} "
+            f"visible square ({expected} cells), got {int(view.sum())} - some "
+            "cells were likely dropped by int32 overflow in the accumulator"
+        )
+
+
 if __name__ == "__main__":
     # test_grid_from_ascii()
     # test_idx_from_coordinates()
     # test_random_positions()
     test_position_equal()
     # jax.jit(test_position_equal)()
+    test_view_cone_does_not_overflow_at_large_radius()

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 import navix as nx
 from navix import observations
@@ -219,9 +220,61 @@ def test_146():
     )
 
 
+def test_147():
+    # https://github.com/epignatelli/navix/issues/147
+    # crop() places the agent at the *bottom* row of the 2*RADIUS+1
+    # first-person view, so the far row is 2*RADIUS cells forward of
+    # the agent - but categorical_first_person()/rgb_first_person()
+    # only diffused view_cone's visibility RADIUS cells, so the
+    # forward half of every first-person view was permanently marked
+    # unseen regardless of whether real walls were there. Verified
+    # against a real MiniGrid render of the identical scenario (open
+    # room, agent centred, no walls within 2*RADIUS in any direction):
+    # pre-fix, Navix's forward half is solid black where MiniGrid
+    # shows open floor; post-fix they closely match.
+    import gymnasium as gym
+    import minigrid  # noqa: F401 - registers MiniGrid-* env ids
+
+    radius = observations.RADIUS
+    tile_size = 8
+    centre = 8  # Navix-Empty-16x16-v0 / MiniGrid-Empty-16x16-v0 interior
+
+    env = nx.make(
+        "Navix-Empty-16x16-v0", observation_fn=observations.rgb_first_person
+    )
+    timestep = env.reset(jax.random.PRNGKey(0))
+    player = timestep.state.entities[Entities.PLAYER]
+    player = player.replace(
+        position=jnp.asarray([[centre, centre]]), direction=jnp.asarray([0])
+    )
+    state = timestep.state.replace(
+        entities={**timestep.state.entities, Entities.PLAYER: player}
+    )
+    navix_img = np.asarray(observations.rgb_first_person(state))
+
+    mg_env = gym.make(
+        "MiniGrid-Empty-16x16-v0",
+        agent_view_size=2 * radius + 1,
+        tile_size=tile_size,
+    )
+    mg_env.reset(seed=0)
+    mg_env.unwrapped.agent_pos = (centre, centre)
+    mg_env.unwrapped.agent_dir = 0
+    mg_img = mg_env.unwrapped.get_frame(agent_pov=True, tile_size=tile_size)
+
+    diff = np.abs(navix_img.astype(int) - mg_img.astype(int))
+    assert diff.mean() < 20, (
+        "Expected Navix's rgb_first_person to closely match a real MiniGrid "
+        "render in an open room with no walls within reach, got mean "
+        f"abs pixel diff {diff.mean():.1f} (max {diff.max()}) - the forward "
+        "half of the view is likely still being marked unseen"
+    )
+
+
 if __name__ == "__main__":
     test_82()
     test_91()
     test_98()
     test_135()
     test_146()
+    test_147()


### PR DESCRIPTION
## Summary
Fixes #147 and #138. Also fixes two more related issues found along the way (grid-line colour, and a int32 overflow in `view_cone` caught by @Near32's review) - see below.

### #147: view_cone radius mismatch (the real bug)
`categorical_first_person()`/`rgb_first_person()` computed their visibility mask via `view_cone(transparency_map, player.position, RADIUS)`. But `crop()` places the agent at the *bottom* row of the `2*RADIUS+1` view, so the far row is `2*RADIUS` cells forward of the agent, not `RADIUS`. `view_cone`'s diffusion only propagated half as far as the crop window actually extends, so the forward half of every first-person view was permanently marked unseen - a hard cutoff at exactly the midpoint, not fog-of-war, regardless of whether real walls were there.

Fixed by passing `RADIUS * 2` to `view_cone` in both functions, matching `crop()`'s actual forward reach.

This was found while investigating #138 (below), using an open room with the agent centred (no walls within reach) to isolate "visibility computation bug" from "legitimate off-map padding" - the two were previously confounded by only ever testing corner scenarios.

### #138: RGB first-person padding colour (folded in)
Out-of-view/unseen tiles used `dark_cell_colour=0` (solid black). First attempt: swap in MiniGrid's raw wall grey constant `(100, 100, 100)`. **That was still wrong** - caught via review (thanks for pushing on this) and fixed properly in a follow-up commit:

Every real cell in `rgb_first_person`'s `patchwork` goes through `apply_minigrid_opacity(opacity=0.7)` before the FOV mask is applied, but `dark_cell_colour` is inserted as a flat literal *after* that, bypassing it entirely. So a genuinely-visible, opacity-adjusted wall doesn't render at the raw `100` at all - it renders at `~146`. Using `100` for the unseen fill created a visible seam between real walls (146) and unseen padding (100) within the *same image* - not a MiniGrid-vs-Navix gap, an internal Navix inconsistency.

Root-caused by checking both sides directly:
- Read `minigrid.core.grid.Grid.render_tile`: `MiniGridEnv.get_pov_render` passes `highlight_mask=vis_mask`, so every visible cell gets `minigrid.utils.rendering.highlight_img` applied (a 30% blend toward white). `apply_minigrid_opacity`'s formula (`255 - 0.7*(255-x)`) is algebraically identical to `highlight_img`'s (`0.7x + 76.5`) - not a coincidence, the existing docstring already said this function exists to replicate MiniGrid's opacity convention.
- Extracted the actual `view_cone` visibility mask and sampled every cell of a real rendered image individually, to confirm a *genuinely visible* wall cell (not an off-map padding cell that an earlier hand-check had mistakenly sampled instead) renders at `(146, 146, 146)` - matching MiniGrid's highlighted wall (`146.5`) almost exactly once the correct cell is compared.

Fixed by deriving `dark_cell_colour` from `apply_minigrid_opacity` itself, rather than hardcoding a second, easily-out-of-sync magic number.

### Bonus: floor tile grid-line colour (not its own issue, found while comparing renders)
`draw_grid_lines()` (`navix/grid.py`) exists specifically to replicate MiniGrid's grid lines, but was dead code - only referenced in a commented-out line in `rgb_first_person` - and was actually broken: `line_thickness = jnp.ceil(TILE_SIZE * 0.031)` returns a float-dtype array, which can't be used as a slice bound (confirmed by calling it directly - `TypeError: Only integer scalar arrays can be converted to a scalar index`). Fixed with plain `math.ceil()` instead (`TILE_SIZE` is a static Python int, never needed to be a JAX op).

The commented-out call site was also the wrong place: applying it to `rgb_first_person`'s per-step entity sprites (player, keys, balls, doors) would draw a grey line across their artwork - MiniGrid never does this, grid lines are background, objects render on top and cover them. Wired in at the correct place instead: `rendering/cache.py`'s `render_background()`, applied only to the floor tile, once, when the static background cache is built - not to walls (MiniGrid's `Wall.render()` fills its whole tile opaquely, hiding any line underneath, and Navix's wall sprite is already a flat uniform fill, confirmed by direct pixel inspection, not assumed).

`luminosity`: the function's default (`100`, MiniGrid's raw grey constant) is correct for walls but wrong here - MiniGrid's grid line is a sub-pixel-width, anti-aliased strip, only *partially* covered by that raw colour at typical tile sizes, while `draw_grid_lines` does a hard, fully-opaque fill with no antialiasing. Tried the "principled" default first - made the match measurably *worse* (corner mean diff 1.40 -> 6.02). Solved `0.7*L + 76.5 = 99` for `L`, then verified empirically rather than trusting the algebra alone: `luminosity=32` gives corner mean diff 1.40 -> **0.34**, open room 2.42 -> **0.54** - the best result across all three fixes.

## Verification

Measured on a real GPU (`Navix-Empty-16x16-v0` vs `MiniGrid-Empty-16x16-v0`, radius=3, identical agent position/direction), across all three commits:

| Scenario | pre-fix | #147 + raw grey | + opacity-adjusted grey | + tuned grid-line colour | + corner fix (final) |
|---|---|---|---|---|---|
| Open room, no walls in reach | 36.4 | 2.42 | 2.42 | 0.54 | **0.293** |
| Corner scenario | much higher | 14.54 | 1.40 | 0.34 | **0.199** |

### Fixed the corner-intersection residual too (caught by inspecting the actual diff array, not just mean/max)
The "known, accepted residual" above turned out to be fixable. MiniGrid draws its top and left grid-line strips as two independent, anti-aliased `fill_coords()` calls - the corner pixel gets covered by *both*, ending up brighter (`114`) than either strip alone (`99`). `draw_grid_lines()` applied one flat luminosity to the whole line, so it could match the edge or the corner, but not both.

Added an optional `corner_luminosity` parameter, filling just the `line_thickness x line_thickness` corner block separately. Solved `0.7*L + 76.5 = 114` for `L`, verified empirically: `corner_luminosity=54` at the floor-tile call site.

Sampled cells directly confirm the final state: real walls and unseen/padding cells render at exactly `(146, 146, 146)` in Navix, matching MiniGrid pixel-for-pixel; floor tiles' grid-line pixels (edges *and* corners) now match within 1 everywhere except the agent's own tile, where its sprite - a separate, independently-authored asset with its own baked-in border, deliberately not touched by this fix - replaces the floor tile entirely.

Confirmed `tests/test_issues.py::test_147` actually catches the #147 bug (not vacuously passing): temporarily reverted the `RADIUS * 2` fix and re-ran it - failed as expected (mean diff 36.4 vs. the test's threshold of 20) - then restored the fix and re-verified it passes.

`test_147` compares a real `rgb_first_person` render against a real MiniGrid render (`minigrid` is already a `requirements_test.txt` dependency) rather than hand-computing `crop()`'s pad/roll/rotate/slice geometry by hand.

### `view_cone` int32 overflow at large radius (found by @Near32's review, fixed here)

[@Near32](https://github.com/Near32) independently confirmed the `RADIUS * 2` fix against MiniGrid's own `Grid.process_vis()` (exact match), and separately found that `view_cone`'s `fin_diff` accumulates path *counts*, not just reachability - each step sums a 3x3 neighbourhood, so the total grows ~9x per step, and it overflows `int32` (~2.1e9) at cone radius 12. Past that, a wrapped-negative cell reads identically to a genuinely unreachable one, so overflow silently *removes* visibility instead of erroring. Since this PR passes `RADIUS * 2` to `view_cone`, it halves the safe ceiling on the public `RADIUS` parameter (`RADIUS <= 11` before this PR, `<= 5` after) - doesn't affect the default `RADIUS=3`, but a real regression at settings someone might reasonably use.

Fixed with the proposed clamp: `jnp.minimum(array, 1)` after every step, turning the accumulator into a real boolean flood (immune to overflow at any radius, behaviour-preserving below the old threshold since only `> 0` is ever read).

Independently re-verified all of it on a real GPU rather than taking the numbers on faith: reproduced the exact overflow figures from the standalone repro script, confirmed the fix restores exact correctness (`(2*radius+1)^2` visible cells, the correct closed form for an open room) at every radius from 10 to 24 - including radius 12+ where it was previously undercounting - confirmed identical masks to an unclamped reference at radius 3-7 (behaviour-preserving), and benchmarked no performance regression.

One tangent this raised: whether a `jax.lax.conv`-based 3x3 kernel would be faster than the existing roll-based separable sum. Benchmarked both directly - roll is consistently ~1.3-1.4x faster across grid sizes 15x15 to 63x63, so the existing approach was already the right call; not changed.

`tests/test_grid.py::test_view_cone_does_not_overflow_at_large_radius` - verified it actually catches the bug (temporarily removed the clamp, confirmed it fails with the exact expected undercounted value, restored the fix, confirmed it passes).

Full test suite (49 passed, including the new test) verified on a real GPU.

## Test plan
- [ ] CI passes
- `tests/test_issues.py::test_147` - real Navix-vs-MiniGrid render comparison, open room
- `tests/test_grid.py::test_view_cone_does_not_overflow_at_large_radius` - overflow regression test
- Full suite (49 passed) verified on real GPU



