### PR TITLE
feat: add Dreamer, a first-class world-model agent (issue #142)

### DIFF
--- a/baselines/dreamer.py
+++ b/baselines/dreamer.py
@@ -36,7 +36,12 @@ if __name__ == "__main__":
             env=env,
             world=WorldModel(obs_dim=obs_dim, act_dim=act_dim, hparams=args.dreamer),
             actor=DreamerActor(act_dim=act_dim, hidden=args.dreamer.hidden_size),
-            critic=DreamerCritic(hidden=args.dreamer.hidden_size),
+            critic=DreamerCritic(
+                hidden=args.dreamer.hidden_size,
+                bins=args.dreamer.bins,
+                low=args.dreamer.bins_low,
+                high=args.dreamer.bins_high,
+            ),
         )
 
         experiment = nx.Experiment(

--- a/baselines/dreamer.py
+++ b/baselines/dreamer.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+import wandb
+import tyro
+
+import navix as nx
+from navix.agents import Dreamer, DreamerHparams, WorldModel, DreamerActor, DreamerCritic
+
+
+@dataclass
+class Args:
+    project_name = "navix-baselines"
+    seeds_range: Tuple[int, int, int] = (0, 10, 1)
+    dreamer: DreamerHparams = DreamerHparams()
+
+
+if __name__ == "__main__":
+    args = tyro.cli(Args)
+
+    for env_id in nx.registry():
+        config = {**vars(args), **{"observations": "symbolic"}, **{"algo": "dreamer"}}
+        wandb.init(project=args.project_name, config=config)
+
+        # Unlike PPO's ActorCritic (which needs a pre-flattened
+        # observation via FlattenObsWrapper, see baselines/ppo.py),
+        # Dreamer's world model flattens whatever shape self.env.
+        # observation_fn returns internally - obs_dim just needs to match
+        # the flattened size of that raw shape.
+        env = nx.make(env_id)
+        obs_dim = int(np.prod(env.observation_space.shape))
+        act_dim = len(env.action_set)
+        agent = Dreamer(
+            hparams=args.dreamer,
+            env=env,
+            world=WorldModel(obs_dim=obs_dim, act_dim=act_dim, hparams=args.dreamer),
+            actor=DreamerActor(act_dim=act_dim, hidden=args.dreamer.hidden_size),
+            critic=DreamerCritic(hidden=args.dreamer.hidden_size),
+        )
+
+        experiment = nx.Experiment(
+            name=args.project_name,
+            agent=agent,
+            env=env,
+            env_id=env_id,
+            seeds=tuple(range(*args.seeds_range)),
+        )
+        experiment.run()

--- a/navix/agents/__init__.py
+++ b/navix/agents/__init__.py
@@ -20,3 +20,10 @@
 
 from .ppo import PPO, PPOHparams as PPOHparams
 from .models import MLPEncoder, ConvEncoder, ActorCritic
+from .dreamer import (
+    Dreamer,
+    DreamerHparams as DreamerHparams,
+    WorldModel,
+    Actor as DreamerActor,
+    Critic as DreamerCritic,
+)

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -27,10 +27,12 @@ embodied/jax/agent.py) rather than assumed from the paper text alone:
 
   1. Symlog inputs/reconstruction (`rlax.signed_logp1`/`signed_expm1`,
      used by the `Encoder` and `TwoHotHead` in `.models`).
-  2. Categorical latents (`stoch` independent categoricals of `classes`
-     each) with straight-through gradients and 1% "unimix" - mixing a
-     little uniform mass into every categorical, so no class ever gets
-     a literal zero probability - for both the prior and posterior.
+  2. Categorical latents (`num_latents` independent categoricals of
+     `num_classes` each, "stoch"/"classes" in the official
+     implementation) with straight-through gradients and 1% "unimix" -
+     mixing a little uniform mass into every categorical, so no class
+     ever gets a literal zero probability - for both the prior and
+     posterior.
   3. KL balancing with free bits: two separate KL terms with different
      stop-gradient placement and independent free-nats floors, not one
      combined KL clamped by a single scalar.
@@ -59,7 +61,7 @@ parameter-efficiency optimization for much larger deter sizes); a plain
 symlog+MSE decoder for observation reconstruction (not the official
 implementation's image-specific CNN decoder); ELU activations and no
 RMSNorm (not load-bearing for correctness, just a smaller/simpler net);
-`stoch`/`classes` default to 8x8 rather than the paper's 32x32, sized
+`num_latents`/`num_classes` default to 8x8 rather than the paper's 32x32, sized
 for navix's small grids rather than Atari-scale observations. None of
 these are the algorithmic identity of DreamerV3 - the five techniques
 above are.
@@ -154,10 +156,12 @@ class DreamerHparams(HParams):
     # World model: categorical latent + KL balancing (paper defaults:
     # stoch=32, classes=32/64, unimix=0.01, free_nats=1.0, dyn_scale=1.0,
     # rep_scale=0.1 - dims reduced here for navix's small grids).
-    stoch: int = struct.field(pytree_node=False, default=8)
-    """Number of independent categorical latent variables."""
-    classes: int = struct.field(pytree_node=False, default=8)
-    """Number of classes per categorical latent variable."""
+    num_latents: int = struct.field(pytree_node=False, default=8)
+    """Number of independent categorical latent variables ("stoch" in
+    the official implementation)."""
+    num_classes: int = struct.field(pytree_node=False, default=8)
+    """Number of classes per categorical latent variable ("classes" in
+    the official implementation)."""
     unimix: float = 0.01
     """Fraction of uniform probability mixed into every categorical."""
     free_nats: float = 1.0
@@ -228,16 +232,18 @@ class DreamerHparams(HParams):
     # Model sizes
     embed_size: int = 128
     """Size of the encoder's output embedding."""
-    deter_size: int = 200
-    """Size of the RSSM's deterministic (GRU) hidden state."""
+    recurrent_size: int = 200
+    """Size of the RSSM's deterministic (GRU) hidden state ("deter" in
+    the official implementation)."""
     hidden_size: int = 200
     """Hidden layer size used throughout the model/actor/critic MLPs."""
 
     @property
-    def stoch_flat(self) -> int:
-        """Flattened size of the categorical latent (`stoch * classes`),
-        i.e. how much of `feat = concat([h, z_flat])` the latent occupies."""
-        return self.stoch * self.classes
+    def latents_flat(self) -> int:
+        """Flattened size of the categorical latent (`num_latents *
+        num_classes`), i.e. how much of `feat = concat([h, z_flat])` the
+        latent occupies."""
+        return self.num_latents * self.num_classes
 
 
 # -------------------------
@@ -253,9 +259,9 @@ class WorldModel(nn.Module):
     def setup(self):
         hp = self.hparams
         self.encoder = Encoder(hp.hidden_size, hp.embed_size)
-        self.rssm = RSSM(hp.deter_size)
-        self.prior = PriorNet(hp.hidden_size, hp.stoch, hp.classes)
-        self.post = PostNet(hp.hidden_size, hp.stoch, hp.classes)
+        self.rssm = RSSM(hp.recurrent_size)
+        self.prior = PriorNet(hp.hidden_size, hp.num_latents, hp.num_classes)
+        self.post = PostNet(hp.hidden_size, hp.num_latents, hp.num_classes)
         self.decoder = Decoder(hp.hidden_size, self.obs_dim)
         self.reward = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
         # Zero-init output like the reward/critic heads (see TwoHotHead):
@@ -272,8 +278,8 @@ class WorldModel(nn.Module):
         )
 
     def init_state(self, batch_size: int) -> Tuple[Array, Array, Array]:
-        h = jnp.zeros((batch_size, self.hparams.deter_size))
-        z_flat = jnp.zeros((batch_size, self.hparams.stoch_flat))
+        h = jnp.zeros((batch_size, self.hparams.recurrent_size))
+        z_flat = jnp.zeros((batch_size, self.hparams.latents_flat))
         a0 = jnp.zeros((batch_size, self.act_dim))
         return h, z_flat, a0
 
@@ -430,8 +436,8 @@ class WorldModel(nn.Module):
         (h_last, z_last, _), (hs, zs, dyn_kls, rep_kls, feats) = jax.lax.scan(
             step,
             (
-                jnp.zeros((B, hp.deter_size)),
-                jnp.zeros((B, hp.stoch_flat)),
+                jnp.zeros((B, hp.recurrent_size)),
+                jnp.zeros((B, hp.latents_flat)),
                 init_rng,
             ),
             inputs,
@@ -498,14 +504,14 @@ class WorldModel(nn.Module):
         while already inside an outer jax.jit (surfaces as a confusing
         `UnexpectedTracerError` pointing at an unrelated submodule)."""
         hp = self.hparams
-        h = jnp.zeros((obs.shape[0], hp.deter_size))
-        z_flat = jnp.zeros((obs.shape[0], hp.stoch_flat))
+        h = jnp.zeros((obs.shape[0], hp.recurrent_size))
+        z_flat = jnp.zeros((obs.shape[0], hp.latents_flat))
         h_t = self.rssm(h, z_flat, a_prev_oh)
         self.prior(h_t)
         embed = self.encoder(obs)
         post_logits = self.post(h_t, embed)
-        z_t = jax.nn.one_hot(jnp.zeros(obs.shape[0], dtype=jnp.int32), hp.classes)
-        z_t = jnp.broadcast_to(z_t[:, None, :], (obs.shape[0], hp.stoch, hp.classes))
+        z_t = jax.nn.one_hot(jnp.zeros(obs.shape[0], dtype=jnp.int32), hp.num_classes)
+        z_t = jnp.broadcast_to(z_t[:, None, :], (obs.shape[0], hp.num_latents, hp.num_classes))
         feat_t = self.feat(h_t, z_t.reshape(obs.shape[0], -1))
         self.decoder(feat_t)
         self.reward(feat_t)
@@ -695,8 +701,8 @@ class DreamerTrainState(struct.PyTreeNode):
     return_norm_hi: Array  # EMA of the 95th percentile of returns
 
     # Latents per-env, carried across collection steps.
-    h: Array  # (N, deter_size)
-    z: Array  # (N, stoch_flat)
+    h: Array  # (N, recurrent_size)
+    z: Array  # (N, latents_flat)
     a_prev_oh: Array  # (N, act_dim)
 
 
@@ -946,7 +952,7 @@ class Dreamer(Agent):
         logps)`, so this factors it out rather than re-running `imagine()`
         (a full `imag_horizon`-step scan) twice per Dreamer.update()."""
         hp = self.hparams
-        h0, z0 = start_feats[:, : hp.deter_size], start_feats[:, hp.deter_size :]
+        h0, z0 = start_feats[:, : hp.recurrent_size], start_feats[:, hp.recurrent_size :]
 
         def actor_logits_fn(feat):
             return self.actor.apply({"params": actor_params}, feat)
@@ -1314,8 +1320,8 @@ class Dreamer(Agent):
             jnp.zeros((1, self.world.act_dim)),
             method=WorldModel.init_probe,
         )
-        a_variables = self.actor.init(ak, jnp.zeros((1, hp.deter_size + hp.stoch_flat)))
-        c_variables = self.critic.init(ck, jnp.zeros((1, hp.deter_size + hp.stoch_flat)))
+        a_variables = self.actor.init(ak, jnp.zeros((1, hp.recurrent_size + hp.latents_flat)))
+        c_variables = self.critic.init(ck, jnp.zeros((1, hp.recurrent_size + hp.latents_flat)))
 
         model_tx = optax.chain(
             optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.model_lr)

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -1283,9 +1283,14 @@ class Dreamer(Agent):
         # Return-normalization scale: EMA-tracked 5th/95th percentile of
         # a quick lambda-return estimate under the current critic, so the
         # actor's advantage is on a comparable scale regardless of the
-        # environment's raw reward magnitude.
+        # environment's raw reward magnitude. Split off a dedicated key
+        # for this probe rollout - `rng` itself is reused just below as
+        # the actor_step scan's carry, and reusing the same key for both
+        # would make the probe's imagined trajectory and the first actor
+        # gradient step draw from identical randomness.
+        rng, key_probe = jax.random.split(rng)
         _, probe_feats, probe_rews, probe_continues, _, _ = self._actor_critic_rollout(
-            model.params, ts.actor.params, start_feats, rng
+            model.params, ts.actor.params, start_feats, key_probe
         )
         head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
         probe_vals_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -191,7 +191,7 @@ class DreamerHparams(HParams):
     technique already used for the world model's own categorical latents
     (see `unimix_categorical`'s docstring), applied here too. Without
     this, the actor's entropy can reach exactly zero: once it does,
-    `_collect` (which samples actions from this same distribution) stops
+    `collect_experience` (which samples actions from this same distribution) stops
     exploring too, so real data collection narrows to whatever the
     collapsed policy repeats, the world model overfits to that narrow
     trajectory, and there is no path back - a self-reinforcing collapse
@@ -332,7 +332,7 @@ class WorldModel(nn.Module):
                 instead of a stale, causally-unrelated belief plus an
                 action that didn't really produce it - matching both the
                 official implementation's `is_first` masking and what
-                `_collect` does with its own carried latents (full-context
+                `collect_experience` does with its own carried latents (full-context
                 belief at the terminal observation, blank slate at the
                 reset one).
 
@@ -463,7 +463,7 @@ class WorldModel(nn.Module):
         WorldModel instance, so - unlike a bare Dense/Sequential module -
         they can only be called from inside a WorldModel.apply() trace,
         which is what this method (called via `self.world.apply(...,
-        method=WorldModel.posterior_step)`) provides for `_collect`."""
+        method=WorldModel.posterior_step)`) provides for `collect_experience`."""
         h_next = self.rssm(h, z_flat, a_prev_oh)
         embed = self.encoder(obs)
         post_dist = unimix_categorical(self.post(h_next, embed), self.hparams.unimix)
@@ -744,7 +744,9 @@ class Dreamer(Agent):
 
     # ---------- Collection ----------
 
-    def _collect(self, ts: DreamerTrainState) -> Tuple[DreamerTrainState, Buffer]:
+    def collect_experience(
+        self, ts: DreamerTrainState
+    ) -> Tuple[DreamerTrainState, Buffer]:
         """Runs `hparams.num_steps` steps in `hparams.num_envs` parallel
         envs, carrying the per-env posterior latent (h, z, a_prev_oh)
         across steps so the policy always acts on an up-to-date belief."""
@@ -1122,7 +1124,7 @@ class Dreamer(Agent):
     def update(self, ts: DreamerTrainState, _) -> Tuple[DreamerTrainState, Dict]:
         hp = self.hparams
 
-        ts, experience = self._collect(ts)
+        ts, experience = self.collect_experience(ts)
         replay = self._write_replay(ts.replay, experience)
         ts = ts.replace(replay=replay)
 

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -181,13 +181,25 @@ class TwoHotHead(nn.Module):
 
     @nn.compact
     def __call__(self, feat: Array) -> Array:
+        # The output layer is ZERO-initialized (official implementation's
+        # `outscale: 0.0` for the reward/critic heads): all-zero logits ->
+        # uniform bin probabilities -> mean symexp(sum(p*bins)) = symexp(0)
+        # = 0 exactly, so an untrained head predicts 0, not symexp of
+        # whatever random logits happen to sum to over bins spanning
+        # symlog +-20 - which can reach +-e^20. Without this, the very
+        # first imagination rollouts feed the actor advantages of garbage
+        # magnitude; the return-normalization EMA (rate 0.01) is far too
+        # slow to absorb that, and ~64 gradient steps of it were observed
+        # to slam the actor into a deterministic policy (entropy pinned at
+        # the unimix floor) before the world model had learned anything -
+        # after which exploration never recovers.
         net = nn.Sequential(
             [
                 nn.Dense(self.hidden_size),
                 nn.elu,
                 nn.Dense(self.hidden_size),
                 nn.elu,
-                nn.Dense(self.bins),
+                nn.Dense(self.bins, kernel_init=nn.initializers.zeros),
             ]
         )
         return net(feat)  # logits, (..., bins)
@@ -217,14 +229,31 @@ class DreamerHparams(HParams):
     """Number of parallel environments to run."""
     num_steps: int = struct.field(pytree_node=False, default=128)
     """Number of environment steps to collect per update."""
-    num_model_updates: int = struct.field(pytree_node=False, default=32)
-    """Number of world-model gradient steps per update."""
-    num_actor_updates: int = struct.field(pytree_node=False, default=32)
-    """Number of actor gradient steps per update."""
-    num_critic_updates: int = struct.field(pytree_node=False, default=32)
-    """Number of critic gradient steps per update."""
+    num_model_updates: int = struct.field(pytree_node=False, default=128)
+    """Number of world-model gradient steps per update. The default is
+    deliberately high relative to the frames collected per update (a
+    replay ratio in the spirit of the official implementation's
+    `train_ratio`): DreamerV3 is designed to be sample-efficient by
+    gradient-stepping far more often than it collects. Concretely, with
+    a sparse reward the rewarded transitions can be ~0.2% of the replay
+    data, and a mean-reduced twohot cross-entropy pushes the reward head
+    toward the base-rate prediction (~0) until it has seen enough
+    positive examples to separate them - at 32 steps/update the reward
+    head was still predicting ~0.004 at real goal transitions after a
+    full 100k-frame run (policy stuck at random-walk success), while at
+    128 it reaches ~0.98 and the same run ends at 100% success."""
+    num_actor_updates: int = struct.field(pytree_node=False, default=128)
+    """Number of actor gradient steps per update (see num_model_updates
+    for why the default is high)."""
+    num_critic_updates: int = struct.field(pytree_node=False, default=128)
+    """Number of critic gradient steps per update (see num_model_updates
+    for why the default is high)."""
     batch_size: int = struct.field(pytree_node=False, default=64)
     """Number of sequences sampled per world-model gradient step."""
+    replay_capacity: int = struct.field(pytree_node=False, default=500_000)
+    """Maximum number of environment frames kept in the replay buffer
+    (rounded down to whole collection rollouts, and never allocated
+    larger than the training budget itself can fill)."""
     seq_len: int = struct.field(pytree_node=False, default=32)
     """Length of the sequences sampled for world-model training."""
     imag_horizon: int = struct.field(pytree_node=False, default=15)
@@ -421,13 +450,16 @@ class WorldModel(nn.Module):
         self.post = PostNet(hp.hidden_size, hp.stoch, hp.classes)
         self.decoder = Decoder(hp.hidden_size, self.obs_dim)
         self.reward = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
+        # Zero-init output like the reward/critic heads (see TwoHotHead):
+        # an untrained term head then predicts sigmoid(0) = 0.5 rather
+        # than confident random continue/terminate calls.
         self.term = nn.Sequential(
             [
                 nn.Dense(hp.hidden_size),
                 nn.elu,
                 nn.Dense(hp.hidden_size),
                 nn.elu,
-                nn.Dense(1),
+                nn.Dense(1, kernel_init=nn.initializers.zeros),
             ]
         )
 
@@ -440,7 +472,7 @@ class WorldModel(nn.Module):
     def feat(self, h: Array, z_flat: Array) -> Array:
         return jnp.concatenate([h, z_flat], axis=-1)
 
-    def observe(self, obs_seq: Array, act_seq: Array, term_seq: Array) -> Tuple[
+    def observe(self, obs_seq: Array, act_seq: Array, first_seq: Array) -> Tuple[
         Tuple[Array, Array], Tuple[Array, Array], Array, Array, Array, Array
     ]:
         """Runs the RSSM over an observed sequence, computing the posterior
@@ -450,30 +482,45 @@ class WorldModel(nn.Module):
             obs_seq (Array): `f32[B, L+1, obs_dim]`, flattened observations.
             act_seq (Array): `i32[B, L]`, actions taken between consecutive
                 observations.
-            term_seq (Array): `f32[B, L]`, `1.0` where `act_seq[:, t]` ended
-                an episode (matching `experience.done`/the `_model_loss`
-                term-head target) - `term_seq[:, t] == 1` means
-                `obs_seq[:, t + 1]` is a fresh post-autoreset observation,
-                *not* a real consequence of `act_seq[:, t]`. Sampled
-                training sequences are sliced from a fixed-size buffer with
-                no regard for episode boundaries (`_sample_batch`), so a
-                sequence commonly straddles an autoreset; without this,
-                every such step would condition the reset observation's
-                posterior on the *previous* episode's (h, z) and pair it
-                with an action that didn't actually cause it - a genuine
-                transition the RSSM cannot learn (the reset is exogenous),
-                and, left unhandled, the resulting garbage (h, z) then
-                propagates forward through every subsequent step of the new
-                episode still inside this sequence, not just the one
-                boundary step. Matches the official implementation's
-                `is_first` masking in `RSSM.observe` (`embodied/jax/
-                rssm.py`): at scan step `t` (which pairs `act_seq[:, t]`
+            first_seq (Array): `f32[B, L]`, `1.0` where `obs_seq[:, t + 1]`
+                is a fresh post-autoreset observation (the first of a new
+                episode) rather than a real consequence of `act_seq[:, t]`.
+                NOTE the required shift relative to the buffer's `done`
+                flags: navix *defers* autoreset to the next `env.step()`
+                call (`Environment.step`'s `should_reset` looks at the
+                INPUT timestep), so `done[t] == 1` means `obs[t + 1]` is
+                the genuine TERMINAL observation - the goal cell actually
+                reached, caused by `act_seq[:, t]`, carrying the episode's
+                reward - and it's `obs[t + 2]` that is the exogenous reset.
+                The correct mask for scan step `t` is therefore
+                `done[t - 1]`, which `_sample_batch` slices as a
+                one-step-shifted window over `done`. An earlier version
+                passed `done` UNshifted, masking one step early: it zeroed
+                the belief state and action exactly at the goal-reaching
+                transition, so the reward/term heads were trained to
+                associate the sparse reward and termination with a
+                *blank-context* posterior of the goal observation - a
+                latent that imagination (which always rolls forward with
+                full context) never produces, so imagined rollouts never
+                saw reward at all, value targets stayed at zero, and the
+                actor's advantage signal was identically ~0 despite the
+                reward head fitting its (mislabeled) training data well.
+                Meanwhile the actual garbage transition - the action
+                consumed by the reset, "causing" the teleport to
+                `obs[t + 2]` - was trained unmasked. Sampled training
+                sequences are sliced from the replay with no regard for
+                episode boundaries, so sequences commonly straddle an
+                autoreset; at scan step `t` (which pairs `act_seq[:, t]`
                 with `embed(obs_seq[:, t + 1])`), both the incoming (h, z)
                 carried from step `t - 1` and `act_seq[:, t]` itself are
-                zeroed whenever `term_seq[:, t] == 1`, so `obs_seq[:, t +
-                1]`'s posterior is computed from a blank slate instead of a
-                stale, causally-unrelated belief plus an action that
-                didn't really produce it.
+                zeroed whenever `first_seq[:, t] == 1`, so the reset
+                observation's posterior is computed from a blank slate
+                instead of a stale, causally-unrelated belief plus an
+                action that didn't really produce it - matching both the
+                official implementation's `is_first` masking and what
+                `_collect` does with its own carried latents (full-context
+                belief at the terminal observation, blank slate at the
+                reset one).
 
         Returns:
             `((h_seq, z_seq), (dyn_kls, rep_kls), feats, obs_pred, rew_logits,
@@ -569,7 +616,7 @@ class WorldModel(nn.Module):
         # the stacked outputs back to (B, L, ...) coming out.
         inputs = jax.tree.map(
             lambda x: jnp.swapaxes(x, 0, 1),
-            (a_oh, embed_all[:, 1:], term_seq.astype(jnp.float32)),
+            (a_oh, embed_all[:, 1:], first_seq.astype(jnp.float32)),
         )
         init_rng = self.make_rng("sample")
         (h_last, z_last, _), (hs, zs, dyn_kls, rep_kls, feats) = jax.lax.scan(
@@ -609,6 +656,27 @@ class WorldModel(nn.Module):
         z_next = straight_through_sample(post_dist, rng)
         z_next_flat = z_next.reshape(*z_next.shape[:-2], -1)
         return h_next, z_next_flat
+
+    def prior_step(
+        self, h: Array, z_flat: Array, a_oh: Array, rng: Array
+    ) -> Tuple[Array, Array, Array]:
+        """One imagined (prior/dynamics) transition with a caller-supplied
+        action - the same mechanics as a single `imagine` rollout step,
+        but decoupled from the actor. Returns `(feat_next, reward_mean,
+        term_prob)`. Used for diagnosis: comparing the reward/term heads'
+        predictions on prior-sampled latents at known real transitions
+        (e.g. forcing the recorded goal-reaching action from the recorded
+        pre-goal posterior state) against their predictions on posterior
+        latents isolates whether a learned signal actually survives into
+        imagination, where the actor is trained."""
+        h_next = self.rssm(h, z_flat, a_oh)
+        prior_dist = unimix_categorical(self.prior(h_next), self.hparams.unimix)
+        z_next = straight_through_sample(prior_dist, rng)
+        z_next_flat = z_next.reshape(*z_next.shape[:-2], -1)
+        feat = jnp.concatenate([h_next, z_next_flat], axis=-1)
+        rew = self.reward.mean(self.reward(feat))
+        term_prob = jax.nn.sigmoid(jnp.squeeze(self.term(feat), -1))
+        return feat, rew, term_prob
 
     def init_probe(self, obs: Array, a_prev_oh: Array) -> None:
         """Touches every submodule exactly once, purely so `WorldModel.
@@ -701,13 +769,17 @@ class Actor(nn.Module):
 
     @nn.compact
     def __call__(self, feat: Array) -> Array:
+        # Near-zero output init (the official implementation's small
+        # actor `outscale`): the initial policy is near-uniform, so early
+        # data collection genuinely explores instead of committing to
+        # whatever the random init happens to prefer.
         net = nn.Sequential(
             [
                 nn.Dense(self.hidden),
                 nn.elu,
                 nn.Dense(self.hidden),
                 nn.elu,
-                nn.Dense(self.act_dim),
+                nn.Dense(self.act_dim, kernel_init=nn.initializers.orthogonal(0.01)),
             ]
         )
         return net(feat)
@@ -734,6 +806,7 @@ class Critic(nn.Module):
 
 class Buffer(struct.PyTreeNode):
     done: Array
+    termination: Array
     action: Array
     reward: Array
     log_prob: Array
@@ -741,6 +814,37 @@ class Buffer(struct.PyTreeNode):
     info: Dict[str, Array]
     t: Array
     state: State
+
+
+class Replay(struct.PyTreeNode):
+    """A fixed-capacity FIFO replay buffer of whole collection rollouts
+    ("blocks" of `num_steps` x `num_envs` transitions), carried inside
+    `DreamerTrainState` so it lives through the `jax.lax.scan` training
+    loop. DreamerV3 is a *replay-based* algorithm: the world model must
+    keep training on past experience, not only the rollout just
+    collected - with a sparse reward, a rare success transition seen only
+    in the update it happened in is forgotten by the reward head one
+    update later, so imagination goes back to predicting zero reward
+    everywhere and the actor's learning signal vanishes as soon as it
+    appears. (An earlier version had no replay at all - `_sample_batch`
+    read directly from the latest rollout - which is exactly the failure
+    mode that produced isolated windows of success that never
+    consolidated.)
+
+    Blocks are written whole (one per `Dreamer.update()` call) at a
+    rolling index; sampled sequences never straddle two blocks, so the
+    rolling overwrite boundary can't splice unrelated timelines together.
+    Only what world-model training needs is stored (obs flattened, action,
+    reward, done, termination) - not the logging-only fields of `Buffer`.
+    """
+
+    obs: Array  # (C, T, N, obs_dim), original observation dtype
+    action: Array  # (C, T, N) i32
+    reward: Array  # (C, T, N) f32
+    done: Array  # (C, T, N) bool - episode ended (termination OR truncation)
+    termination: Array  # (C, T, N) bool - true environment termination only
+    idx: Array  # scalar i32, next block slot to (over)write
+    size: Array  # scalar i32, number of filled block slots
 
 
 # -------------------------
@@ -773,6 +877,7 @@ class DreamerTrainState(struct.PyTreeNode):
     actor: TrainState
     critic: TrainState
     slow_critic_params: dict
+    replay: Replay
 
     env_state: Timestep
     rng: Array
@@ -880,6 +985,7 @@ class Dreamer(Agent):
 
             transition = Buffer(
                 done=new_env_state.is_done(),
+                termination=new_env_state.is_termination(),
                 action=a,
                 reward=new_env_state.reward,
                 log_prob=log_prob,
@@ -906,46 +1012,86 @@ class Dreamer(Agent):
         )
         return ts, traj
 
-    def _sample_batch(
-        self, rng: Array, experience: Buffer
-    ) -> Tuple[Array, Array, Array, Array]:
-        """Samples `hparams.batch_size` sequences of length `hparams.seq_len
-        + 1` observations / `seq_len` actions from the most recent
-        rollout, for world-model training."""
-        hp = self.hparams
-        T, N = experience.obs.shape[0], experience.obs.shape[1]
-        L = hp.seq_len
-        max_start = jnp.maximum(T - (L + 1), 0)
+    @staticmethod
+    def _write_replay(replay: Replay, experience: Buffer) -> Replay:
+        """Appends one whole collection rollout to the replay buffer as a
+        block at the rolling write index (overwriting the oldest block
+        once the buffer is full)."""
+        obs = experience.obs.reshape(*experience.obs.shape[:2], -1)
 
-        rng, key1, key2 = jax.random.split(rng, 3)
-        env_idx = jax.random.randint(key1, (hp.batch_size,), minval=0, maxval=N)
-        start_idx = jax.random.randint(
-            key2, (hp.batch_size,), minval=0, maxval=jnp.maximum(1, max_start + 1)
+        def put(buf, new):
+            return jax.lax.dynamic_update_index_in_dim(
+                buf, new.astype(buf.dtype), replay.idx, 0
+            )
+
+        capacity = replay.obs.shape[0]
+        return replay.replace(
+            obs=put(replay.obs, obs),
+            action=put(replay.action, experience.action),
+            reward=put(replay.reward, experience.reward),
+            done=put(replay.done, experience.done),
+            termination=put(replay.termination, experience.termination),
+            idx=(replay.idx + 1) % capacity,
+            size=jnp.minimum(replay.size + 1, capacity),
         )
 
-        def take_seq(ei, si):
-            obs_seq = jax.lax.dynamic_slice_in_dim(experience.obs[:, ei], si, L + 1)
-            act_seq = jax.lax.dynamic_slice_in_dim(experience.action[:, ei], si, L)
-            rew_seq = jax.lax.dynamic_slice_in_dim(experience.reward[:, ei], si, L)
-            term_seq = jax.lax.dynamic_slice_in_dim(
-                experience.done[:, ei].astype(jnp.float32), si, L
-            )
-            return obs_seq, act_seq, rew_seq, term_seq
+    def _sample_batch(
+        self, rng: Array, replay: Replay
+    ) -> Tuple[Array, Array, Array, Array, Array]:
+        """Samples `hparams.batch_size` sequences of `hparams.seq_len + 1`
+        observations / `seq_len` actions uniformly from the *filled* part
+        of the replay buffer (all blocks written so far, not just the
+        latest rollout), for world-model training. Returns
+        `(obs_seq, act_seq, rew_seq, first_seq, terminal_seq)`:
+        `first_seq[t] = done[start + t - 1]` - the one-step-SHIFTED window
+        over `done` that `observe()`'s boundary masking needs, because
+        navix defers autoreset by one step: `done[t] == 1` marks
+        `obs[t + 1]` as the genuine terminal observation, and it's
+        `obs[t + 2]` that is the fresh reset (see `observe`'s docstring).
+        Window starts are drawn from `[1, T - seq_len - 1]` (never 0) so
+        the shifted window's first element always exists in-block.
+        `terminal_seq` marks true environment termination only (the term
+        head's target - a timeout truncation is NOT a terminal state, the
+        episode was cut short exogenously, see `_model_loss`)."""
+        hp = self.hparams
+        C, T, N = replay.action.shape
+        L = hp.seq_len
+        max_start = jnp.maximum(T - (L + 1), 1)
 
-        obs_seq, act_seq, rew_seq, term_seq = jax.vmap(take_seq)(env_idx, start_idx)
-        return self._flatten_obs(obs_seq.reshape(-1, *obs_seq.shape[2:])).reshape(
-            hp.batch_size, L + 1, -1
-        ), act_seq, rew_seq, term_seq
+        rng, key1, key2, key3 = jax.random.split(rng, 4)
+        block_idx = jax.random.randint(
+            key1, (hp.batch_size,), minval=0, maxval=jnp.maximum(replay.size, 1)
+        )
+        env_idx = jax.random.randint(key2, (hp.batch_size,), minval=0, maxval=N)
+        start_idx = jax.random.randint(
+            key3, (hp.batch_size,), minval=1, maxval=max_start + 1
+        )
+
+        def take_seq(bi, ei, si):
+            obs_seq = jax.lax.dynamic_slice_in_dim(
+                replay.obs[bi, :, ei].astype(jnp.float32), si, L + 1
+            )
+            act_seq = jax.lax.dynamic_slice_in_dim(replay.action[bi, :, ei], si, L)
+            rew_seq = jax.lax.dynamic_slice_in_dim(replay.reward[bi, :, ei], si, L)
+            first_seq = jax.lax.dynamic_slice_in_dim(
+                replay.done[bi, :, ei].astype(jnp.float32), si - 1, L
+            )
+            terminal_seq = jax.lax.dynamic_slice_in_dim(
+                replay.termination[bi, :, ei].astype(jnp.float32), si, L
+            )
+            return obs_seq, act_seq, rew_seq, first_seq, terminal_seq
+
+        return jax.vmap(take_seq)(block_idx, env_idx, start_idx)
 
     # ---------- Losses ----------
 
-    def _model_loss(self, params, obs_seq, act_seq, rew_seq, term_seq, rng):
+    def _model_loss(self, params, obs_seq, act_seq, rew_seq, first_seq, terminal_seq, rng):
         (hs, zs), (dyn_kls, rep_kls), feats, obs_pred, rew_logits, term_logits = (
             self.world.apply(
                 {"params": params},
                 obs_seq,
                 act_seq,
-                term_seq,
+                first_seq,
                 method=WorldModel.observe,
                 rngs={"sample": rng},
             )
@@ -965,9 +1111,20 @@ class Dreamer(Agent):
         # pattern _actor_loss/_critic_loss use.
         reward_head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
         rew_loss = jnp.mean(reward_head.loss(rew_logits, rew_seq.reshape(-1)))
+        # The term head's target is TRUE environment termination only,
+        # never timeout truncation - imagination uses this head as
+        # `continues = 1 - sigmoid(term_logit)`, i.e. "does the MDP end
+        # here", and a truncated episode didn't end because of the state,
+        # it was cut short exogenously by a step limit the agent can't
+        # even observe (time isn't in the observation). An earlier
+        # version trained it on `done` (termination OR truncation):
+        # since most unsuccessful episodes end by timeout, that taught
+        # the model that episodes die spontaneously at an unpredictable
+        # background rate, deflating `continues` - and with it every
+        # imagined value target and rollout weight - everywhere.
         term_loss = jnp.mean(
             optax.sigmoid_binary_cross_entropy(
-                jnp.squeeze(term_logits, -1), term_seq.reshape(-1)
+                jnp.squeeze(term_logits, -1), terminal_seq.reshape(-1)
             )
         )
 
@@ -1008,34 +1165,57 @@ class Dreamer(Agent):
             method=WorldModel.imagine,
         )
         continues = 1.0 - jax.nn.sigmoid(term_logits)
-        # weight[t] down-weights step t by how much discount/continuation
-        # probability has decayed by the time it's reached - later imagined
-        # steps count for less both because they're discounted more, and
-        # because the rollout may well have "really" terminated earlier
-        # than this imagined continuation pretends (continues < 1 there).
-        # Matches the official implementation's `cumprod(disc*con)/disc`.
-        weight = jnp.cumprod(hp.discount * continues, axis=1) / hp.discount
-        return feats, rews, continues, actions, logps, weight
+        # Index conventions, spelled out because an off-by-one here is
+        # exactly the bug this refactor fixed: `imagine`'s scan emits only
+        # *resulting* states - feats[t] is the state REACHED by actions[t],
+        # which was taken FROM feats_in[t] (the seed `start_feats` at t=0,
+        # feats[t-1] after). The lambda-return recursion below therefore
+        # produces targets[t] = return of feats_in[t], so everything the
+        # actor/critic losses evaluate per-step - the policy distribution
+        # actions[t] is scored under, the value baseline subtracted from
+        # targets[t], the critic's regression input - must be feats_in[t],
+        # not feats[t]. An earlier version used feats[t] for all three:
+        # the policy gradient scored each action under the distribution of
+        # the state it *led to*, the advantage subtracted the *next*
+        # state's value, and (worst, see `weight` below) the step weight
+        # included the outcome state's own continuation probability.
+        feats_in = jnp.concatenate([start_feats[:, None, :], feats[:, :-1]], axis=1)
+        # weight[t] = prob the imagined trajectory is still alive when
+        # actions[t] is taken, times the discount accumulated getting
+        # there: prod_{i<t}(discount * continues[i]) - continues of the
+        # states *before* the action, never continues[t] itself, which is
+        # the continuation of the action's own outcome. Including it (as
+        # `cumprod(discount*continues)/discount` over these same arrays
+        # did before) multiplied each action's whole loss term by
+        # 1 - P(terminal | its outcome): in a sparse goal task the action
+        # that reaches the goal makes the term head fire, so the one
+        # policy gradient carrying the reward signal was scaled toward
+        # zero exactly when it mattered - actions at the (real) start
+        # states get full weight 1 instead.
+        weight = jnp.concatenate(
+            [
+                jnp.ones_like(continues[:, :1]),
+                jnp.cumprod(hp.discount * continues, axis=1)[:, :-1],
+            ],
+            axis=1,
+        )
+        return feats_in, feats, rews, continues, actions, weight
 
     def _actor_loss(
         self, actor_params, model_params, critic_params, start_feats, return_norm_scale, rng
     ):
         hp = self.hparams
-        feats, rews, continues, actions, _, weight = self._actor_critic_rollout(
+        feats_in, feats, rews, continues, actions, weight = self._actor_critic_rollout(
             model_params, actor_params, start_feats, rng
         )
-        # feats[t]/rews[t] are already aligned to the same imagined
-        # transition (rews[t] is the reward *for reaching* feats[t]), so
-        # vals[t] = V(feats[t]) is exactly the right bootstrap for
-        # rews[t] - next_values=vals, rewards=rews need no shift. An
-        # earlier version paired rews[:-1] with vals[1:], bootstrapping
-        # every reward with the value *two* imagined steps ahead instead
-        # of one - a systematic bias that made the advantage strongly,
-        # persistently negative from the very first update regardless of
-        # entropy coefficient or gradient-clip norm (verified: varying
-        # either by 3+ orders of magnitude left the advantage trajectory
-        # essentially unchanged, since the bug is in what's being
-        # computed, not in how big a step is taken from it).
+        # vals[t] = V(feats[t]) is the bootstrap for rews[t] (the reward
+        # for *reaching* feats[t]), so the lambda-return recursion yields
+        # targets[t] = return of feats_in[t], the state actions[t] was
+        # taken FROM (see _actor_critic_rollout's index-convention
+        # comment). The baseline subtracted from it must therefore be
+        # V(feats_in[t]), and the policy distribution actions[t] is scored
+        # under must be the one at feats_in[t] - not feats[t], the state
+        # the action *led to*, which an earlier version used for both.
         head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
         vals_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(
             {"params": critic_params}, feats
@@ -1044,7 +1224,11 @@ class Dreamer(Agent):
         targets = jax.lax.stop_gradient(
             self._lambda_returns(vals, rews, continues, hp.discount, hp.lam)
         )
-        adv = jax.lax.stop_gradient((targets - vals) / return_norm_scale)
+        baseline_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(
+            {"params": critic_params}, feats_in
+        )
+        baseline = head.mean(baseline_logits)
+        adv = jax.lax.stop_gradient((targets - baseline) / return_norm_scale)
 
         # REINFORCE: log_prob(sg(action)) * sg(advantage), not backprop
         # through the sampled discrete action - distrax.Categorical.
@@ -1057,7 +1241,7 @@ class Dreamer(Agent):
         # here).
         actor_logits = jax.vmap(
             lambda f: self.actor.apply({"params": actor_params}, f)
-        )(feats)
+        )(feats_in)
         dist = unimix_categorical(actor_logits, hp.actor_unimix)
         logp = dist.log_prob(jax.lax.stop_gradient(actions))
         entropy = dist.entropy()
@@ -1069,6 +1253,14 @@ class Dreamer(Agent):
             "agent/actor/loss": loss,
             "agent/actor/entropy": entropy.mean(),
             "agent/actor/adv": adv.mean(),
+            # Imagination health: if the world model is any good, imagined
+            # reward should be on the same scale as the real collected
+            # reward rate, and targets should track true policy value -
+            # divergence between these and reality is the signature of the
+            # actor optimizing against model error instead of the task.
+            "agent/imag/rew": rews.mean(),
+            "agent/imag/continues": continues.mean(),
+            "agent/imag/target": targets.mean(),
         }
         return loss, logs
 
@@ -1076,9 +1268,18 @@ class Dreamer(Agent):
         self, critic_params, model_params, actor_params, slow_critic_params, start_feats, rng
     ):
         hp = self.hparams
-        feats, rews, continues, actions, _, weight = self._actor_critic_rollout(
+        feats_in, feats, rews, continues, actions, weight = self._actor_critic_rollout(
             model_params, actor_params, start_feats, rng
         )
+        # targets[t] is the return of feats_in[t] (see _actor_critic_
+        # rollout's index-convention comment), so the critic regresses
+        # V(feats_in[t]) toward it - an earlier version regressed
+        # V(feats[t]), training every state's value toward the *previous*
+        # state's return, which (among other biases) taught the value of
+        # a goal state to include the reward already collected by
+        # *reaching* it. As a bonus, feats_in[0] is a real posterior
+        # state (from replayed experience), so the critic also trains
+        # directly on real states, as the official implementation does.
         head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
         vals_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(
             {"params": critic_params}, feats
@@ -1089,7 +1290,7 @@ class Dreamer(Agent):
         )
 
         pred_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(
-            {"params": critic_params}, feats
+            {"params": critic_params}, feats_in
         )
         regress_loss = jnp.mean(
             jax.lax.stop_gradient(weight) * jax.vmap(head.loss)(pred_logits, targets)
@@ -1097,7 +1298,7 @@ class Dreamer(Agent):
 
         slow_logits = jax.lax.stop_gradient(
             jax.vmap(self.critic.apply, in_axes=(None, 0))(
-                {"params": slow_critic_params}, feats
+                {"params": slow_critic_params}, feats_in
             )
         )
         slow_target = jax.lax.stop_gradient(head.mean(slow_logits))
@@ -1110,7 +1311,7 @@ class Dreamer(Agent):
             "agent/critic/loss": loss,
             "agent/critic/regress_loss": regress_loss,
             "agent/critic/slow_reg_loss": slow_reg_loss,
-            "agent/critic/value": vals.mean(),
+            "agent/critic/value": jax.vmap(head.mean)(pred_logits).mean(),
         }
         return loss, logs
 
@@ -1120,16 +1321,20 @@ class Dreamer(Agent):
         hp = self.hparams
 
         ts, experience = self._collect(ts)
+        replay = self._write_replay(ts.replay, experience)
+        ts = ts.replace(replay=replay)
 
         def model_step(carry, _):
             model, rng = carry
             rng, key_batch, key_loss = jax.random.split(rng, 3)
-            obs_seq, act_seq, rew_seq, term_seq = self._sample_batch(
-                key_batch, experience
+            obs_seq, act_seq, rew_seq, first_seq, terminal_seq = self._sample_batch(
+                key_batch, replay
             )
 
             def loss_fn(p):
-                return self._model_loss(p, obs_seq, act_seq, rew_seq, term_seq, key_loss)
+                return self._model_loss(
+                    p, obs_seq, act_seq, rew_seq, first_seq, terminal_seq, key_loss
+                )
 
             (loss, (feats, mlogs)), grads = jax.value_and_grad(loss_fn, has_aux=True)(
                 model.params
@@ -1148,12 +1353,12 @@ class Dreamer(Agent):
         # One fresh batch of features to seed the actor/critic imagination
         # rollouts from, reusing the just-updated model.
         rng, key_batch, key_observe = jax.random.split(rng, 3)
-        obs_seq, act_seq, _, term_seq = self._sample_batch(key_batch, experience)
+        obs_seq, act_seq, _, first_seq, _ = self._sample_batch(key_batch, replay)
         _, _, feats, _, _, _ = self.world.apply(
             {"params": model.params},
             obs_seq,
             act_seq,
-            term_seq,
+            first_seq,
             method=WorldModel.observe,
             rngs={"sample": key_observe},
         )
@@ -1165,7 +1370,7 @@ class Dreamer(Agent):
         # a quick lambda-return estimate under the current critic, so the
         # actor's advantage is on a comparable scale regardless of the
         # environment's raw reward magnitude.
-        probe_feats, probe_rews, probe_continues, _, _, _ = self._actor_critic_rollout(
+        _, probe_feats, probe_rews, probe_continues, _, _ = self._actor_critic_rollout(
             model.params, ts.actor.params, start_feats, rng
         )
         head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
@@ -1209,12 +1414,12 @@ class Dreamer(Agent):
         alogs = jax.tree.map(lambda x: jnp.mean(x), alogs)
 
         def critic_step(carry, _):
-            critic, rng = carry
+            critic, slow_critic_params, rng = carry
             rng, key = jax.random.split(rng)
 
             def loss_fn(p):
                 return self._critic_loss(
-                    p, model.params, actor.params, ts.slow_critic_params, start_feats, key
+                    p, model.params, actor.params, slow_critic_params, start_feats, key
                 )
 
             (loss, clogs), grads = jax.value_and_grad(loss_fn, has_aux=True)(
@@ -1224,19 +1429,33 @@ class Dreamer(Agent):
                 lambda g: jnp.nan_to_num(g, nan=0.0, posinf=0.0, neginf=0.0), grads
             )
             critic = critic.apply_gradients(grads=grads)
-            return (critic, rng), {"loss/critic": loss, **clogs}
+            # The slow critic's EMA advances once per GRADIENT STEP (as in
+            # the official implementation), not once per update() cycle.
+            # With slow_critic_reg = 1.0 the online critic is regularized
+            # toward the slow one as strongly as toward its actual
+            # lambda-return targets, so a slow critic that only moved
+            # rate=0.02 per *cycle* (i.e. per num_critic_updates gradient
+            # steps - 32x more laggard than official) froze the pair near
+            # their (zero) init: values were observed to crawl at ~1/10 of
+            # their true scale over a whole training run, keeping
+            # advantages - and with them the actor's learning signal -
+            # near zero long after the world model had learned where the
+            # reward is.
+            slow_critic_params = jax.tree.map(
+                lambda slow, online: (1 - hp.slow_critic_rate) * slow
+                + hp.slow_critic_rate * online,
+                slow_critic_params,
+                critic.params,
+            )
+            return (critic, slow_critic_params, rng), {"loss/critic": loss, **clogs}
 
-        (critic, rng), clogs = jax.lax.scan(
-            critic_step, (ts.critic, rng), None, length=hp.num_critic_updates
+        (critic, slow_critic_params, rng), clogs = jax.lax.scan(
+            critic_step,
+            (ts.critic, ts.slow_critic_params, rng),
+            None,
+            length=hp.num_critic_updates,
         )
         clogs = jax.tree.map(lambda x: jnp.mean(x), clogs)
-
-        slow_critic_params = jax.tree.map(
-            lambda slow, online: (1 - hp.slow_critic_rate) * slow
-            + hp.slow_critic_rate * online,
-            ts.slow_critic_params,
-            critic.params,
-        )
 
         ts = ts.replace(
             model=model,
@@ -1328,11 +1547,36 @@ class Dreamer(Agent):
             w_variables, hp.num_envs, method=WorldModel.init_state
         )
 
+        # One replay block per update() call (num_steps x num_envs
+        # frames); never allocate more blocks than the training budget
+        # can actually fill.
+        block_frames = hp.num_steps * hp.num_envs
+        num_blocks = int(
+            max(1, min(hp.replay_capacity // block_frames, hp.budget // block_frames))
+        )
+        obs_dtype = env_state.observation.dtype
+        replay = Replay(
+            obs=jnp.zeros(
+                (num_blocks, hp.num_steps, hp.num_envs, obs_dim), dtype=obs_dtype
+            ),
+            action=jnp.zeros((num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.int32),
+            reward=jnp.zeros(
+                (num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.float32
+            ),
+            done=jnp.zeros((num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.bool_),
+            termination=jnp.zeros(
+                (num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.bool_
+            ),
+            idx=jnp.asarray(0, dtype=jnp.int32),
+            size=jnp.asarray(0, dtype=jnp.int32),
+        )
+
         return DreamerTrainState(
             model=model_state,
             actor=actor_state,
             critic=critic_state,
             slow_critic_params=c_variables["params"],
+            replay=replay,
             env_state=env_state,
             rng=rng,
             frames=jnp.asarray(0, dtype=jnp.int32),

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -263,6 +263,26 @@ class DreamerHparams(HParams):
     # Actor: REINFORCE + entropy bonus + return normalization.
     actor_entropy: float = 3e-4
     """Entropy bonus coefficient in the actor's REINFORCE loss."""
+    actor_unimix: float = 0.05
+    """Fraction of uniform probability mixed into the actor's action
+    distribution wherever it's sampled from or scored (data collection,
+    imagination, and the REINFORCE loss) - the same `unimix_categorical`
+    technique already used for the world model's own categorical latents
+    (see `unimix_categorical`'s docstring), applied here too. Without
+    this, the actor's entropy can reach exactly zero: once it does,
+    `_collect` (which samples actions from this same distribution) stops
+    exploring too, so real data collection narrows to whatever the
+    collapsed policy repeats, the world model overfits to that narrow
+    trajectory, and there is no path back - a self-reinforcing collapse
+    verified empirically (entropy hits exactly 0.0 and success rate
+    permanently flatlines at 0%, independent of how many actor gradient
+    steps are taken per update - slowing that down only delays the same
+    terminal collapse, it doesn't prevent it). A structural floor on the
+    minimum action probability makes that specific failure mode
+    impossible rather than merely less likely. Higher than the world
+    model's 0.01 default since the action space here is much smaller
+    (a handful of actions vs. many latent classes), so the same
+    probability mass floor matters proportionally more per action."""
     return_norm_rate: float = 0.01
     """EMA rate for the return-normalization percentile tracker."""
     return_norm_limit: float = 1.0
@@ -420,7 +440,7 @@ class WorldModel(nn.Module):
     def feat(self, h: Array, z_flat: Array) -> Array:
         return jnp.concatenate([h, z_flat], axis=-1)
 
-    def observe(self, obs_seq: Array, act_seq: Array) -> Tuple[
+    def observe(self, obs_seq: Array, act_seq: Array, term_seq: Array) -> Tuple[
         Tuple[Array, Array], Tuple[Array, Array], Array, Array, Array, Array
     ]:
         """Runs the RSSM over an observed sequence, computing the posterior
@@ -430,6 +450,30 @@ class WorldModel(nn.Module):
             obs_seq (Array): `f32[B, L+1, obs_dim]`, flattened observations.
             act_seq (Array): `i32[B, L]`, actions taken between consecutive
                 observations.
+            term_seq (Array): `f32[B, L]`, `1.0` where `act_seq[:, t]` ended
+                an episode (matching `experience.done`/the `_model_loss`
+                term-head target) - `term_seq[:, t] == 1` means
+                `obs_seq[:, t + 1]` is a fresh post-autoreset observation,
+                *not* a real consequence of `act_seq[:, t]`. Sampled
+                training sequences are sliced from a fixed-size buffer with
+                no regard for episode boundaries (`_sample_batch`), so a
+                sequence commonly straddles an autoreset; without this,
+                every such step would condition the reset observation's
+                posterior on the *previous* episode's (h, z) and pair it
+                with an action that didn't actually cause it - a genuine
+                transition the RSSM cannot learn (the reset is exogenous),
+                and, left unhandled, the resulting garbage (h, z) then
+                propagates forward through every subsequent step of the new
+                episode still inside this sequence, not just the one
+                boundary step. Matches the official implementation's
+                `is_first` masking in `RSSM.observe` (`embodied/jax/
+                rssm.py`): at scan step `t` (which pairs `act_seq[:, t]`
+                with `embed(obs_seq[:, t + 1])`), both the incoming (h, z)
+                carried from step `t - 1` and `act_seq[:, t]` itself are
+                zeroed whenever `term_seq[:, t] == 1`, so `obs_seq[:, t +
+                1]`'s posterior is computed from a blank slate instead of a
+                stale, causally-unrelated belief plus an action that
+                didn't really produce it.
 
         Returns:
             `((h_seq, z_seq), (dyn_kls, rep_kls), feats, obs_pred, rew_logits,
@@ -450,10 +494,29 @@ class WorldModel(nn.Module):
         embed_all = jax.vmap(self.encoder)(obs_seq.reshape(B * (L + 1), -1)).reshape(
             B, L + 1, -1
         )
+        # a_oh[:, t] = act_seq[t], the action taken FROM obs_seq[t] TO
+        # obs_seq[t+1] - paired directly with embed_all[:, 1:] (embeddings
+        # of obs_seq[1:]) below with NO shift. An earlier version prepended
+        # a zero action and dropped the last one (`a_prev = concat([zeros,
+        # a_oh[:-1]])`), pairing embed(obs_seq[t+1]) with act_seq[t-1]
+        # instead of act_seq[t] - i.e. every posterior/prior at scan step
+        # t was computed as if the action taken *before* act_seq[t] had
+        # produced obs_seq[t+1], one step stale. This directly contradicts
+        # both `posterior_step` (used for real-env collection: `h_next =
+        # rssm(h, z, a_just_taken)` then posterior on `embed(new_obs)` -
+        # the action and the observation it produced, paired together) and
+        # `imagine`'s `rollout_step` (`h_next = rssm(h, z, a)` using the
+        # action just sampled from the *current* state to reach the next
+        # one) - both of which already use the correct, unshifted pairing.
+        # Training `observe()` with actions mismatched by one timestep
+        # from the observations/rewards/terminations they actually caused
+        # silently degrades everything derived from it (obs/reward/term
+        # losses, and - critically - the prior network `imagine()` samples
+        # from), while `obs_loss`/`rew_loss` can still fit close to zero
+        # by the end of training since consecutive actions/observations in
+        # a grid-world are highly autocorrelated, masking the bug in the
+        # aggregate loss curves alone.
         a_oh = jax.nn.one_hot(act_seq, self.act_dim)
-        a_prev = jnp.concatenate(
-            [jnp.zeros((B, 1, self.act_dim)), a_oh[:, :-1]], axis=1
-        )
 
         # Plain jax.lax.scan, not nn.scan: `step` closes over `self`
         # implicitly (via self.rssm/self.prior/self.post) rather than
@@ -470,9 +533,20 @@ class WorldModel(nn.Module):
         # plain jax.lax.scan doesn't auto-split Flax's rng streams.
         def step(carry, inputs):
             h_prev, z_prev_flat, rng = carry
-            a_prev_t, embed_t = inputs
+            a_t, embed_t, is_first_t = inputs
             rng, key = jax.random.split(rng)
-            h_t = self.rssm(h_prev, z_prev_flat, a_prev_t)
+            # is_first_t == 1 means embed_t is a fresh post-autoreset
+            # observation - zero the incoming (h, z) *and* the incoming
+            # action before this step's RSSM update (matching the official
+            # implementation's `is_first` masking, see the docstring above)
+            # so the reset observation's posterior comes from a blank
+            # slate rather than a stale, unrelated belief paired with an
+            # action that didn't cause it.
+            keep = (1.0 - is_first_t)[:, None]
+            h_prev = h_prev * keep
+            z_prev_flat = z_prev_flat * keep
+            a_t = a_t * keep
+            h_t = self.rssm(h_prev, z_prev_flat, a_t)
             prior_logits = self.prior(h_t)
             post_logits = self.post(h_t, embed_t)
             prior_dist = unimix_categorical(prior_logits, hp.unimix)
@@ -494,7 +568,8 @@ class WorldModel(nn.Module):
         # batch-major (B, L, ...) - swap to (L, B, ...) going in, and swap
         # the stacked outputs back to (B, L, ...) coming out.
         inputs = jax.tree.map(
-            lambda x: jnp.swapaxes(x, 0, 1), (a_prev[:, :L], embed_all[:, 1:])
+            lambda x: jnp.swapaxes(x, 0, 1),
+            (a_oh, embed_all[:, 1:], term_seq.astype(jnp.float32)),
         )
         init_rng = self.make_rng("sample")
         (h_last, z_last, _), (hs, zs, dyn_kls, rep_kls, feats) = jax.lax.scan(
@@ -586,8 +661,9 @@ class WorldModel(nn.Module):
             feat = jnp.concatenate([h, z_flat], axis=-1)
             logits = actor_logits_fn(feat)
             rng, key_a, key_z = jax.random.split(rng, 3)
-            a = distrax.Categorical(logits=logits).sample(seed=key_a)
-            logp = distrax.Categorical(logits=logits).log_prob(a)
+            actor_dist = unimix_categorical(logits, self.hparams.actor_unimix)
+            a = actor_dist.sample(seed=key_a)
+            logp = actor_dist.log_prob(a)
             a_oh = jax.nn.one_hot(a, logits.shape[-1])
             h_next = self.rssm(h, z_flat, a_oh)
             prior_dist = unimix_categorical(self.prior(h_next), self.hparams.unimix)
@@ -773,8 +849,9 @@ class Dreamer(Agent):
             feat = jnp.concatenate([h, z], axis=-1)
             logits = self.actor.apply({"params": ts.actor.params}, feat)
             rng, key_a = jax.random.split(rng)
-            a = distrax.Categorical(logits=logits).sample(seed=key_a)
-            log_prob = distrax.Categorical(logits=logits).log_prob(a)
+            actor_dist = unimix_categorical(logits, hp.actor_unimix)
+            a = actor_dist.sample(seed=key_a)
+            log_prob = actor_dist.log_prob(a)
 
             new_env_state = jax.vmap(self.env.step, in_axes=(0, 0))(env_state, a)
 
@@ -868,6 +945,7 @@ class Dreamer(Agent):
                 {"params": params},
                 obs_seq,
                 act_seq,
+                term_seq,
                 method=WorldModel.observe,
                 rngs={"sample": rng},
             )
@@ -930,29 +1008,43 @@ class Dreamer(Agent):
             method=WorldModel.imagine,
         )
         continues = 1.0 - jax.nn.sigmoid(term_logits)
-        return feats, rews, continues, actions, logps
+        # weight[t] down-weights step t by how much discount/continuation
+        # probability has decayed by the time it's reached - later imagined
+        # steps count for less both because they're discounted more, and
+        # because the rollout may well have "really" terminated earlier
+        # than this imagined continuation pretends (continues < 1 there).
+        # Matches the official implementation's `cumprod(disc*con)/disc`.
+        weight = jnp.cumprod(hp.discount * continues, axis=1) / hp.discount
+        return feats, rews, continues, actions, logps, weight
 
     def _actor_loss(
         self, actor_params, model_params, critic_params, start_feats, return_norm_scale, rng
     ):
         hp = self.hparams
-        feats, rews, continues, actions, _ = self._actor_critic_rollout(
+        feats, rews, continues, actions, _, weight = self._actor_critic_rollout(
             model_params, actor_params, start_feats, rng
         )
-        # vals covers the full imagined horizon including the start state
-        # (feats[:, 0] is the real posterior feature the rollout began
-        # from), so lambda-returns/advantages align 1:1 with each
-        # imagined transition, unlike bootstrapping from feats[:, 1:]
-        # only (which would drop the last transition's target entirely).
+        # feats[t]/rews[t] are already aligned to the same imagined
+        # transition (rews[t] is the reward *for reaching* feats[t]), so
+        # vals[t] = V(feats[t]) is exactly the right bootstrap for
+        # rews[t] - next_values=vals, rewards=rews need no shift. An
+        # earlier version paired rews[:-1] with vals[1:], bootstrapping
+        # every reward with the value *two* imagined steps ahead instead
+        # of one - a systematic bias that made the advantage strongly,
+        # persistently negative from the very first update regardless of
+        # entropy coefficient or gradient-clip norm (verified: varying
+        # either by 3+ orders of magnitude left the advantage trajectory
+        # essentially unchanged, since the bug is in what's being
+        # computed, not in how big a step is taken from it).
         head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
         vals_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(
             {"params": critic_params}, feats
         )
         vals = head.mean(vals_logits)
         targets = jax.lax.stop_gradient(
-            self._lambda_returns(vals[:, 1:], rews[:, :-1], continues[:, :-1], hp.discount, hp.lam)
+            self._lambda_returns(vals, rews, continues, hp.discount, hp.lam)
         )
-        adv = jax.lax.stop_gradient((targets - vals[:, :-1]) / return_norm_scale)
+        adv = jax.lax.stop_gradient((targets - vals) / return_norm_scale)
 
         # REINFORCE: log_prob(sg(action)) * sg(advantage), not backprop
         # through the sampled discrete action - distrax.Categorical.
@@ -965,11 +1057,13 @@ class Dreamer(Agent):
         # here).
         actor_logits = jax.vmap(
             lambda f: self.actor.apply({"params": actor_params}, f)
-        )(feats[:, :-1])
-        dist = distrax.Categorical(logits=actor_logits)
-        logp = dist.log_prob(jax.lax.stop_gradient(actions[:, :-1]))
+        )(feats)
+        dist = unimix_categorical(actor_logits, hp.actor_unimix)
+        logp = dist.log_prob(jax.lax.stop_gradient(actions))
         entropy = dist.entropy()
-        policy_loss = -(logp * adv + hp.actor_entropy * entropy)
+        policy_loss = jax.lax.stop_gradient(weight) * -(
+            logp * adv + hp.actor_entropy * entropy
+        )
         loss = policy_loss.mean()
         logs = {
             "agent/actor/loss": loss,
@@ -982,7 +1076,7 @@ class Dreamer(Agent):
         self, critic_params, model_params, actor_params, slow_critic_params, start_feats, rng
     ):
         hp = self.hparams
-        feats, rews, continues, actions, _ = self._actor_critic_rollout(
+        feats, rews, continues, actions, _, weight = self._actor_critic_rollout(
             model_params, actor_params, start_feats, rng
         )
         head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
@@ -991,21 +1085,25 @@ class Dreamer(Agent):
         )
         vals = jax.vmap(head.mean)(vals_logits)
         targets = jax.lax.stop_gradient(
-            self._lambda_returns(vals[:, 1:], rews[:, :-1], continues[:, :-1], hp.discount, hp.lam)
+            self._lambda_returns(vals, rews, continues, hp.discount, hp.lam)
         )
 
         pred_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(
-            {"params": critic_params}, feats[:, :-1]
+            {"params": critic_params}, feats
         )
-        regress_loss = jnp.mean(jax.vmap(head.loss)(pred_logits, targets))
+        regress_loss = jnp.mean(
+            jax.lax.stop_gradient(weight) * jax.vmap(head.loss)(pred_logits, targets)
+        )
 
         slow_logits = jax.lax.stop_gradient(
             jax.vmap(self.critic.apply, in_axes=(None, 0))(
-                {"params": slow_critic_params}, feats[:, :-1]
+                {"params": slow_critic_params}, feats
             )
         )
         slow_target = jax.lax.stop_gradient(head.mean(slow_logits))
-        slow_reg_loss = jnp.mean(jax.vmap(head.loss)(pred_logits, slow_target))
+        slow_reg_loss = jnp.mean(
+            jax.lax.stop_gradient(weight) * jax.vmap(head.loss)(pred_logits, slow_target)
+        )
 
         loss = regress_loss + hp.slow_critic_reg * slow_reg_loss
         logs = {
@@ -1050,11 +1148,12 @@ class Dreamer(Agent):
         # One fresh batch of features to seed the actor/critic imagination
         # rollouts from, reusing the just-updated model.
         rng, key_batch, key_observe = jax.random.split(rng, 3)
-        obs_seq, act_seq, _, _ = self._sample_batch(key_batch, experience)
+        obs_seq, act_seq, _, term_seq = self._sample_batch(key_batch, experience)
         _, _, feats, _, _, _ = self.world.apply(
             {"params": model.params},
             obs_seq,
             act_seq,
+            term_seq,
             method=WorldModel.observe,
             rngs={"sample": key_observe},
         )
@@ -1066,7 +1165,7 @@ class Dreamer(Agent):
         # a quick lambda-return estimate under the current critic, so the
         # actor's advantage is on a comparable scale regardless of the
         # environment's raw reward magnitude.
-        probe_feats, probe_rews, probe_continues, _, _ = self._actor_critic_rollout(
+        probe_feats, probe_rews, probe_continues, _, _, _ = self._actor_critic_rollout(
             model.params, ts.actor.params, start_feats, rng
         )
         head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
@@ -1075,7 +1174,7 @@ class Dreamer(Agent):
         )
         probe_vals = jax.vmap(head.mean)(probe_vals_logits)
         probe_returns = self._lambda_returns(
-            probe_vals[:, 1:], probe_rews[:, :-1], probe_continues[:, :-1], hp.discount, hp.lam
+            probe_vals, probe_rews, probe_continues, hp.discount, hp.lam
         )
         lo = jnp.percentile(probe_returns, 5)
         hi = jnp.percentile(probe_returns, 95)

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -705,6 +705,116 @@ class DreamerTrainState(struct.PyTreeNode):
     z: Array  # (N, latents_flat)
     a_prev_oh: Array  # (N, act_dim)
 
+    @classmethod
+    def create(
+        cls,
+        rng: Array,
+        hparams: DreamerHparams,
+        env: Environment,
+        world: WorldModel,
+        actor: Actor,
+        critic: Critic,
+    ) -> "DreamerTrainState":
+        """Builds an initial `DreamerTrainState`: inits the world model/
+        actor/critic's params and optimizers, resets `hparams.num_envs`
+        environments, and allocates an empty replay buffer sized to
+        whichever is smaller of `hparams.replay_capacity` and what
+        `hparams.budget` can actually fill. Mirrors the `flax.training.
+        train_state.TrainState.create` convention PPO's own `TrainingState`
+        relies on (construction logic lives on the state itself, not on
+        the agent that produces it)."""
+        hp = hparams
+        obs_dim = world.obs_dim
+        assert obs_dim == int(np.prod(env.observation_space.shape)), (
+            "world's obs_dim must match the (flattened) observation space "
+            f"of env - got obs_dim={obs_dim}, but env.observation_space."
+            f"shape={env.observation_space.shape} flattens to "
+            f"{int(np.prod(env.observation_space.shape))}. Construct "
+            "WorldModel(obs_dim=int(np.prod(env.observation_space.shape)), "
+            "act_dim=len(env.action_set), hparams=...) explicitly, the "
+            "same way PPO expects ActorCritic(action_dim=len(env."
+            "action_set)) pre-constructed rather than building it internally."
+        )
+
+        rng, wk1, wk2, ak, ck = jax.random.split(rng, 5)
+        w_variables = world.init(
+            {"params": wk1, "sample": wk2},
+            jnp.zeros((1, obs_dim)),
+            jnp.zeros((1, world.act_dim)),
+            method=WorldModel.init_probe,
+        )
+        a_variables = actor.init(
+            ak, jnp.zeros((1, hp.recurrent_size + hp.latents_flat))
+        )
+        c_variables = critic.init(
+            ck, jnp.zeros((1, hp.recurrent_size + hp.latents_flat))
+        )
+
+        model_tx = optax.chain(
+            optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.model_lr)
+        )
+        actor_tx = optax.chain(
+            optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.actor_lr)
+        )
+        critic_tx = optax.chain(
+            optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.critic_lr)
+        )
+        model_state = TrainState.create(
+            apply_fn=world.apply, params=w_variables["params"], tx=model_tx
+        )
+        actor_state = TrainState.create(
+            apply_fn=actor.apply, params=a_variables["params"], tx=actor_tx
+        )
+        critic_state = TrainState.create(
+            apply_fn=critic.apply, params=c_variables["params"], tx=critic_tx
+        )
+
+        rng, rs = jax.random.split(rng)
+        reset_rng = jax.random.split(rs, hp.num_envs)
+        env_state = jax.vmap(env.reset)(reset_rng)
+        h0, z0, a0 = world.apply(w_variables, hp.num_envs, method=WorldModel.init_state)
+
+        # One replay block per update() call (num_steps x num_envs
+        # frames); never allocate more blocks than the training budget
+        # can actually fill.
+        block_frames = hp.num_steps * hp.num_envs
+        num_blocks = int(
+            max(1, min(hp.replay_capacity // block_frames, hp.budget // block_frames))
+        )
+        obs_dtype = env_state.observation.dtype
+        replay = Replay(
+            obs=jnp.zeros(
+                (num_blocks, hp.num_steps, hp.num_envs, obs_dim), dtype=obs_dtype
+            ),
+            action=jnp.zeros((num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.int32),
+            reward=jnp.zeros(
+                (num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.float32
+            ),
+            done=jnp.zeros((num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.bool_),
+            termination=jnp.zeros(
+                (num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.bool_
+            ),
+            idx=jnp.asarray(0, dtype=jnp.int32),
+            size=jnp.asarray(0, dtype=jnp.int32),
+        )
+
+        return cls(
+            model=model_state,
+            actor=actor_state,
+            critic=critic_state,
+            slow_critic_params=c_variables["params"],
+            replay=replay,
+            env_state=env_state,
+            rng=rng,
+            frames=jnp.asarray(0, dtype=jnp.int32),
+            updates=jnp.asarray(0, dtype=jnp.int32),
+            return_norm_lo=jnp.asarray(0.0, dtype=jnp.float32),
+            return_norm_hi=jnp.asarray(0.0, dtype=jnp.float32),
+            h=h0,
+            z=z0,
+            a_prev_oh=a0,
+        )
+
 
 # -------------------------
 # Agent
@@ -1301,108 +1411,21 @@ class Dreamer(Agent):
 
     # ---------- Train entry point ----------
 
-    def _init_train_state(self, rng: Array) -> DreamerTrainState:
-        hp = self.hparams
-        obs_dim = self.world.obs_dim
-        assert obs_dim == int(np.prod(self.env.observation_space.shape)), (
-            "self.world's obs_dim must match the (flattened) observation "
-            f"space of self.env - got obs_dim={obs_dim}, but "
-            f"env.observation_space.shape={self.env.observation_space.shape} "
-            f"flattens to {int(np.prod(self.env.observation_space.shape))}. "
-            "Construct WorldModel(obs_dim=int(np.prod(env.observation_space."
-            "shape)), act_dim=len(env.action_set), hparams=...) explicitly, "
-            "the same way PPO expects ActorCritic(action_dim=len(env."
-            "action_set)) pre-constructed rather than building it internally."
-        )
-
-        rng, wk1, wk2, ak, ck = jax.random.split(rng, 5)
-        w_variables = self.world.init(
-            {"params": wk1, "sample": wk2},
-            jnp.zeros((1, obs_dim)),
-            jnp.zeros((1, self.world.act_dim)),
-            method=WorldModel.init_probe,
-        )
-        a_variables = self.actor.init(ak, jnp.zeros((1, hp.recurrent_size + hp.latents_flat)))
-        c_variables = self.critic.init(ck, jnp.zeros((1, hp.recurrent_size + hp.latents_flat)))
-
-        model_tx = optax.chain(
-            optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.model_lr)
-        )
-        actor_tx = optax.chain(
-            optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.actor_lr)
-        )
-        critic_tx = optax.chain(
-            optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.critic_lr)
-        )
-        model_state = TrainState.create(
-            apply_fn=self.world.apply, params=w_variables["params"], tx=model_tx
-        )
-        actor_state = TrainState.create(
-            apply_fn=self.actor.apply, params=a_variables["params"], tx=actor_tx
-        )
-        critic_state = TrainState.create(
-            apply_fn=self.critic.apply, params=c_variables["params"], tx=critic_tx
-        )
-
-        rng, rs = jax.random.split(rng)
-        reset_rng = jax.random.split(rs, hp.num_envs)
-        env_state = jax.vmap(self.env.reset)(reset_rng)
-        h0, z0, a0 = self.world.apply(
-            w_variables, hp.num_envs, method=WorldModel.init_state
-        )
-
-        # One replay block per update() call (num_steps x num_envs
-        # frames); never allocate more blocks than the training budget
-        # can actually fill.
-        block_frames = hp.num_steps * hp.num_envs
-        num_blocks = int(
-            max(1, min(hp.replay_capacity // block_frames, hp.budget // block_frames))
-        )
-        obs_dtype = env_state.observation.dtype
-        replay = Replay(
-            obs=jnp.zeros(
-                (num_blocks, hp.num_steps, hp.num_envs, obs_dim), dtype=obs_dtype
-            ),
-            action=jnp.zeros((num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.int32),
-            reward=jnp.zeros(
-                (num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.float32
-            ),
-            done=jnp.zeros((num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.bool_),
-            termination=jnp.zeros(
-                (num_blocks, hp.num_steps, hp.num_envs), dtype=jnp.bool_
-            ),
-            idx=jnp.asarray(0, dtype=jnp.int32),
-            size=jnp.asarray(0, dtype=jnp.int32),
-        )
-
-        return DreamerTrainState(
-            model=model_state,
-            actor=actor_state,
-            critic=critic_state,
-            slow_critic_params=c_variables["params"],
-            replay=replay,
-            env_state=env_state,
-            rng=rng,
-            frames=jnp.asarray(0, dtype=jnp.int32),
-            updates=jnp.asarray(0, dtype=jnp.int32),
-            return_norm_lo=jnp.asarray(0.0, dtype=jnp.float32),
-            return_norm_hi=jnp.asarray(0.0, dtype=jnp.float32),
-            h=h0,
-            z=z0,
-            a_prev_oh=a0,
-        )
-
     def train_first_update(self, rng: Array) -> Tuple[DreamerTrainState, Dict]:
         """Runs initialisation plus exactly one `update()` call. Mainly
         useful for tests/debugging, where running a full `train()` (sized
         by `hparams.budget`) is either unnecessary or awkward to size
         exactly."""
-        ts = self._init_train_state(rng)
+        ts = DreamerTrainState.create(
+            rng, self.hparams, self.env, self.world, self.actor, self.critic
+        )
         return self.update(ts, None)
 
     def train(self, rng: Array) -> Tuple[DreamerTrainState, Dict]:
         hp = self.hparams
-        ts = self._init_train_state(rng)
+        ts = DreamerTrainState.create(
+            rng, self.hparams, self.env, self.world, self.actor, self.critic
+        )
         num_updates = hp.budget // (hp.num_steps * hp.num_envs)
 
         start_time = time.time()

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -1,0 +1,1001 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# A lightweight, MLP-based Dreamer-style world-model agent (RSSM + actor +
+# critic trained on imagined rollouts). This is a simplified reproduction
+# inspired by Dreamer/DreamerV2/DreamerV3 (Hafner et al.), not a faithful
+# port of any single one of those papers - the world model uses a unit
+# -variance Gaussian decoder and a single free-bits KL scalar rather than
+# per-dimension free bits, categorical latents, symlog transforms, or
+# their two-hot reward/value heads. Originally written for a NeurIPS
+# rebuttal on the `neurips` research branch; ported here as a first-class
+# `navix.agents` module per issue #142, with three correctness fixes made
+# during the port (see below).
+
+from __future__ import annotations
+import time
+from typing import Callable, Dict, Tuple
+
+import numpy as np
+import distrax
+import jax
+import jax.numpy as jnp
+from jax import Array
+import optax
+import flax.linen as nn
+from flax.linen.initializers import constant, orthogonal
+from flax.training.train_state import TrainState
+from flax import struct
+
+from .agent import Agent, HParams
+from ..environments import Environment
+from ..environments.environment import Timestep
+from ..states import State
+
+# -------------------------
+# Hyperparameters
+# -------------------------
+
+
+class DreamerHparams(HParams):
+    # Training schedule
+    budget: int = struct.field(pytree_node=False, default=1_000_000)
+    """Number of environment frames to train for."""
+    num_envs: int = struct.field(pytree_node=False, default=16)
+    """Number of parallel environments to run."""
+    num_steps: int = struct.field(pytree_node=False, default=128)
+    """Number of environment steps to collect per update."""
+    num_model_updates: int = struct.field(pytree_node=False, default=32)
+    """Number of world-model gradient steps per update."""
+    num_actor_updates: int = struct.field(pytree_node=False, default=32)
+    """Number of actor gradient steps per update."""
+    num_critic_updates: int = struct.field(pytree_node=False, default=32)
+    """Number of critic gradient steps per update."""
+    batch_size: int = struct.field(pytree_node=False, default=64)
+    """Number of sequences sampled per world-model gradient step."""
+    seq_len: int = struct.field(pytree_node=False, default=32)
+    """Length of the sequences sampled for world-model training."""
+    imag_horizon: int = struct.field(pytree_node=False, default=15)
+    """Length of the imagined rollouts used to train the actor and critic."""
+    discount: float = 0.99
+    """Discount factor used in the imagined-rollout lambda-returns."""
+    lam: float = 0.95
+    """Lambda parameter of the imagined-rollout lambda-returns."""
+
+    # Loss scales
+    kl_scale: float = 1.0
+    """Weight of the KL term in the world-model loss."""
+    free_kl: float = 1.0
+    """Free-bits floor on the (batch-mean) KL term - the model isn't
+    penalised for KL below this value."""
+
+    # Opt/grad
+    model_lr: float = 3e-4
+    """Learning rate for the world model's optimizer."""
+    actor_lr: float = 3e-4
+    """Learning rate for the actor's optimizer."""
+    critic_lr: float = 3e-4
+    """Learning rate for the critic's optimizer."""
+    max_grad_norm: float = 100.0
+    """Maximum gradient norm for clipping, applied to each of the three
+    optimizers independently."""
+
+    # Model sizes
+    embed_size: int = 128
+    """Size of the encoder's output embedding."""
+    deter_size: int = 200
+    """Size of the RSSM's deterministic (GRU) hidden state."""
+    stoch_size: int = 30
+    """Size of the RSSM's stochastic latent."""
+    hidden_size: int = 200
+    """Hidden layer size used throughout the model/actor/critic MLPs."""
+
+
+# -------------------------
+# World Model (lightweight Dreamer-style RSSM)
+# -------------------------
+
+
+def _diag_gaussian(loc: Array, scale: Array) -> distrax.MultivariateNormalDiag:
+    return distrax.MultivariateNormalDiag(loc=loc, scale_diag=scale)
+
+
+def _softplus_std(x: Array, min_std: float = 0.1) -> Array:
+    return nn.softplus(x) + min_std
+
+
+class Encoder(nn.Module):
+    hidden_size: int
+    embed_size: int
+
+    @nn.compact
+    def __call__(self, obs: Array) -> Array:
+        net = nn.Sequential(
+            [
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.embed_size),
+            ]
+        )
+        return net(obs)
+
+
+class Decoder(nn.Module):
+    hidden_size: int
+    obs_dim: int
+
+    @nn.compact
+    def __call__(self, feat: Array) -> distrax.MultivariateNormalDiag:
+        net = nn.Sequential(
+            [
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.obs_dim),
+            ]
+        )
+        mean = net(feat)
+        scale = jnp.ones_like(mean)  # unit-variance decoder (simple & stable)
+        return _diag_gaussian(mean, scale)
+
+
+class RewardHead(nn.Module):
+    hidden_size: int
+
+    @nn.compact
+    def __call__(self, feat: Array) -> distrax.Normal:
+        net = nn.Sequential(
+            [
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(1),
+            ]
+        )
+        mean = jnp.squeeze(net(feat), -1)
+        scale = jnp.ones_like(mean)
+        return distrax.Normal(loc=mean, scale=scale)
+
+
+class TermHead(nn.Module):
+    hidden_size: int
+
+    @nn.compact
+    def __call__(self, feat: Array) -> distrax.Bernoulli:
+        net = nn.Sequential(
+            [
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(1),
+            ]
+        )
+        logits = jnp.squeeze(net(feat), -1)
+        return distrax.Bernoulli(logits=logits)
+
+
+class PriorNet(nn.Module):
+    hidden_size: int
+    stoch_size: int
+
+    @nn.compact
+    def __call__(self, h: Array) -> distrax.MultivariateNormalDiag:
+        x = nn.elu(nn.Dense(self.hidden_size)(h))
+        loc = nn.Dense(self.stoch_size)(x)
+        pre = nn.Dense(self.stoch_size)(x)
+        scale = _softplus_std(pre)
+        return _diag_gaussian(loc, scale)
+
+
+class PostNet(nn.Module):
+    hidden_size: int
+    stoch_size: int
+
+    @nn.compact
+    def __call__(self, h: Array, embed: Array) -> distrax.MultivariateNormalDiag:
+        x = jnp.concatenate([h, embed], axis=-1)
+        x = nn.elu(nn.Dense(self.hidden_size)(x))
+        loc = nn.Dense(self.stoch_size)(x)
+        pre = nn.Dense(self.stoch_size)(x)
+        scale = _softplus_std(pre)
+        return _diag_gaussian(loc, scale)
+
+
+class RSSM(nn.Module):
+    deter_size: int
+
+    @nn.compact
+    def __call__(self, h_prev: Array, z_prev: Array, a_prev_oh: Array) -> Array:
+        x = jnp.concatenate([z_prev, a_prev_oh], axis=-1)
+        gru = nn.GRUCell(features=self.deter_size)
+        h, _ = gru(h_prev, x)  # GRUCell returns (new_carry, y); y == new_carry
+        return h
+
+
+class WorldModel(nn.Module):
+    obs_dim: int
+    act_dim: int
+    hparams: DreamerHparams
+
+    def setup(self):
+        hp = self.hparams
+        self.encoder = Encoder(hp.hidden_size, hp.embed_size)
+        self.rssm = RSSM(hp.deter_size)
+        self.prior = PriorNet(hp.hidden_size, hp.stoch_size)
+        self.post = PostNet(hp.hidden_size, hp.stoch_size)
+        self.decoder = Decoder(hp.hidden_size, self.obs_dim)
+        self.reward = RewardHead(hp.hidden_size)
+        self.term = TermHead(hp.hidden_size)
+
+    def init_state(self, batch_size: int) -> Tuple[Array, Array, Array]:
+        h = jnp.zeros((batch_size, self.hparams.deter_size))
+        z = jnp.zeros((batch_size, self.hparams.stoch_size))
+        a0 = jnp.zeros((batch_size, self.act_dim))
+        return h, z, a0
+
+    def feat(self, h: Array, z: Array) -> Array:
+        return jnp.concatenate([h, z], axis=-1)
+
+    def observe(self, obs_seq: Array, act_seq: Array) -> Tuple[
+        Tuple[Array, Array],
+        Array,
+        Tuple[distrax.Distribution, distrax.Distribution, distrax.Distribution],
+        Array,
+    ]:
+        """Runs the RSSM over an observed sequence, computing the posterior
+        latent at every step and decoding obs/reward/termination from it.
+
+        Args:
+            obs_seq (Array): `f32[B, L+1, obs_dim]`, flattened observations.
+            act_seq (Array): `i32[B, L]`, actions taken between consecutive
+                observations.
+
+        Returns:
+            `((h_seq, z_seq), kls, (obs_dist, rew_dist, term_dist), feats)`,
+            all aligned with `obs_seq[:, 1:]` (i.e. `L` steps, `t=0..L-1`).
+            `kls` is `f32[B, L]`, the per-step `KL(post || prior)` - computed
+            inside the scan body rather than returned as `(priors, posts)`
+            distribution objects, because jax.lax.scan only restacks a
+            distrax.Distribution's array *leaves* across the new leading
+            (L) axis; its batch_shape/event_shape (computed once from the
+            un-stacked per-step arrays) go stale, so calling
+            post.kl_divergence(prior) *after* the scan raises a shape
+            mismatch deep inside distrax/tfp. Computing it per-step, while
+            the distributions' shapes are still consistent with their own
+            metadata, sidesteps that entirely."""
+        B, Lp1, _ = obs_seq.shape
+        L = Lp1 - 1
+
+        embed_all = jax.vmap(self.encoder)(obs_seq.reshape(B * (L + 1), -1)).reshape(
+            B, L + 1, -1
+        )
+        a_oh = jax.nn.one_hot(act_seq, self.act_dim)
+        a_prev = jnp.concatenate(
+            [jnp.zeros((B, 1, self.act_dim)), a_oh[:, :-1]], axis=1
+        )
+
+        # Plain jax.lax.scan, not nn.scan: `step` closes over `self`
+        # implicitly (via self.rssm/self.prior/self.post) rather than
+        # taking it as an explicit first argument, which is what Flax's
+        # lifted nn.scan requires when called as `nn.scan(step, ...)(carry,
+        # xs)` - passing a plain closure that way makes Flax's transform
+        # machinery treat `carry` itself as the (missing) `self` argument,
+        # failing deep inside with a confusing `'tuple' object has no
+        # attribute '_state'`. `imagine()` below already uses plain
+        # jax.lax.scan correctly for the same reason; this mirrors it.
+        # Since setup() already built every submodule once, calling them
+        # repeatedly inside a plain scan just reuses their closed-over
+        # params - no Flax-level parameter broadcasting is needed here.
+        # The per-step posterior sample rng is threaded through the scan
+        # carry explicitly instead of nn.scan's split_rngs, since plain
+        # jax.lax.scan doesn't auto-split Flax's rng streams.
+        def step(carry, inputs):
+            h_prev, z_prev, rng = carry
+            a_prev_t, embed_t = inputs
+            rng, key = jax.random.split(rng)
+            h_t = self.rssm(h_prev, z_prev, a_prev_t)
+            prior_t = self.prior(h_t)
+            post_t = self.post(h_t, embed_t)
+            kl_t = post_t.kl_divergence(prior_t)  # (B,) - see observe()'s docstring
+            z_t = post_t.sample(seed=key)
+            feat_t = self.feat(h_t, z_t)
+            return (h_t, z_t, rng), (h_t, z_t, kl_t, feat_t)
+
+        # jax.lax.scan always scans over axis 0, but our sequences are
+        # batch-major (B, L, ...) - swap to (L, B, ...) going in, and swap
+        # the stacked outputs back to (B, L, ...) coming out, since
+        # downstream code (feats.reshape(B * L, -1) below,
+        # start_feats = feats[:, :-1]... in update()) expects batch-major.
+        inputs = jax.tree.map(
+            lambda x: jnp.swapaxes(x, 0, 1), (a_prev[:, :L], embed_all[:, 1:])
+        )
+        hp = self.hparams
+        init_rng = self.make_rng("sample")
+        (h_last, z_last, _), (hs, zs, kls, feats) = jax.lax.scan(
+            step,
+            (jnp.zeros((B, hp.deter_size)), jnp.zeros((B, hp.stoch_size)), init_rng),
+            inputs,
+            length=L,
+        )
+        hs, zs, kls, feats = jax.tree.map(
+            lambda x: jnp.swapaxes(x, 0, 1), (hs, zs, kls, feats)
+        )
+
+        feats_flat = feats.reshape(B * L, -1)
+        obs_dist = self.decoder(feats_flat)
+        rew_dist = self.reward(feats_flat)
+        term_dist = self.term(feats_flat)
+
+        return (hs, zs), kls, (obs_dist, rew_dist, term_dist), feats
+
+    def posterior_step(
+        self, h: Array, z: Array, a_prev_oh: Array, obs: Array, rng: Array
+    ) -> Tuple[Array, Array]:
+        """One environment-collection step: advances the RSSM's belief with
+        the previous action, then updates it to the posterior given the new
+        observation. Encoder/RSSM/posterior are submodules bound to this
+        WorldModel instance, so - unlike a bare Dense/Sequential module -
+        they can only be called from inside a WorldModel.apply() trace,
+        which is what this method (called via `self.world.apply(...,
+        method=WorldModel.posterior_step)`) provides for `_collect`."""
+        h_next = self.rssm(h, z, a_prev_oh)
+        embed = self.encoder(obs)
+        post = self.post(h_next, embed)
+        z_next = post.sample(seed=rng)
+        return h_next, z_next
+
+    def init_probe(self, obs: Array, a_prev_oh: Array) -> None:
+        """Touches every submodule exactly once, purely so `WorldModel.
+        init()` can discover every parameter's shape. Parameters are keyed
+        by submodule path, not by how many times a submodule is called in
+        the "real" forward pass, so a single non-scanned pass creates the
+        identical parameter tree `observe()` would - deliberately used
+        instead of `observe()` for `.init()`, because `.init()` does its
+        own internal tracing to discover shapes, which doesn't compose
+        safely with tracing through observe()'s internal jax.lax.scan
+        while already inside an outer jax.jit (surfaces as a confusing
+        `UnexpectedTracerError` pointing at an unrelated submodule)."""
+        h = jnp.zeros((obs.shape[0], self.hparams.deter_size))
+        z = jnp.zeros((obs.shape[0], self.hparams.stoch_size))
+        h_t = self.rssm(h, z, a_prev_oh)
+        self.prior(h_t)
+        embed = self.encoder(obs)
+        post_t = self.post(h_t, embed)
+        feat_t = self.feat(h_t, post_t.mean())
+        self.decoder(feat_t)
+        self.reward(feat_t)
+        self.term(feat_t)
+
+    def imagine(
+        self,
+        start_h: Array,
+        start_z: Array,
+        actor_logits_fn: Callable[[Array], Array],
+        horizon: int,
+        rng: Array,
+    ) -> Tuple[Array, Array, Array]:
+        """Rolls the RSSM forward purely through its own prior (no real
+        observations), sampling actions from `actor_logits_fn` at each
+        step - the "imagined" trajectories the actor and critic train on.
+
+        Returns `(feats, rewards, terms)`, all `(B, H, ...)` (batch-major).
+        `rewards`/`terms` are plain arrays (each step's reward/term
+        distribution mean), not distrax.Distribution objects - as in
+        observe(), a distrax.Distribution's batch_shape/event_shape are
+        computed once from its un-stacked per-step arrays, and go stale
+        under jax.lax.scan's leaf-only restacking, so any post-scan method
+        call on it (including .mean()) is unsafe. Reducing to a mean
+        before accumulating sidesteps that."""
+
+        def rollout_step(carry, _):
+            h, z, rng = carry
+            feat = jnp.concatenate([h, z], axis=-1)
+            logits = actor_logits_fn(feat)
+            rng, key = jax.random.split(rng)
+            a = distrax.Categorical(logits=logits).sample(seed=key)
+            a_oh = jax.nn.one_hot(a, logits.shape[-1])
+            h_next = self.rssm(h, z, a_oh)
+            prior = self.prior(h_next)
+            rng, key = jax.random.split(rng)
+            z_next = prior.sample(seed=key)
+            feat_next = jnp.concatenate([h_next, z_next], axis=-1)
+            rew_mean = self.reward(feat_next).mean()
+            term_mean = self.term(feat_next).mean()
+            return (h_next, z_next, rng), (feat_next, rew_mean, term_mean)
+
+        (hT, zT, _), (feats, rews, terms) = jax.lax.scan(
+            rollout_step, (start_h, start_z, rng), None, length=horizon
+        )
+        # (H, B, ...) -> (B, H, ...)
+        feats, rews, terms = jax.tree.map(lambda x: jnp.swapaxes(x, 0, 1), (feats, rews, terms))
+        return feats, rews, terms
+
+
+# -------------------------
+# Actor & Critic
+# -------------------------
+
+
+class Actor(nn.Module):
+    act_dim: int
+    hidden: int = 200
+
+    @nn.compact
+    def __call__(self, feat: Array) -> Array:
+        net = nn.Sequential(
+            [
+                nn.Dense(self.hidden),
+                nn.elu,
+                nn.Dense(self.hidden),
+                nn.elu,
+                nn.Dense(
+                    self.act_dim, kernel_init=orthogonal(0.01), bias_init=constant(0.0)
+                ),
+            ]
+        )
+        return net(feat)
+
+    def dist(self, feat: Array) -> distrax.Categorical:
+        return distrax.Categorical(logits=self(feat))
+
+
+class Critic(nn.Module):
+    hidden: int = 200
+
+    @nn.compact
+    def __call__(self, feat: Array) -> Array:
+        net = nn.Sequential(
+            [
+                nn.Dense(self.hidden),
+                nn.elu,
+                nn.Dense(self.hidden),
+                nn.elu,
+                nn.Dense(1, kernel_init=orthogonal(1.0), bias_init=constant(0.0)),
+            ]
+        )
+        return jnp.squeeze(net(feat), -1)
+
+
+# -------------------------
+# Buffer (shape-compatible with Agent.log_to_wandb)
+# -------------------------
+
+
+class Buffer(struct.PyTreeNode):
+    done: Array
+    action: Array
+    reward: Array
+    log_prob: Array
+    obs: Array
+    info: Dict[str, Array]
+    t: Array
+    state: State
+
+
+# -------------------------
+# Training state
+# -------------------------
+
+
+class DreamerTrainState(struct.PyTreeNode):
+    """Unlike `flax.training.train_state.TrainState` (used by `PPO`), this
+    wraps three *independent* `TrainState`s, one per network - the world
+    model, actor, and critic each have their own optimizer, learning rate
+    and step counter, and are updated via their own `apply_gradients()`.
+
+    An earlier draft of this agent instead subclassed `TrainState` directly
+    and hand-rolled `tx.update()` + `optax.apply_updates()` for all three
+    networks while sharing a single `tx`/`step` field meant to be swapped
+    between updates - the swap never actually took effect before each
+    network's update ran, so actor and critic gradients were silently
+    applied through the model's optimizer (and learning rate) instead of
+    their own, and since `apply_gradients()` was never called, the step
+    counter never incremented at all. Three separate `TrainState`s make
+    both bugs structurally impossible instead of relying on remembering to
+    swap a shared field correctly."""
+
+    model: TrainState
+    actor: TrainState
+    critic: TrainState
+
+    env_state: Timestep
+    rng: Array
+    frames: Array
+    updates: Array
+
+    # Latents per-env, carried across collection steps.
+    h: Array  # (N, deter_size)
+    z: Array  # (N, stoch_size)
+    a_prev_oh: Array  # (N, act_dim)
+
+
+# -------------------------
+# Agent
+# -------------------------
+
+
+class Dreamer(Agent):
+    hparams: DreamerHparams
+    env: Environment
+    world: WorldModel = struct.field(pytree_node=False)
+    actor: Actor = struct.field(pytree_node=False)
+    critic: Critic = struct.field(pytree_node=False)
+
+    # ---------- Utilities ----------
+
+    @staticmethod
+    def _flatten_obs(obs: Array) -> Array:
+        """Flattens every non-batch dimension of `obs` into one vector, so
+        the Dense-based world model can consume any navix observation
+        shape (`categorical`'s `(H, W)`, `rgb`'s `(H, W, 3)`, `symbolic`'s
+        `(H, W, 3)`, ...) without the caller needing to pre-wrap the env,
+        the way `baselines/ppo.py`'s `FlattenObsWrapper` does for `PPO`."""
+        return obs.reshape(obs.shape[0], -1)
+
+    @staticmethod
+    def _discount_weights(gamma: float, length: int) -> Array:
+        if length <= 0:
+            return jnp.ones((0,), dtype=jnp.float32)
+        d = jnp.cumprod(jnp.full((length - 1,), gamma, dtype=jnp.float32))
+        return jnp.concatenate([jnp.ones((1,), dtype=jnp.float32), d], axis=0)
+
+    @staticmethod
+    def _compute_lambda_values(
+        next_values: Array,
+        rewards: Array,
+        terminals: Array,
+        discount: float,
+        lam: float,
+    ) -> Array:
+        # shapes: (B, H), (B, H), (B, H) - batch-major, but jax.lax.scan
+        # only ever scans axis 0, so time (H, the axis this function
+        # actually recurs over) needs to be axis 0 for the scan itself;
+        # swap in and back out around it.
+        def scan_fn(carry, inputs):
+            v_lambda_next = carry
+            r_t, term_t, v_tp1 = inputs
+            td = r_t + (1.0 - term_t) * (1.0 - lam) * discount * v_tp1
+            v_lambda = td + v_lambda_next * lam * discount
+            return v_lambda, v_lambda
+
+        init = jnp.zeros_like(next_values[:, -1])
+        rewards_t, terminals_t, next_values_t = jax.tree.map(
+            lambda x: jnp.swapaxes(x, 0, 1)[::-1], (rewards, terminals, next_values)
+        )
+        _, vals_t = jax.lax.scan(
+            scan_fn,
+            init,
+            (rewards_t, terminals_t, next_values_t),
+            length=next_values.shape[1],
+        )
+        return jnp.swapaxes(vals_t[::-1], 0, 1)
+
+    # ---------- Collection ----------
+
+    def _collect(
+        self, ts: DreamerTrainState
+    ) -> Tuple[DreamerTrainState, Buffer]:
+        """Runs `hparams.num_steps` steps in `hparams.num_envs` parallel
+        envs, carrying the per-env posterior latent (h, z, a_prev_oh)
+        across steps so the policy always acts on an up-to-date belief."""
+        hp = self.hparams
+
+        def _env_step(carry, _):
+            env_state, rng, h, z, a_prev_oh = carry
+
+            feat = jnp.concatenate([h, z], axis=-1)
+            logits = self.actor.apply({"params": ts.actor.params}, feat)
+            rng, key_a = jax.random.split(rng)
+            a = distrax.Categorical(logits=logits).sample(seed=key_a)
+            log_prob = distrax.Categorical(logits=logits).log_prob(a)
+
+            new_env_state = jax.vmap(self.env.step, in_axes=(0, 0))(env_state, a)
+
+            a_oh = jax.nn.one_hot(a, logits.shape[-1])
+            flat_obs = self._flatten_obs(new_env_state.observation)
+            rng, key_z = jax.random.split(rng)
+            keys_z = jax.random.split(key_z, hp.num_envs)
+            h_next, z_next = jax.vmap(
+                lambda h_, z_, a_, o_, k_: self.world.apply(
+                    {"params": ts.model.params},
+                    h_,
+                    z_,
+                    a_,
+                    o_,
+                    k_,
+                    method=WorldModel.posterior_step,
+                )
+            )(h, z, a_oh, flat_obs, keys_z)
+
+            # Reset latents where the env just autoreset, so a new episode
+            # doesn't start by conditioning on the previous one's belief.
+            done = new_env_state.is_done()
+            h_next = jnp.where(done[:, None], jnp.zeros_like(h_next), h_next)
+            z_next = jnp.where(done[:, None], jnp.zeros_like(z_next), z_next)
+            a_oh_next = jnp.where(done[:, None], jnp.zeros_like(a_oh), a_oh)
+
+            transition = Buffer(
+                done=new_env_state.is_done(),
+                action=a,
+                reward=new_env_state.reward,
+                log_prob=log_prob,
+                obs=env_state.observation,
+                info=new_env_state.info,
+                t=env_state.t,
+                state=env_state.state,
+            )
+            return (new_env_state, rng, h_next, z_next, a_oh_next), transition
+
+        (env_state, rng, h, z, a_prev_oh), traj = jax.lax.scan(
+            _env_step,
+            (ts.env_state, ts.rng, ts.h, ts.z, ts.a_prev_oh),
+            None,
+            length=hp.num_steps,
+        )
+        ts = ts.replace(
+            env_state=env_state,
+            rng=rng,
+            h=h,
+            z=z,
+            a_prev_oh=a_prev_oh,
+            frames=ts.frames + hp.num_steps * hp.num_envs,
+        )
+        return ts, traj
+
+    def _sample_batch(
+        self, rng: Array, experience: Buffer
+    ) -> Tuple[Array, Array, Array, Array]:
+        """Samples `hparams.batch_size` sequences of length `hparams.seq_len
+        + 1` observations / `seq_len` actions from the most recent
+        rollout, for world-model training."""
+        hp = self.hparams
+        T, N = experience.obs.shape[0], experience.obs.shape[1]
+        L = hp.seq_len
+        max_start = jnp.maximum(T - (L + 1), 0)
+
+        rng, key1, key2 = jax.random.split(rng, 3)
+        env_idx = jax.random.randint(key1, (hp.batch_size,), minval=0, maxval=N)
+        start_idx = jax.random.randint(
+            key2, (hp.batch_size,), minval=0, maxval=jnp.maximum(1, max_start + 1)
+        )
+
+        def take_seq(ei, si):
+            obs_seq = jax.lax.dynamic_slice_in_dim(experience.obs[:, ei], si, L + 1)
+            act_seq = jax.lax.dynamic_slice_in_dim(experience.action[:, ei], si, L)
+            rew_seq = jax.lax.dynamic_slice_in_dim(experience.reward[:, ei], si, L)
+            term_seq = jax.lax.dynamic_slice_in_dim(
+                experience.done[:, ei].astype(jnp.float32), si, L
+            )
+            return obs_seq, act_seq, rew_seq, term_seq
+
+        obs_seq, act_seq, rew_seq, term_seq = jax.vmap(take_seq)(env_idx, start_idx)
+        return self._flatten_obs(obs_seq.reshape(-1, *obs_seq.shape[2:])).reshape(
+            hp.batch_size, L + 1, -1
+        ), act_seq, rew_seq, term_seq
+
+    # ---------- Losses ----------
+
+    def _model_loss(self, params, obs_seq, act_seq, rew_seq, term_seq, rng):
+        (hs, zs), kls, (obs_dist, rew_dist, term_dist), feats = self.world.apply(
+            {"params": params},
+            obs_seq,
+            act_seq,
+            method=WorldModel.observe,
+            rngs={"sample": rng},
+        )
+        B, L = act_seq.shape
+        kl = jnp.mean(kls)
+        kl = jnp.maximum(kl, self.hparams.free_kl)
+        obs_ll = jnp.mean(obs_dist.log_prob(obs_seq[:, 1:].reshape(B * L, -1)))
+        rew_ll = jnp.mean(rew_dist.log_prob(rew_seq.reshape(-1)))
+        term_ll = jnp.mean(term_dist.log_prob(term_seq.reshape(-1)))
+        loss = self.hparams.kl_scale * kl - obs_ll - rew_ll - term_ll
+        logs = {
+            "agent/model/kl": kl,
+            "agent/model/log_p_obs": -obs_ll,
+            "agent/model/log_p_rew": -rew_ll,
+            "agent/model/log_p_term": -term_ll,
+        }
+        return loss, (feats, logs)
+
+    def _actor_loss(self, actor_params, model_params, critic_params, start_feats, rng):
+        hp = self.hparams
+        h0, z0 = start_feats[:, : hp.deter_size], start_feats[:, hp.deter_size :]
+
+        def actor_logits_fn(feat):
+            return self.actor.apply({"params": actor_params}, feat)
+
+        feats, rews, terms = self.world.apply(
+            {"params": model_params},
+            h0,
+            z0,
+            actor_logits_fn,
+            hp.imag_horizon,
+            rng,
+            method=WorldModel.imagine,
+        )
+        # vals_tp1 = V(feats[1:]) bootstraps each reward with the *next*
+        # imagined state's value, so it only covers H-1 pairs (there's no
+        # feats[H] within this rollout to bootstrap the last reward with)
+        # - truncate rews/terms to match rather than the full H-length
+        # rollout.
+        vals_tp1 = jax.vmap(self.critic.apply, in_axes=(None, 0))(
+            {"params": critic_params}, feats[:, 1:]
+        )
+        lam_vals = self._compute_lambda_values(
+            vals_tp1, rews[:, :-1], terms[:, :-1], hp.discount, hp.lam
+        )
+        disc = self._discount_weights(hp.discount, hp.imag_horizon - 1)
+        loss = -(lam_vals * disc).mean()
+        entropy = (
+            distrax.Categorical(
+                logits=self.actor.apply({"params": actor_params}, start_feats)
+            )
+            .entropy()
+            .mean()
+        )
+        logs = {"agent/actor/loss": loss, "agent/actor/entropy": entropy}
+        return loss, logs
+
+    def _critic_loss(self, critic_params, model_params, actor_params, start_feats, rng):
+        hp = self.hparams
+        h0, z0 = start_feats[:, : hp.deter_size], start_feats[:, hp.deter_size :]
+
+        def actor_logits_fn(feat):
+            return self.actor.apply({"params": actor_params}, feat)
+
+        feats, rews, terms = self.world.apply(
+            {"params": model_params},
+            h0,
+            z0,
+            actor_logits_fn,
+            hp.imag_horizon,
+            rng,
+            method=WorldModel.imagine,
+        )
+        vals_tp1 = jax.vmap(self.critic.apply, in_axes=(None, 0))(
+            {"params": critic_params}, feats[:, 1:]
+        )
+        targets = jax.lax.stop_gradient(
+            self._compute_lambda_values(
+                vals_tp1, rews[:, :-1], terms[:, :-1], hp.discount, hp.lam
+            )
+        )
+        # preds must align with targets' H-1 length, hence feats[:, :-1]
+        # (dropping the last imagined state, which targets has no
+        # lambda-return for - see _actor_loss's vals_tp1 comment).
+        preds = jax.vmap(self.critic.apply, in_axes=(None, 0))(
+            {"params": critic_params}, feats[:, :-1]
+        )
+        disc = self._discount_weights(hp.discount, hp.imag_horizon - 1)
+        loss = jnp.mean(((preds - targets) ** 2) * disc)
+        return loss, {"agent/critic/loss": loss}
+
+    # ---------- One update (collect + model/actor/critic) ----------
+
+    def update(self, ts: DreamerTrainState, _) -> Tuple[DreamerTrainState, Dict]:
+        hp = self.hparams
+
+        ts, experience = self._collect(ts)
+
+        def model_step(carry, _):
+            model, rng = carry
+            rng, key_batch, key_loss = jax.random.split(rng, 3)
+            obs_seq, act_seq, rew_seq, term_seq = self._sample_batch(
+                key_batch, experience
+            )
+
+            def loss_fn(p):
+                return self._model_loss(p, obs_seq, act_seq, rew_seq, term_seq, key_loss)
+
+            (loss, (feats, mlogs)), grads = jax.value_and_grad(loss_fn, has_aux=True)(
+                model.params
+            )
+            grads = jax.tree.map(
+                lambda g: jnp.nan_to_num(g, nan=0.0, posinf=0.0, neginf=0.0), grads
+            )
+            model = model.apply_gradients(grads=grads)
+            return (model, rng), {"loss/model": loss, **mlogs}
+
+        (model, rng), mlogs = jax.lax.scan(
+            model_step, (ts.model, ts.rng), None, length=hp.num_model_updates
+        )
+        mlogs = jax.tree.map(lambda x: jnp.mean(x), mlogs)
+
+        # One fresh batch of features to seed the actor/critic imagination
+        # rollouts from, reusing the just-updated model.
+        rng, key_batch, key_observe = jax.random.split(rng, 3)
+        obs_seq, act_seq, _, _ = self._sample_batch(key_batch, experience)
+        _, _, _, feats = self.world.apply(
+            {"params": model.params},
+            obs_seq,
+            act_seq,
+            method=WorldModel.observe,
+            rngs={"sample": key_observe},
+        )
+        start_feats = jax.lax.stop_gradient(
+            feats[:, :-1].reshape(-1, feats.shape[-1])
+        )
+
+        def actor_step(carry, _):
+            actor, rng = carry
+            rng, key = jax.random.split(rng)
+
+            def loss_fn(p):
+                return self._actor_loss(p, model.params, ts.critic.params, start_feats, key)
+
+            (loss, alogs), grads = jax.value_and_grad(loss_fn, has_aux=True)(
+                actor.params
+            )
+            grads = jax.tree.map(
+                lambda g: jnp.nan_to_num(g, nan=0.0, posinf=0.0, neginf=0.0), grads
+            )
+            actor = actor.apply_gradients(grads=grads)
+            return (actor, rng), {"loss/actor": loss, **alogs}
+
+        (actor, rng), alogs = jax.lax.scan(
+            actor_step, (ts.actor, rng), None, length=hp.num_actor_updates
+        )
+        alogs = jax.tree.map(lambda x: jnp.mean(x), alogs)
+
+        def critic_step(carry, _):
+            critic, rng = carry
+            rng, key = jax.random.split(rng)
+
+            def loss_fn(p):
+                return self._critic_loss(p, model.params, actor.params, start_feats, key)
+
+            (loss, clogs), grads = jax.value_and_grad(loss_fn, has_aux=True)(
+                critic.params
+            )
+            grads = jax.tree.map(
+                lambda g: jnp.nan_to_num(g, nan=0.0, posinf=0.0, neginf=0.0), grads
+            )
+            critic = critic.apply_gradients(grads=grads)
+            return (critic, rng), {"loss/critic": loss, **clogs}
+
+        (critic, rng), clogs = jax.lax.scan(
+            critic_step, (ts.critic, rng), None, length=hp.num_critic_updates
+        )
+        clogs = jax.tree.map(lambda x: jnp.mean(x), clogs)
+
+        ts = ts.replace(
+            model=model,
+            actor=actor,
+            critic=critic,
+            rng=rng,
+            updates=ts.updates + 1,
+        )
+
+        logs = {}
+        logs.update(mlogs)
+        logs.update(alogs)
+        logs.update(clogs)
+        logs["done_mask"] = experience.done
+        logs["returns"] = experience.info["return"]
+        logs["lengths"] = experience.t
+        logs["iter/frames"] = ts.frames
+        logs["iter/updates"] = ts.updates
+        logs["iter/model_lr"] = self.hparams.model_lr
+        logs["iter/actor_lr"] = self.hparams.actor_lr
+        logs["iter/critic_lr"] = self.hparams.critic_lr
+
+        if self.hparams.log_render:
+            from ..observations import rgb
+
+            b = jax.random.randint(ts.rng, (), 0, self.hparams.num_envs)
+            logs["render/human"] = jax.vmap(rgb)(
+                jax.tree.map(lambda x: x[:, b], experience.state)
+            ).transpose((0, 3, 1, 2))
+
+        if self.hparams.debug:
+            jax.debug.callback(self.log_to_wandb, logs, experience)
+
+        return ts, logs
+
+    # ---------- Train entry point ----------
+
+    def _init_train_state(self, rng: Array) -> DreamerTrainState:
+        hp = self.hparams
+        obs_dim = self.world.obs_dim
+        assert obs_dim == int(np.prod(self.env.observation_space.shape)), (
+            "self.world's obs_dim must match the (flattened) observation "
+            f"space of self.env - got obs_dim={obs_dim}, but "
+            f"env.observation_space.shape={self.env.observation_space.shape} "
+            f"flattens to {int(np.prod(self.env.observation_space.shape))}. "
+            "Construct WorldModel(obs_dim=int(np.prod(env.observation_space."
+            "shape)), act_dim=len(env.action_set), hparams=...) explicitly, "
+            "the same way PPO expects ActorCritic(action_dim=len(env."
+            "action_set)) pre-constructed rather than building it internally."
+        )
+
+        rng, wk1, wk2, ak, ck = jax.random.split(rng, 5)
+        w_variables = self.world.init(
+            {"params": wk1, "sample": wk2},
+            jnp.zeros((1, obs_dim)),
+            jnp.zeros((1, self.world.act_dim)),
+            method=WorldModel.init_probe,
+        )
+        a_variables = self.actor.init(ak, jnp.zeros((1, hp.deter_size + hp.stoch_size)))
+        c_variables = self.critic.init(ck, jnp.zeros((1, hp.deter_size + hp.stoch_size)))
+
+        model_tx = optax.chain(
+            optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.model_lr)
+        )
+        actor_tx = optax.chain(
+            optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.actor_lr)
+        )
+        critic_tx = optax.chain(
+            optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.critic_lr)
+        )
+        model_state = TrainState.create(
+            apply_fn=self.world.apply, params=w_variables["params"], tx=model_tx
+        )
+        actor_state = TrainState.create(
+            apply_fn=self.actor.apply, params=a_variables["params"], tx=actor_tx
+        )
+        critic_state = TrainState.create(
+            apply_fn=self.critic.apply, params=c_variables["params"], tx=critic_tx
+        )
+
+        rng, rs = jax.random.split(rng)
+        reset_rng = jax.random.split(rs, hp.num_envs)
+        env_state = jax.vmap(self.env.reset)(reset_rng)
+        h0, z0, a0 = self.world.apply(
+            w_variables, hp.num_envs, method=WorldModel.init_state
+        )
+
+        return DreamerTrainState(
+            model=model_state,
+            actor=actor_state,
+            critic=critic_state,
+            env_state=env_state,
+            rng=rng,
+            frames=jnp.asarray(0, dtype=jnp.int32),
+            updates=jnp.asarray(0, dtype=jnp.int32),
+            h=h0,
+            z=z0,
+            a_prev_oh=a0,
+        )
+
+    def train_first_update(self, rng: Array) -> Tuple[DreamerTrainState, Dict]:
+        """Runs initialisation plus exactly one `update()` call. Mainly
+        useful for tests/debugging, where running a full `train()` (sized
+        by `hparams.budget`) is either unnecessary or awkward to size
+        exactly."""
+        ts = self._init_train_state(rng)
+        return self.update(ts, None)
+
+    def train(self, rng: Array) -> Tuple[DreamerTrainState, Dict]:
+        hp = self.hparams
+        ts = self._init_train_state(rng)
+        num_updates = hp.budget // (hp.num_steps * hp.num_envs)
+
+        start_time = time.time()
+        ts, logs = jax.lax.scan(self.update, ts, None, length=num_updates)
+        elapsed = time.time() - start_time
+        logs["iter/fps"] = jnp.asarray([ts.frames / elapsed] * num_updates)
+        logs["iter/wall_time"] = jnp.asarray([elapsed] * num_updates)
+
+        return ts, logs

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -17,51 +17,60 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# A from-scratch DreamerV3 (Hafner et al., "Mastering Diverse Domains
-# through World Models", https://arxiv.org/abs/2301.04104) agent: an RSSM
-# world model with categorical latents, trained jointly with an actor and
-# critic on imagined rollouts. Implements the paper's five headline
-# robustness techniques, cross-checked directly against the official
-# implementation (github.com/danijar/dreamerv3, dreamerv3/rssm.py and
-# embodied/jax/agent.py) rather than assumed from the paper text alone:
-#
-#   1. Symlog inputs/reconstruction (`symlog`/`symexp` below).
-#   2. Categorical latents (`stoch` independent categoricals of `classes`
-#      each) with straight-through gradients and 1% "unimix" - mixing a
-#      little uniform mass into every categorical, so no class ever gets
-#      a literal zero probability - for both the prior and posterior.
-#   3. KL balancing with free bits: two separate KL terms with different
-#      stop-gradient placement and independent free-nats floors, not one
-#      combined KL clamped by a single scalar.
-#   4. Symexp-twohot regression for reward and value (`TwoHotHead`), not
-#      a Gaussian/MSE head - a discrete classification loss over an
-#      exponentially-spaced grid of bins, which is far less sensitive to
-#      reward-scale outliers than a Gaussian likelihood.
-#   5. Return normalization: an EMA-tracked 5th-95th percentile range of
-#      returns rescales advantages, so the policy gradient's magnitude
-#      stays stable across environments with very different reward
-#      scales, without per-environment tuning.
-#
-# Also matches the official implementation's actor loss shape: REINFORCE
-# (log_prob(action) * advantage + entropy bonus), not backpropagation
-# through sampled discrete actions - discrete distrax.Categorical.sample()
-# has no gradient path back to its logits, so naively differentiating an
-# imagined-rollout return through a *sampled* discrete action (as an
-# earlier draft of this agent did) trains nothing through that path at
-# all - and an EMA "slow" target critic that the online critic is
-# regularized toward, for training stability.
-#
-# Deliberate simplifications, kept for navix's small grid-world
-# observations rather than image-scale ones: a plain nn.GRUCell for the
-# deterministic recurrent state (not the official "block GRU", a
-# parameter-efficiency optimization for much larger deter sizes); a plain
-# symlog+MSE decoder for observation reconstruction (not the official
-# implementation's image-specific CNN decoder); ELU activations and no
-# RMSNorm (not load-bearing for correctness, just a smaller/simpler net);
-# `stoch`/`classes` default to 8x8 rather than the paper's 32x32, sized
-# for navix's small grids rather than Atari-scale observations. None of
-# these are the algorithmic identity of DreamerV3 - the five techniques
-# above are.
+"""A from-scratch DreamerV3 (Hafner et al., "Mastering Diverse Domains
+through World Models", https://arxiv.org/abs/2301.04104) agent: an RSSM
+world model with categorical latents, trained jointly with an actor and
+critic on imagined rollouts. Implements the paper's five headline
+robustness techniques, cross-checked directly against the official
+implementation (github.com/danijar/dreamerv3, dreamerv3/rssm.py and
+embodied/jax/agent.py) rather than assumed from the paper text alone:
+
+  1. Symlog inputs/reconstruction (`rlax.signed_logp1`/`signed_expm1`,
+     used by the `Encoder` and `TwoHotHead` in `.models`).
+  2. Categorical latents (`stoch` independent categoricals of `classes`
+     each) with straight-through gradients and 1% "unimix" - mixing a
+     little uniform mass into every categorical, so no class ever gets
+     a literal zero probability - for both the prior and posterior.
+  3. KL balancing with free bits: two separate KL terms with different
+     stop-gradient placement and independent free-nats floors, not one
+     combined KL clamped by a single scalar.
+  4. Symexp-twohot regression for reward and value (`TwoHotHead`), not
+     a Gaussian/MSE head - a discrete classification loss over an
+     exponentially-spaced grid of bins, which is far less sensitive to
+     reward-scale outliers than a Gaussian likelihood.
+  5. Return normalization: an EMA-tracked 5th-95th percentile range of
+     returns rescales advantages, so the policy gradient's magnitude
+     stays stable across environments with very different reward
+     scales, without per-environment tuning.
+
+Also matches the official implementation's actor loss shape: REINFORCE
+(log_prob(action) * advantage + entropy bonus), not backpropagation
+through sampled discrete actions - discrete distrax.Categorical.sample()
+has no gradient path back to its logits, so naively differentiating an
+imagined-rollout return through a *sampled* discrete action (as an
+earlier draft of this agent did) trains nothing through that path at
+all - and an EMA "slow" target critic that the online critic is
+regularized toward, for training stability.
+
+Deliberate simplifications, kept for navix's small grid-world
+observations rather than image-scale ones: a plain nn.GRUCell for the
+deterministic recurrent state (not the official "block GRU", a
+parameter-efficiency optimization for much larger deter sizes); a plain
+symlog+MSE decoder for observation reconstruction (not the official
+implementation's image-specific CNN decoder); ELU activations and no
+RMSNorm (not load-bearing for correctness, just a smaller/simpler net);
+`stoch`/`classes` default to 8x8 rather than the paper's 32x32, sized
+for navix's small grids rather than Atari-scale observations. None of
+these are the algorithmic identity of DreamerV3 - the five techniques
+above are.
+
+The world model's reusable building blocks (categorical-latent
+utilities, the symexp-twohot head, and the RSSM's encoder/decoder/prior/
+posterior networks) live in `.models`, alongside PPO's shared network
+components; this module holds what's specific to Dreamer itself: the
+`WorldModel` that wires those blocks into an RSSM, the actor/critic
+heads, and the `Dreamer` agent's collection/replay/training loop.
+"""
 
 from __future__ import annotations
 import time
@@ -79,108 +88,20 @@ from flax.training.train_state import TrainState
 from flax import struct
 
 from .agent import Agent, HParams
+from .models import (
+    unimix_categorical,
+    straight_through_sample,
+    categorical_kl,
+    TwoHotHead,
+    Encoder,
+    Decoder,
+    RSSM,
+    PriorNet,
+    PostNet,
+)
 from ..environments import Environment
 from ..environments.environment import Timestep
 from ..states import State
-
-
-# -------------------------
-# Categorical latents: unimix + straight-through sampling
-# -------------------------
-
-
-def unimix_categorical(logits: Array, unimix: float) -> distrax.Categorical:
-    """Builds a `distrax.Categorical` from `logits` after mixing in a
-    `unimix` fraction of uniform probability mass across the last axis -
-    the "unimix" trick (1% by default in the paper): guarantees every
-    class keeps at least `unimix / classes` probability, so neither the
-    KL term nor the entropy can collapse to exactly zero, which keeps the
-    prior from ever fully committing and losing gradient signal."""
-    probs = jax.nn.softmax(logits, axis=-1)
-    uniform = jnp.ones_like(probs) / probs.shape[-1]
-    probs = (1.0 - unimix) * probs + unimix * uniform
-    return distrax.Categorical(probs=probs)
-
-
-def straight_through_sample(dist: distrax.Categorical, rng: Array) -> Array:
-    """Samples a one-hot vector from `dist`, with a straight-through
-    gradient: the forward value is a genuine (discrete) sample, but the
-    backward gradient flows as if the output were `dist.probs` directly
-    (`sg(onehot - probs) + probs` has forward value `onehot`, since
-    `onehot - probs` is stop-gradiented, but its Jacobian w.r.t. upstream
-    parameters is `probs`'s). This is what makes the RSSM's own latent
-    trainable end-to-end despite being discrete - distinct from the
-    *actor's* action sampling below, which deliberately does NOT use
-    this (see the module docstring)."""
-    idx = dist.sample(seed=rng)
-    onehot = jax.nn.one_hot(idx, dist.probs.shape[-1])
-    return jax.lax.stop_gradient(onehot - dist.probs) + dist.probs
-
-
-def categorical_kl(post: distrax.Categorical, prior: distrax.Categorical) -> Array:
-    """Sum of `KL(post_i || prior_i)` over the `stoch` independent
-    categoricals (the second-to-last axis) - each categorical's own KL,
-    summed, matching how DreamerV3 treats the full stochastic latent
-    (`stoch` categoricals of `classes` each) as one joint distribution
-    for the purposes of the free-nats floor."""
-    return post.kl_divergence(prior).sum(axis=-1)
-
-
-# -------------------------
-# Symexp-twohot head (reward, value)
-# -------------------------
-
-
-class TwoHotHead(nn.Module):
-    """A scalar-valued prediction head (reward, value) implemented as
-    classification over `bins` evenly-spaced bins in symlog space, with a
-    twohot cross-entropy loss - the "symexp twohot" head from the paper.
-    Far more robust to reward/value outliers than a Gaussian/MSE head,
-    since an extreme target only ever saturates the loss for its two
-    nearest bins, not the whole (unbounded) squared-error term."""
-
-    hidden_size: int
-    bins: int = 255
-    low: float = -20.0
-    high: float = 20.0
-
-    @nn.compact
-    def __call__(self, feat: Array) -> Array:
-        # The output layer is ZERO-initialized (official implementation's
-        # `outscale: 0.0` for the reward/critic heads): all-zero logits ->
-        # uniform bin probabilities -> mean symexp(sum(p*bins)) = symexp(0)
-        # = 0 exactly, so an untrained head predicts 0, not symexp of
-        # whatever random logits happen to sum to over bins spanning
-        # symlog +-20 - which can reach +-e^20. Without this, the very
-        # first imagination rollouts feed the actor advantages of garbage
-        # magnitude; the return-normalization EMA (rate 0.01) is far too
-        # slow to absorb that, and ~64 gradient steps of it were observed
-        # to slam the actor into a deterministic policy (entropy pinned at
-        # the unimix floor) before the world model had learned anything -
-        # after which exploration never recovers.
-        net = nn.Sequential(
-            [
-                nn.Dense(self.hidden_size),
-                nn.elu,
-                nn.Dense(self.hidden_size),
-                nn.elu,
-                nn.Dense(self.bins, kernel_init=nn.initializers.zeros),
-            ]
-        )
-        return net(feat)  # logits, (..., bins)
-
-    def loss(self, logits: Array, target: Array) -> Array:
-        twohot = rlax.transform_to_2hot(
-            rlax.signed_logp1(target), self.low, self.high, self.bins
-        )
-        logp = jax.nn.log_softmax(logits, axis=-1)
-        return -jnp.sum(twohot * logp, axis=-1)
-
-    def mean(self, logits: Array) -> Array:
-        probs = jax.nn.softmax(logits, axis=-1)
-        return rlax.signed_expm1(
-            rlax.transform_from_2hot(probs, self.low, self.high, self.bins)
-        )
 
 
 # -------------------------
@@ -322,86 +243,6 @@ class DreamerHparams(HParams):
 # -------------------------
 # World model: RSSM with categorical latents
 # -------------------------
-
-
-class Encoder(nn.Module):
-    hidden_size: int
-    embed_size: int
-
-    @nn.compact
-    def __call__(self, obs: Array) -> Array:
-        net = nn.Sequential(
-            [
-                nn.Dense(self.hidden_size),
-                nn.elu,
-                nn.Dense(self.hidden_size),
-                nn.elu,
-                nn.Dense(self.embed_size),
-            ]
-        )
-        return net(rlax.signed_logp1(obs))
-
-
-class Decoder(nn.Module):
-    hidden_size: int
-    obs_dim: int
-
-    @nn.compact
-    def __call__(self, feat: Array) -> Array:
-        """Returns a prediction of `symlog(obs)` directly (not a
-        distribution) - reconstruction loss is plain MSE against
-        `symlog(obs)`, the paper's "symlog MSE" observation head, simpler
-        than the image-specific decoder the official implementation uses
-        since navix's observations here are flat vectors, not pixels."""
-        net = nn.Sequential(
-            [
-                nn.Dense(self.hidden_size),
-                nn.elu,
-                nn.Dense(self.hidden_size),
-                nn.elu,
-                nn.Dense(self.obs_dim),
-            ]
-        )
-        return net(feat)
-
-
-class RSSM(nn.Module):
-    deter_size: int
-
-    @nn.compact
-    def __call__(self, h_prev: Array, z_prev_flat: Array, a_prev_oh: Array) -> Array:
-        x = jnp.concatenate([z_prev_flat, a_prev_oh], axis=-1)
-        gru = nn.GRUCell(features=self.deter_size)
-        h, _ = gru(h_prev, x)  # GRUCell returns (new_carry, y); y == new_carry
-        return h
-
-
-class PriorNet(nn.Module):
-    hidden_size: int
-    stoch: int
-    classes: int
-
-    @nn.compact
-    def __call__(self, h: Array) -> Array:
-        """Returns raw logits, `(..., stoch, classes)` - unimix is applied
-        by the caller (`unimix_categorical`), not baked in here, so every
-        caller treats prior and posterior identically."""
-        x = nn.elu(nn.Dense(self.hidden_size)(h))
-        logits = nn.Dense(self.stoch * self.classes)(x)
-        return logits.reshape(*h.shape[:-1], self.stoch, self.classes)
-
-
-class PostNet(nn.Module):
-    hidden_size: int
-    stoch: int
-    classes: int
-
-    @nn.compact
-    def __call__(self, h: Array, embed: Array) -> Array:
-        x = jnp.concatenate([h, embed], axis=-1)
-        x = nn.elu(nn.Dense(self.hidden_size)(x))
-        logits = nn.Dense(self.stoch * self.classes)(x)
-        return logits.reshape(*h.shape[:-1], self.stoch, self.classes)
 
 
 class WorldModel(nn.Module):

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -73,6 +73,7 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 import optax
+import rlax
 import flax.linen as nn
 from flax.training.train_state import TrainState
 from flax import struct
@@ -81,23 +82,6 @@ from .agent import Agent, HParams
 from ..environments import Environment
 from ..environments.environment import Timestep
 from ..states import State
-
-
-# -------------------------
-# Symlog / symexp
-# -------------------------
-
-
-def symlog(x: Array) -> Array:
-    """`sign(x) * log(1 + |x|)` - compresses large magnitudes so a network
-    doesn't need to represent, e.g., both a reward of 1 and one of 1000 on
-    the same linear scale. Self-inverse with `symexp`."""
-    return jnp.sign(x) * jnp.log1p(jnp.abs(x))
-
-
-def symexp(x: Array) -> Array:
-    """Inverse of `symlog`: `sign(x) * (exp(|x|) - 1)`."""
-    return jnp.sign(x) * jnp.expm1(jnp.abs(x))
 
 
 # -------------------------
@@ -147,25 +131,6 @@ def categorical_kl(post: distrax.Categorical, prior: distrax.Categorical) -> Arr
 # -------------------------
 
 
-def twohot_encode(x: Array, bin_centers: Array) -> Array:
-    """Encodes scalar `x` (already in symlog space) as a soft one-hot
-    vector over `bin_centers` (ascending, evenly spaced): all mass on the
-    two bins bracketing `x`, split by linear interpolation. This is the
-    "twohot" target the classification loss is computed against - lets a
-    discrete softmax head represent a continuous value to sub-bin
-    precision, rather than being limited to `bins`-many exact outputs."""
-    K = bin_centers.shape[0]
-    x = jnp.clip(x, bin_centers[0], bin_centers[-1])
-    below = jnp.sum(bin_centers[None, ...] <= x[..., None], axis=-1) - 1
-    below = jnp.clip(below, 0, K - 2)
-    above = below + 1
-    lo, hi = bin_centers[below], bin_centers[above]
-    weight_hi = jnp.where(hi > lo, (x - lo) / (hi - lo), 0.0)
-    onehot_lo = jax.nn.one_hot(below, K)
-    onehot_hi = jax.nn.one_hot(above, K)
-    return onehot_lo * (1.0 - weight_hi)[..., None] + onehot_hi * weight_hi[..., None]
-
-
 class TwoHotHead(nn.Module):
     """A scalar-valued prediction head (reward, value) implemented as
     classification over `bins` evenly-spaced bins in symlog space, with a
@@ -205,15 +170,17 @@ class TwoHotHead(nn.Module):
         return net(feat)  # logits, (..., bins)
 
     def loss(self, logits: Array, target: Array) -> Array:
-        bin_centers = jnp.linspace(self.low, self.high, self.bins)
-        twohot = twohot_encode(symlog(target), bin_centers)
+        twohot = rlax.transform_to_2hot(
+            rlax.signed_logp1(target), self.low, self.high, self.bins
+        )
         logp = jax.nn.log_softmax(logits, axis=-1)
         return -jnp.sum(twohot * logp, axis=-1)
 
     def mean(self, logits: Array) -> Array:
-        bin_centers = jnp.linspace(self.low, self.high, self.bins)
         probs = jax.nn.softmax(logits, axis=-1)
-        return symexp(jnp.sum(probs * bin_centers, axis=-1))
+        return rlax.signed_expm1(
+            rlax.transform_from_2hot(probs, self.low, self.high, self.bins)
+        )
 
 
 # -------------------------
@@ -372,7 +339,7 @@ class Encoder(nn.Module):
                 nn.Dense(self.embed_size),
             ]
         )
-        return net(symlog(obs))
+        return net(rlax.signed_logp1(obs))
 
 
 class Decoder(nn.Module):
@@ -919,26 +886,14 @@ class Dreamer(Agent):
     def _lambda_returns(
         next_values: Array, rewards: Array, continues: Array, discount: float, lam: float
     ) -> Array:
-        """shapes: (B, H), (B, H), (B, H) -> (B, H). `continues` is
-        `1 - terminal`. jax.lax.scan only ever scans axis 0, but these are
-        batch-major (B, H) with H (time) as axis 1 - swap to (H, B) in and
-        out around the scan itself."""
-
-        def scan_fn(carry, inputs):
-            v_lambda_next = carry
-            r_t, cont_t, v_tp1 = inputs
-            td = r_t + cont_t * (1.0 - lam) * discount * v_tp1
-            v_lambda = td + cont_t * v_lambda_next * lam * discount
-            return v_lambda, v_lambda
-
-        init = next_values[:, -1]
-        rewards_t, continues_t, next_values_t = jax.tree.map(
-            lambda x: jnp.swapaxes(x, 0, 1)[::-1], (rewards, continues, next_values)
+        """shapes: (B, H), (B, H), (B, H) -> (B, H). Thin wrapper around
+        `rlax.lambda_returns`, vmapped over the batch axis (that function
+        itself scans over axis 0, which here is time): same recursion
+        `Gₜ = rₜ + γₜ·((1−λ)vₜ + λGₜ₊₁)`, same boundary init `v[-1]`. Mirrors
+        how ppo.py wraps `rlax.truncated_generalized_advantage_estimation`."""
+        return jax.vmap(rlax.lambda_returns, in_axes=(0, 0, 0, None))(
+            rewards, discount * continues, next_values, lam
         )
-        _, vals_t = jax.lax.scan(
-            scan_fn, init, (rewards_t, continues_t, next_values_t), length=rewards.shape[1]
-        )
-        return jnp.swapaxes(vals_t[::-1], 0, 1)
 
     # ---------- Collection ----------
 
@@ -1101,7 +1056,7 @@ class Dreamer(Agent):
         dyn_loss = jnp.mean(jnp.maximum(dyn_kls, hp.free_nats))
         rep_loss = jnp.mean(jnp.maximum(rep_kls, hp.free_nats))
 
-        obs_target = symlog(obs_seq[:, 1:].reshape(B * L, -1))
+        obs_target = rlax.signed_logp1(obs_seq[:, 1:].reshape(B * L, -1))
         obs_loss = jnp.mean(jnp.square(obs_pred - obs_target))
 
         # TwoHotHead.loss/.mean are plain array math (no nn.Dense/params

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -17,16 +17,51 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# A lightweight, MLP-based Dreamer-style world-model agent (RSSM + actor +
-# critic trained on imagined rollouts). This is a simplified reproduction
-# inspired by Dreamer/DreamerV2/DreamerV3 (Hafner et al.), not a faithful
-# port of any single one of those papers - the world model uses a unit
-# -variance Gaussian decoder and a single free-bits KL scalar rather than
-# per-dimension free bits, categorical latents, symlog transforms, or
-# their two-hot reward/value heads. Originally written for a NeurIPS
-# rebuttal on the `neurips` research branch; ported here as a first-class
-# `navix.agents` module per issue #142, with three correctness fixes made
-# during the port (see below).
+# A from-scratch DreamerV3 (Hafner et al., "Mastering Diverse Domains
+# through World Models", https://arxiv.org/abs/2301.04104) agent: an RSSM
+# world model with categorical latents, trained jointly with an actor and
+# critic on imagined rollouts. Implements the paper's five headline
+# robustness techniques, cross-checked directly against the official
+# implementation (github.com/danijar/dreamerv3, dreamerv3/rssm.py and
+# embodied/jax/agent.py) rather than assumed from the paper text alone:
+#
+#   1. Symlog inputs/reconstruction (`symlog`/`symexp` below).
+#   2. Categorical latents (`stoch` independent categoricals of `classes`
+#      each) with straight-through gradients and 1% "unimix" - mixing a
+#      little uniform mass into every categorical, so no class ever gets
+#      a literal zero probability - for both the prior and posterior.
+#   3. KL balancing with free bits: two separate KL terms with different
+#      stop-gradient placement and independent free-nats floors, not one
+#      combined KL clamped by a single scalar.
+#   4. Symexp-twohot regression for reward and value (`TwoHotHead`), not
+#      a Gaussian/MSE head - a discrete classification loss over an
+#      exponentially-spaced grid of bins, which is far less sensitive to
+#      reward-scale outliers than a Gaussian likelihood.
+#   5. Return normalization: an EMA-tracked 5th-95th percentile range of
+#      returns rescales advantages, so the policy gradient's magnitude
+#      stays stable across environments with very different reward
+#      scales, without per-environment tuning.
+#
+# Also matches the official implementation's actor loss shape: REINFORCE
+# (log_prob(action) * advantage + entropy bonus), not backpropagation
+# through sampled discrete actions - discrete distrax.Categorical.sample()
+# has no gradient path back to its logits, so naively differentiating an
+# imagined-rollout return through a *sampled* discrete action (as an
+# earlier draft of this agent did) trains nothing through that path at
+# all - and an EMA "slow" target critic that the online critic is
+# regularized toward, for training stability.
+#
+# Deliberate simplifications, kept for navix's small grid-world
+# observations rather than image-scale ones: a plain nn.GRUCell for the
+# deterministic recurrent state (not the official "block GRU", a
+# parameter-efficiency optimization for much larger deter sizes); a plain
+# symlog+MSE decoder for observation reconstruction (not the official
+# implementation's image-specific CNN decoder); ELU activations and no
+# RMSNorm (not load-bearing for correctness, just a smaller/simpler net);
+# `stoch`/`classes` default to 8x8 rather than the paper's 32x32, sized
+# for navix's small grids rather than Atari-scale observations. None of
+# these are the algorithmic identity of DreamerV3 - the five techniques
+# above are.
 
 from __future__ import annotations
 import time
@@ -39,7 +74,6 @@ import jax.numpy as jnp
 from jax import Array
 import optax
 import flax.linen as nn
-from flax.linen.initializers import constant, orthogonal
 from flax.training.train_state import TrainState
 from flax import struct
 
@@ -47,6 +81,128 @@ from .agent import Agent, HParams
 from ..environments import Environment
 from ..environments.environment import Timestep
 from ..states import State
+
+
+# -------------------------
+# Symlog / symexp
+# -------------------------
+
+
+def symlog(x: Array) -> Array:
+    """`sign(x) * log(1 + |x|)` - compresses large magnitudes so a network
+    doesn't need to represent, e.g., both a reward of 1 and one of 1000 on
+    the same linear scale. Self-inverse with `symexp`."""
+    return jnp.sign(x) * jnp.log1p(jnp.abs(x))
+
+
+def symexp(x: Array) -> Array:
+    """Inverse of `symlog`: `sign(x) * (exp(|x|) - 1)`."""
+    return jnp.sign(x) * jnp.expm1(jnp.abs(x))
+
+
+# -------------------------
+# Categorical latents: unimix + straight-through sampling
+# -------------------------
+
+
+def unimix_categorical(logits: Array, unimix: float) -> distrax.Categorical:
+    """Builds a `distrax.Categorical` from `logits` after mixing in a
+    `unimix` fraction of uniform probability mass across the last axis -
+    the "unimix" trick (1% by default in the paper): guarantees every
+    class keeps at least `unimix / classes` probability, so neither the
+    KL term nor the entropy can collapse to exactly zero, which keeps the
+    prior from ever fully committing and losing gradient signal."""
+    probs = jax.nn.softmax(logits, axis=-1)
+    uniform = jnp.ones_like(probs) / probs.shape[-1]
+    probs = (1.0 - unimix) * probs + unimix * uniform
+    return distrax.Categorical(probs=probs)
+
+
+def straight_through_sample(dist: distrax.Categorical, rng: Array) -> Array:
+    """Samples a one-hot vector from `dist`, with a straight-through
+    gradient: the forward value is a genuine (discrete) sample, but the
+    backward gradient flows as if the output were `dist.probs` directly
+    (`sg(onehot - probs) + probs` has forward value `onehot`, since
+    `onehot - probs` is stop-gradiented, but its Jacobian w.r.t. upstream
+    parameters is `probs`'s). This is what makes the RSSM's own latent
+    trainable end-to-end despite being discrete - distinct from the
+    *actor's* action sampling below, which deliberately does NOT use
+    this (see the module docstring)."""
+    idx = dist.sample(seed=rng)
+    onehot = jax.nn.one_hot(idx, dist.probs.shape[-1])
+    return jax.lax.stop_gradient(onehot - dist.probs) + dist.probs
+
+
+def categorical_kl(post: distrax.Categorical, prior: distrax.Categorical) -> Array:
+    """Sum of `KL(post_i || prior_i)` over the `stoch` independent
+    categoricals (the second-to-last axis) - each categorical's own KL,
+    summed, matching how DreamerV3 treats the full stochastic latent
+    (`stoch` categoricals of `classes` each) as one joint distribution
+    for the purposes of the free-nats floor."""
+    return post.kl_divergence(prior).sum(axis=-1)
+
+
+# -------------------------
+# Symexp-twohot head (reward, value)
+# -------------------------
+
+
+def twohot_encode(x: Array, bin_centers: Array) -> Array:
+    """Encodes scalar `x` (already in symlog space) as a soft one-hot
+    vector over `bin_centers` (ascending, evenly spaced): all mass on the
+    two bins bracketing `x`, split by linear interpolation. This is the
+    "twohot" target the classification loss is computed against - lets a
+    discrete softmax head represent a continuous value to sub-bin
+    precision, rather than being limited to `bins`-many exact outputs."""
+    K = bin_centers.shape[0]
+    x = jnp.clip(x, bin_centers[0], bin_centers[-1])
+    below = jnp.sum(bin_centers[None, ...] <= x[..., None], axis=-1) - 1
+    below = jnp.clip(below, 0, K - 2)
+    above = below + 1
+    lo, hi = bin_centers[below], bin_centers[above]
+    weight_hi = jnp.where(hi > lo, (x - lo) / (hi - lo), 0.0)
+    onehot_lo = jax.nn.one_hot(below, K)
+    onehot_hi = jax.nn.one_hot(above, K)
+    return onehot_lo * (1.0 - weight_hi)[..., None] + onehot_hi * weight_hi[..., None]
+
+
+class TwoHotHead(nn.Module):
+    """A scalar-valued prediction head (reward, value) implemented as
+    classification over `bins` evenly-spaced bins in symlog space, with a
+    twohot cross-entropy loss - the "symexp twohot" head from the paper.
+    Far more robust to reward/value outliers than a Gaussian/MSE head,
+    since an extreme target only ever saturates the loss for its two
+    nearest bins, not the whole (unbounded) squared-error term."""
+
+    hidden_size: int
+    bins: int = 255
+    low: float = -20.0
+    high: float = 20.0
+
+    @nn.compact
+    def __call__(self, feat: Array) -> Array:
+        net = nn.Sequential(
+            [
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.bins),
+            ]
+        )
+        return net(feat)  # logits, (..., bins)
+
+    def loss(self, logits: Array, target: Array) -> Array:
+        bin_centers = jnp.linspace(self.low, self.high, self.bins)
+        twohot = twohot_encode(symlog(target), bin_centers)
+        logp = jax.nn.log_softmax(logits, axis=-1)
+        return -jnp.sum(twohot * logp, axis=-1)
+
+    def mean(self, logits: Array) -> Array:
+        bin_centers = jnp.linspace(self.low, self.high, self.bins)
+        probs = jax.nn.softmax(logits, axis=-1)
+        return symexp(jnp.sum(probs * bin_centers, axis=-1))
+
 
 # -------------------------
 # Hyperparameters
@@ -78,12 +234,48 @@ class DreamerHparams(HParams):
     lam: float = 0.95
     """Lambda parameter of the imagined-rollout lambda-returns."""
 
-    # Loss scales
-    kl_scale: float = 1.0
-    """Weight of the KL term in the world-model loss."""
-    free_kl: float = 1.0
-    """Free-bits floor on the (batch-mean) KL term - the model isn't
-    penalised for KL below this value."""
+    # World model: categorical latent + KL balancing (paper defaults:
+    # stoch=32, classes=32/64, unimix=0.01, free_nats=1.0, dyn_scale=1.0,
+    # rep_scale=0.1 - dims reduced here for navix's small grids).
+    stoch: int = struct.field(pytree_node=False, default=8)
+    """Number of independent categorical latent variables."""
+    classes: int = struct.field(pytree_node=False, default=8)
+    """Number of classes per categorical latent variable."""
+    unimix: float = 0.01
+    """Fraction of uniform probability mixed into every categorical."""
+    free_nats: float = 1.0
+    """Per-(batch,time) KL floor - below this, dyn/rep loss is zero."""
+    dyn_scale: float = 1.0
+    """Weight of the KL(sg(post)||prior) ("dynamics") term."""
+    rep_scale: float = 0.1
+    """Weight of the KL(post||sg(prior)) ("representation") term."""
+
+    # Reward/value heads (symexp twohot).
+    bins: int = struct.field(pytree_node=False, default=41)
+    """Number of bins for the reward/value symexp-twohot heads (paper:
+    255; reduced here since navix's rewards/returns span a far smaller
+    dynamic range than Atari's)."""
+    bins_low: float = -20.0
+    """Lower edge of the symlog-space bin range."""
+    bins_high: float = 20.0
+    """Upper edge of the symlog-space bin range."""
+
+    # Actor: REINFORCE + entropy bonus + return normalization.
+    actor_entropy: float = 3e-4
+    """Entropy bonus coefficient in the actor's REINFORCE loss."""
+    return_norm_rate: float = 0.01
+    """EMA rate for the return-normalization percentile tracker."""
+    return_norm_limit: float = 1.0
+    """Floor on the return-normalization scale (perc95 - perc5), so a
+    near-constant reward signal doesn't blow the advantage up by dividing
+    by a near-zero scale."""
+
+    # Slow (EMA target) critic.
+    slow_critic_rate: float = 0.02
+    """EMA rate the slow critic's params track the online critic at."""
+    slow_critic_reg: float = 1.0
+    """Weight of the online critic's regularization loss toward the slow
+    critic's prediction, on top of its lambda-return regression loss."""
 
     # Opt/grad
     model_lr: float = 3e-4
@@ -101,23 +293,19 @@ class DreamerHparams(HParams):
     """Size of the encoder's output embedding."""
     deter_size: int = 200
     """Size of the RSSM's deterministic (GRU) hidden state."""
-    stoch_size: int = 30
-    """Size of the RSSM's stochastic latent."""
     hidden_size: int = 200
     """Hidden layer size used throughout the model/actor/critic MLPs."""
 
+    @property
+    def stoch_flat(self) -> int:
+        """Flattened size of the categorical latent (`stoch * classes`),
+        i.e. how much of `feat = concat([h, z_flat])` the latent occupies."""
+        return self.stoch * self.classes
+
 
 # -------------------------
-# World Model (lightweight Dreamer-style RSSM)
+# World model: RSSM with categorical latents
 # -------------------------
-
-
-def _diag_gaussian(loc: Array, scale: Array) -> distrax.MultivariateNormalDiag:
-    return distrax.MultivariateNormalDiag(loc=loc, scale_diag=scale)
-
-
-def _softplus_std(x: Array, min_std: float = 0.1) -> Array:
-    return nn.softplus(x) + min_std
 
 
 class Encoder(nn.Module):
@@ -135,7 +323,7 @@ class Encoder(nn.Module):
                 nn.Dense(self.embed_size),
             ]
         )
-        return net(obs)
+        return net(symlog(obs))
 
 
 class Decoder(nn.Module):
@@ -143,7 +331,12 @@ class Decoder(nn.Module):
     obs_dim: int
 
     @nn.compact
-    def __call__(self, feat: Array) -> distrax.MultivariateNormalDiag:
+    def __call__(self, feat: Array) -> Array:
+        """Returns a prediction of `symlog(obs)` directly (not a
+        distribution) - reconstruction loss is plain MSE against
+        `symlog(obs)`, the paper's "symlog MSE" observation head, simpler
+        than the image-specific decoder the official implementation uses
+        since navix's observations here are flat vectors, not pixels."""
         net = nn.Sequential(
             [
                 nn.Dense(self.hidden_size),
@@ -153,84 +346,46 @@ class Decoder(nn.Module):
                 nn.Dense(self.obs_dim),
             ]
         )
-        mean = net(feat)
-        scale = jnp.ones_like(mean)  # unit-variance decoder (simple & stable)
-        return _diag_gaussian(mean, scale)
-
-
-class RewardHead(nn.Module):
-    hidden_size: int
-
-    @nn.compact
-    def __call__(self, feat: Array) -> distrax.Normal:
-        net = nn.Sequential(
-            [
-                nn.Dense(self.hidden_size),
-                nn.elu,
-                nn.Dense(self.hidden_size),
-                nn.elu,
-                nn.Dense(1),
-            ]
-        )
-        mean = jnp.squeeze(net(feat), -1)
-        scale = jnp.ones_like(mean)
-        return distrax.Normal(loc=mean, scale=scale)
-
-
-class TermHead(nn.Module):
-    hidden_size: int
-
-    @nn.compact
-    def __call__(self, feat: Array) -> distrax.Bernoulli:
-        net = nn.Sequential(
-            [
-                nn.Dense(self.hidden_size),
-                nn.elu,
-                nn.Dense(self.hidden_size),
-                nn.elu,
-                nn.Dense(1),
-            ]
-        )
-        logits = jnp.squeeze(net(feat), -1)
-        return distrax.Bernoulli(logits=logits)
-
-
-class PriorNet(nn.Module):
-    hidden_size: int
-    stoch_size: int
-
-    @nn.compact
-    def __call__(self, h: Array) -> distrax.MultivariateNormalDiag:
-        x = nn.elu(nn.Dense(self.hidden_size)(h))
-        loc = nn.Dense(self.stoch_size)(x)
-        pre = nn.Dense(self.stoch_size)(x)
-        scale = _softplus_std(pre)
-        return _diag_gaussian(loc, scale)
-
-
-class PostNet(nn.Module):
-    hidden_size: int
-    stoch_size: int
-
-    @nn.compact
-    def __call__(self, h: Array, embed: Array) -> distrax.MultivariateNormalDiag:
-        x = jnp.concatenate([h, embed], axis=-1)
-        x = nn.elu(nn.Dense(self.hidden_size)(x))
-        loc = nn.Dense(self.stoch_size)(x)
-        pre = nn.Dense(self.stoch_size)(x)
-        scale = _softplus_std(pre)
-        return _diag_gaussian(loc, scale)
+        return net(feat)
 
 
 class RSSM(nn.Module):
     deter_size: int
 
     @nn.compact
-    def __call__(self, h_prev: Array, z_prev: Array, a_prev_oh: Array) -> Array:
-        x = jnp.concatenate([z_prev, a_prev_oh], axis=-1)
+    def __call__(self, h_prev: Array, z_prev_flat: Array, a_prev_oh: Array) -> Array:
+        x = jnp.concatenate([z_prev_flat, a_prev_oh], axis=-1)
         gru = nn.GRUCell(features=self.deter_size)
         h, _ = gru(h_prev, x)  # GRUCell returns (new_carry, y); y == new_carry
         return h
+
+
+class PriorNet(nn.Module):
+    hidden_size: int
+    stoch: int
+    classes: int
+
+    @nn.compact
+    def __call__(self, h: Array) -> Array:
+        """Returns raw logits, `(..., stoch, classes)` - unimix is applied
+        by the caller (`unimix_categorical`), not baked in here, so every
+        caller treats prior and posterior identically."""
+        x = nn.elu(nn.Dense(self.hidden_size)(h))
+        logits = nn.Dense(self.stoch * self.classes)(x)
+        return logits.reshape(*h.shape[:-1], self.stoch, self.classes)
+
+
+class PostNet(nn.Module):
+    hidden_size: int
+    stoch: int
+    classes: int
+
+    @nn.compact
+    def __call__(self, h: Array, embed: Array) -> Array:
+        x = jnp.concatenate([h, embed], axis=-1)
+        x = nn.elu(nn.Dense(self.hidden_size)(x))
+        logits = nn.Dense(self.stoch * self.classes)(x)
+        return logits.reshape(*h.shape[:-1], self.stoch, self.classes)
 
 
 class WorldModel(nn.Module):
@@ -242,29 +397,34 @@ class WorldModel(nn.Module):
         hp = self.hparams
         self.encoder = Encoder(hp.hidden_size, hp.embed_size)
         self.rssm = RSSM(hp.deter_size)
-        self.prior = PriorNet(hp.hidden_size, hp.stoch_size)
-        self.post = PostNet(hp.hidden_size, hp.stoch_size)
+        self.prior = PriorNet(hp.hidden_size, hp.stoch, hp.classes)
+        self.post = PostNet(hp.hidden_size, hp.stoch, hp.classes)
         self.decoder = Decoder(hp.hidden_size, self.obs_dim)
-        self.reward = RewardHead(hp.hidden_size)
-        self.term = TermHead(hp.hidden_size)
+        self.reward = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
+        self.term = nn.Sequential(
+            [
+                nn.Dense(hp.hidden_size),
+                nn.elu,
+                nn.Dense(hp.hidden_size),
+                nn.elu,
+                nn.Dense(1),
+            ]
+        )
 
     def init_state(self, batch_size: int) -> Tuple[Array, Array, Array]:
         h = jnp.zeros((batch_size, self.hparams.deter_size))
-        z = jnp.zeros((batch_size, self.hparams.stoch_size))
+        z_flat = jnp.zeros((batch_size, self.hparams.stoch_flat))
         a0 = jnp.zeros((batch_size, self.act_dim))
-        return h, z, a0
+        return h, z_flat, a0
 
-    def feat(self, h: Array, z: Array) -> Array:
-        return jnp.concatenate([h, z], axis=-1)
+    def feat(self, h: Array, z_flat: Array) -> Array:
+        return jnp.concatenate([h, z_flat], axis=-1)
 
     def observe(self, obs_seq: Array, act_seq: Array) -> Tuple[
-        Tuple[Array, Array],
-        Array,
-        Tuple[distrax.Distribution, distrax.Distribution, distrax.Distribution],
-        Array,
+        Tuple[Array, Array], Tuple[Array, Array], Array, Array, Array, Array
     ]:
         """Runs the RSSM over an observed sequence, computing the posterior
-        latent at every step and decoding obs/reward/termination from it.
+        latent at every step and decoding obs/reward/term from it.
 
         Args:
             obs_seq (Array): `f32[B, L+1, obs_dim]`, flattened observations.
@@ -272,18 +432,18 @@ class WorldModel(nn.Module):
                 observations.
 
         Returns:
-            `((h_seq, z_seq), kls, (obs_dist, rew_dist, term_dist), feats)`,
-            all aligned with `obs_seq[:, 1:]` (i.e. `L` steps, `t=0..L-1`).
-            `kls` is `f32[B, L]`, the per-step `KL(post || prior)` - computed
-            inside the scan body rather than returned as `(priors, posts)`
-            distribution objects, because jax.lax.scan only restacks a
+            `((h_seq, z_seq), (dyn_kls, rep_kls), feats, obs_pred, rew_logits,
+            term_logits)`, all aligned with `obs_seq[:, 1:]` (`L` steps,
+            `t=0..L-1`) except `(h_seq, z_seq)` and `feats`, which keep
+            their own `(B, L, ...)` shape. `dyn_kls`/`rep_kls` are
+            `f32[B, L]`, computed inside the scan body (not returned as
+            distribution objects) because jax.lax.scan only restacks a
             distrax.Distribution's array *leaves* across the new leading
-            (L) axis; its batch_shape/event_shape (computed once from the
-            un-stacked per-step arrays) go stale, so calling
-            post.kl_divergence(prior) *after* the scan raises a shape
-            mismatch deep inside distrax/tfp. Computing it per-step, while
-            the distributions' shapes are still consistent with their own
-            metadata, sidesteps that entirely."""
+            axis; its batch_shape/event_shape (computed once from the
+            un-stacked per-step arrays) go stale, so calling e.g.
+            .kl_divergence() *after* the scan raises a shape mismatch deep
+            inside distrax/tfp."""
+        hp = self.hparams
         B, Lp1, _ = obs_seq.shape
         L = Lp1 - 1
 
@@ -302,55 +462,64 @@ class WorldModel(nn.Module):
         # xs)` - passing a plain closure that way makes Flax's transform
         # machinery treat `carry` itself as the (missing) `self` argument,
         # failing deep inside with a confusing `'tuple' object has no
-        # attribute '_state'`. `imagine()` below already uses plain
-        # jax.lax.scan correctly for the same reason; this mirrors it.
-        # Since setup() already built every submodule once, calling them
-        # repeatedly inside a plain scan just reuses their closed-over
-        # params - no Flax-level parameter broadcasting is needed here.
-        # The per-step posterior sample rng is threaded through the scan
-        # carry explicitly instead of nn.scan's split_rngs, since plain
-        # jax.lax.scan doesn't auto-split Flax's rng streams.
+        # attribute '_state'`. Since setup() already built every submodule
+        # once, calling them repeatedly inside a plain scan just reuses
+        # their closed-over params - no Flax-level parameter broadcasting
+        # is needed here. The per-step sample rng is threaded through the
+        # scan carry explicitly instead of nn.scan's split_rngs, since
+        # plain jax.lax.scan doesn't auto-split Flax's rng streams.
         def step(carry, inputs):
-            h_prev, z_prev, rng = carry
+            h_prev, z_prev_flat, rng = carry
             a_prev_t, embed_t = inputs
             rng, key = jax.random.split(rng)
-            h_t = self.rssm(h_prev, z_prev, a_prev_t)
-            prior_t = self.prior(h_t)
-            post_t = self.post(h_t, embed_t)
-            kl_t = post_t.kl_divergence(prior_t)  # (B,) - see observe()'s docstring
-            z_t = post_t.sample(seed=key)
-            feat_t = self.feat(h_t, z_t)
-            return (h_t, z_t, rng), (h_t, z_t, kl_t, feat_t)
+            h_t = self.rssm(h_prev, z_prev_flat, a_prev_t)
+            prior_logits = self.prior(h_t)
+            post_logits = self.post(h_t, embed_t)
+            prior_dist = unimix_categorical(prior_logits, hp.unimix)
+            post_dist = unimix_categorical(post_logits, hp.unimix)
+            prior_dist_sg = distrax.Categorical(
+                probs=jax.lax.stop_gradient(prior_dist.probs)
+            )
+            post_dist_sg = distrax.Categorical(
+                probs=jax.lax.stop_gradient(post_dist.probs)
+            )
+            dyn_kl_t = categorical_kl(post_dist_sg, prior_dist)
+            rep_kl_t = categorical_kl(post_dist, prior_dist_sg)
+            z_t = straight_through_sample(post_dist, key)
+            z_t_flat = z_t.reshape(*z_t.shape[:-2], -1)
+            feat_t = self.feat(h_t, z_t_flat)
+            return (h_t, z_t_flat, rng), (h_t, z_t_flat, dyn_kl_t, rep_kl_t, feat_t)
 
         # jax.lax.scan always scans over axis 0, but our sequences are
         # batch-major (B, L, ...) - swap to (L, B, ...) going in, and swap
-        # the stacked outputs back to (B, L, ...) coming out, since
-        # downstream code (feats.reshape(B * L, -1) below,
-        # start_feats = feats[:, :-1]... in update()) expects batch-major.
+        # the stacked outputs back to (B, L, ...) coming out.
         inputs = jax.tree.map(
             lambda x: jnp.swapaxes(x, 0, 1), (a_prev[:, :L], embed_all[:, 1:])
         )
-        hp = self.hparams
         init_rng = self.make_rng("sample")
-        (h_last, z_last, _), (hs, zs, kls, feats) = jax.lax.scan(
+        (h_last, z_last, _), (hs, zs, dyn_kls, rep_kls, feats) = jax.lax.scan(
             step,
-            (jnp.zeros((B, hp.deter_size)), jnp.zeros((B, hp.stoch_size)), init_rng),
+            (
+                jnp.zeros((B, hp.deter_size)),
+                jnp.zeros((B, hp.stoch_flat)),
+                init_rng,
+            ),
             inputs,
             length=L,
         )
-        hs, zs, kls, feats = jax.tree.map(
-            lambda x: jnp.swapaxes(x, 0, 1), (hs, zs, kls, feats)
+        hs, zs, dyn_kls, rep_kls, feats = jax.tree.map(
+            lambda x: jnp.swapaxes(x, 0, 1), (hs, zs, dyn_kls, rep_kls, feats)
         )
 
         feats_flat = feats.reshape(B * L, -1)
-        obs_dist = self.decoder(feats_flat)
-        rew_dist = self.reward(feats_flat)
-        term_dist = self.term(feats_flat)
+        obs_pred = self.decoder(feats_flat)
+        rew_logits = self.reward(feats_flat)
+        term_logits = self.term(feats_flat)
 
-        return (hs, zs), kls, (obs_dist, rew_dist, term_dist), feats
+        return (hs, zs), (dyn_kls, rep_kls), feats, obs_pred, rew_logits, term_logits
 
     def posterior_step(
-        self, h: Array, z: Array, a_prev_oh: Array, obs: Array, rng: Array
+        self, h: Array, z_flat: Array, a_prev_oh: Array, obs: Array, rng: Array
     ) -> Tuple[Array, Array]:
         """One environment-collection step: advances the RSSM's belief with
         the previous action, then updates it to the posterior given the new
@@ -359,11 +528,12 @@ class WorldModel(nn.Module):
         they can only be called from inside a WorldModel.apply() trace,
         which is what this method (called via `self.world.apply(...,
         method=WorldModel.posterior_step)`) provides for `_collect`."""
-        h_next = self.rssm(h, z, a_prev_oh)
+        h_next = self.rssm(h, z_flat, a_prev_oh)
         embed = self.encoder(obs)
-        post = self.post(h_next, embed)
-        z_next = post.sample(seed=rng)
-        return h_next, z_next
+        post_dist = unimix_categorical(self.post(h_next, embed), self.hparams.unimix)
+        z_next = straight_through_sample(post_dist, rng)
+        z_next_flat = z_next.reshape(*z_next.shape[:-2], -1)
+        return h_next, z_next_flat
 
     def init_probe(self, obs: Array, a_prev_oh: Array) -> None:
         """Touches every submodule exactly once, purely so `WorldModel.
@@ -376,13 +546,16 @@ class WorldModel(nn.Module):
         safely with tracing through observe()'s internal jax.lax.scan
         while already inside an outer jax.jit (surfaces as a confusing
         `UnexpectedTracerError` pointing at an unrelated submodule)."""
-        h = jnp.zeros((obs.shape[0], self.hparams.deter_size))
-        z = jnp.zeros((obs.shape[0], self.hparams.stoch_size))
-        h_t = self.rssm(h, z, a_prev_oh)
+        hp = self.hparams
+        h = jnp.zeros((obs.shape[0], hp.deter_size))
+        z_flat = jnp.zeros((obs.shape[0], hp.stoch_flat))
+        h_t = self.rssm(h, z_flat, a_prev_oh)
         self.prior(h_t)
         embed = self.encoder(obs)
-        post_t = self.post(h_t, embed)
-        feat_t = self.feat(h_t, post_t.mean())
+        post_logits = self.post(h_t, embed)
+        z_t = jax.nn.one_hot(jnp.zeros(obs.shape[0], dtype=jnp.int32), hp.classes)
+        z_t = jnp.broadcast_to(z_t[:, None, :], (obs.shape[0], hp.stoch, hp.classes))
+        feat_t = self.feat(h_t, z_t.reshape(obs.shape[0], -1))
         self.decoder(feat_t)
         self.reward(feat_t)
         self.term(feat_t)
@@ -390,46 +563,55 @@ class WorldModel(nn.Module):
     def imagine(
         self,
         start_h: Array,
-        start_z: Array,
+        start_z_flat: Array,
         actor_logits_fn: Callable[[Array], Array],
         horizon: int,
         rng: Array,
-    ) -> Tuple[Array, Array, Array]:
+    ) -> Tuple[Array, Array, Array, Array, Array]:
         """Rolls the RSSM forward purely through its own prior (no real
         observations), sampling actions from `actor_logits_fn` at each
         step - the "imagined" trajectories the actor and critic train on.
 
-        Returns `(feats, rewards, terms)`, all `(B, H, ...)` (batch-major).
-        `rewards`/`terms` are plain arrays (each step's reward/term
-        distribution mean), not distrax.Distribution objects - as in
-        observe(), a distrax.Distribution's batch_shape/event_shape are
-        computed once from its un-stacked per-step arrays, and go stale
-        under jax.lax.scan's leaf-only restacking, so any post-scan method
-        call on it (including .mean()) is unsafe. Reducing to a mean
-        before accumulating sidesteps that."""
+        Returns `(feats, rewards, terms, actions, action_logps)`, all
+        `(B, H, ...)` (batch-major). `rewards` is the reward head's
+        decoded mean (plain array, not a TwoHotHead logits tensor);
+        `actions`/`action_logps` are returned because the actor loss
+        needs `log_prob(action)` under the *current* actor params for its
+        REINFORCE term - recomputed at loss-value-and-grad time from the
+        stored actions, not reused from here (this rollout's actor calls
+        may run in a different tracing context)."""
 
         def rollout_step(carry, _):
-            h, z, rng = carry
-            feat = jnp.concatenate([h, z], axis=-1)
+            h, z_flat, rng = carry
+            feat = jnp.concatenate([h, z_flat], axis=-1)
             logits = actor_logits_fn(feat)
-            rng, key = jax.random.split(rng)
-            a = distrax.Categorical(logits=logits).sample(seed=key)
+            rng, key_a, key_z = jax.random.split(rng, 3)
+            a = distrax.Categorical(logits=logits).sample(seed=key_a)
+            logp = distrax.Categorical(logits=logits).log_prob(a)
             a_oh = jax.nn.one_hot(a, logits.shape[-1])
-            h_next = self.rssm(h, z, a_oh)
-            prior = self.prior(h_next)
-            rng, key = jax.random.split(rng)
-            z_next = prior.sample(seed=key)
-            feat_next = jnp.concatenate([h_next, z_next], axis=-1)
-            rew_mean = self.reward(feat_next).mean()
-            term_mean = self.term(feat_next).mean()
-            return (h_next, z_next, rng), (feat_next, rew_mean, term_mean)
+            h_next = self.rssm(h, z_flat, a_oh)
+            prior_dist = unimix_categorical(self.prior(h_next), self.hparams.unimix)
+            z_next = straight_through_sample(prior_dist, key_z)
+            z_next_flat = z_next.reshape(*z_next.shape[:-2], -1)
+            feat_next = jnp.concatenate([h_next, z_next_flat], axis=-1)
+            rew_mean = self.reward.mean(self.reward(feat_next))
+            term_logit = jnp.squeeze(self.term(feat_next), -1)
+            return (h_next, z_next_flat, rng), (
+                feat_next,
+                rew_mean,
+                term_logit,
+                a,
+                logp,
+            )
 
-        (hT, zT, _), (feats, rews, terms) = jax.lax.scan(
-            rollout_step, (start_h, start_z, rng), None, length=horizon
+        (hT, zT, _), (feats, rews, term_logits, actions, logps) = jax.lax.scan(
+            rollout_step, (start_h, start_z_flat, rng), None, length=horizon
         )
         # (H, B, ...) -> (B, H, ...)
-        feats, rews, terms = jax.tree.map(lambda x: jnp.swapaxes(x, 0, 1), (feats, rews, terms))
-        return feats, rews, terms
+        feats, rews, term_logits, actions, logps = jax.tree.map(
+            lambda x: jnp.swapaxes(x, 0, 1), (feats, rews, term_logits, actions, logps)
+        )
+        return feats, rews, term_logits, actions, logps
 
 
 # -------------------------
@@ -449,9 +631,7 @@ class Actor(nn.Module):
                 nn.elu,
                 nn.Dense(self.hidden),
                 nn.elu,
-                nn.Dense(
-                    self.act_dim, kernel_init=orthogonal(0.01), bias_init=constant(0.0)
-                ),
+                nn.Dense(self.act_dim),
             ]
         )
         return net(feat)
@@ -462,19 +642,13 @@ class Actor(nn.Module):
 
 class Critic(nn.Module):
     hidden: int = 200
+    bins: int = 255
+    low: float = -20.0
+    high: float = 20.0
 
     @nn.compact
     def __call__(self, feat: Array) -> Array:
-        net = nn.Sequential(
-            [
-                nn.Dense(self.hidden),
-                nn.elu,
-                nn.Dense(self.hidden),
-                nn.elu,
-                nn.Dense(1, kernel_init=orthogonal(1.0), bias_init=constant(0.0)),
-            ]
-        )
-        return jnp.squeeze(net(feat), -1)
+        return TwoHotHead(self.hidden, self.bins, self.low, self.high)(feat)
 
 
 # -------------------------
@@ -499,34 +673,41 @@ class Buffer(struct.PyTreeNode):
 
 
 class DreamerTrainState(struct.PyTreeNode):
-    """Unlike `flax.training.train_state.TrainState` (used by `PPO`), this
-    wraps three *independent* `TrainState`s, one per network - the world
-    model, actor, and critic each have their own optimizer, learning rate
-    and step counter, and are updated via their own `apply_gradients()`.
+    """Wraps three *independent* `TrainState`s, one per network - the
+    world model, actor, and critic each have their own optimizer,
+    learning rate and step counter, and are updated via their own
+    `apply_gradients()`. An earlier draft instead subclassed `TrainState`
+    directly and shared one `tx`/`step` field meant to be swapped between
+    the three networks' updates; the swap never actually took effect
+    before each network's update ran, so actor and critic gradients were
+    silently applied through the model's optimizer (and learning rate)
+    instead of their own, and the step counter never incremented since
+    `apply_gradients()` was never called. Three separate `TrainState`s
+    make both bugs structurally impossible instead of relying on
+    remembering to swap a shared field correctly.
 
-    An earlier draft of this agent instead subclassed `TrainState` directly
-    and hand-rolled `tx.update()` + `optax.apply_updates()` for all three
-    networks while sharing a single `tx`/`step` field meant to be swapped
-    between updates - the swap never actually took effect before each
-    network's update ran, so actor and critic gradients were silently
-    applied through the model's optimizer (and learning rate) instead of
-    their own, and since `apply_gradients()` was never called, the step
-    counter never incremented at all. Three separate `TrainState`s make
-    both bugs structurally impossible instead of relying on remembering to
-    swap a shared field correctly."""
+    `slow_critic_params` is a plain EMA-tracked copy of the critic's
+    params (not a fourth optimized TrainState - nothing ever computes a
+    gradient w.r.t. it, it only ever gets updated by exponential
+    averaging toward `critic.params`), used both to regularize the online
+    critic's training and to compute the return-normalization statistics.
+    """
 
     model: TrainState
     actor: TrainState
     critic: TrainState
+    slow_critic_params: dict
 
     env_state: Timestep
     rng: Array
     frames: Array
     updates: Array
+    return_norm_lo: Array  # EMA of the 5th percentile of returns
+    return_norm_hi: Array  # EMA of the 95th percentile of returns
 
     # Latents per-env, carried across collection steps.
     h: Array  # (N, deter_size)
-    z: Array  # (N, stoch_size)
+    z: Array  # (N, stoch_flat)
     a_prev_oh: Array  # (N, act_dim)
 
 
@@ -554,48 +735,33 @@ class Dreamer(Agent):
         return obs.reshape(obs.shape[0], -1)
 
     @staticmethod
-    def _discount_weights(gamma: float, length: int) -> Array:
-        if length <= 0:
-            return jnp.ones((0,), dtype=jnp.float32)
-        d = jnp.cumprod(jnp.full((length - 1,), gamma, dtype=jnp.float32))
-        return jnp.concatenate([jnp.ones((1,), dtype=jnp.float32), d], axis=0)
-
-    @staticmethod
-    def _compute_lambda_values(
-        next_values: Array,
-        rewards: Array,
-        terminals: Array,
-        discount: float,
-        lam: float,
+    def _lambda_returns(
+        next_values: Array, rewards: Array, continues: Array, discount: float, lam: float
     ) -> Array:
-        # shapes: (B, H), (B, H), (B, H) - batch-major, but jax.lax.scan
-        # only ever scans axis 0, so time (H, the axis this function
-        # actually recurs over) needs to be axis 0 for the scan itself;
-        # swap in and back out around it.
+        """shapes: (B, H), (B, H), (B, H) -> (B, H). `continues` is
+        `1 - terminal`. jax.lax.scan only ever scans axis 0, but these are
+        batch-major (B, H) with H (time) as axis 1 - swap to (H, B) in and
+        out around the scan itself."""
+
         def scan_fn(carry, inputs):
             v_lambda_next = carry
-            r_t, term_t, v_tp1 = inputs
-            td = r_t + (1.0 - term_t) * (1.0 - lam) * discount * v_tp1
-            v_lambda = td + v_lambda_next * lam * discount
+            r_t, cont_t, v_tp1 = inputs
+            td = r_t + cont_t * (1.0 - lam) * discount * v_tp1
+            v_lambda = td + cont_t * v_lambda_next * lam * discount
             return v_lambda, v_lambda
 
-        init = jnp.zeros_like(next_values[:, -1])
-        rewards_t, terminals_t, next_values_t = jax.tree.map(
-            lambda x: jnp.swapaxes(x, 0, 1)[::-1], (rewards, terminals, next_values)
+        init = next_values[:, -1]
+        rewards_t, continues_t, next_values_t = jax.tree.map(
+            lambda x: jnp.swapaxes(x, 0, 1)[::-1], (rewards, continues, next_values)
         )
         _, vals_t = jax.lax.scan(
-            scan_fn,
-            init,
-            (rewards_t, terminals_t, next_values_t),
-            length=next_values.shape[1],
+            scan_fn, init, (rewards_t, continues_t, next_values_t), length=rewards.shape[1]
         )
         return jnp.swapaxes(vals_t[::-1], 0, 1)
 
     # ---------- Collection ----------
 
-    def _collect(
-        self, ts: DreamerTrainState
-    ) -> Tuple[DreamerTrainState, Buffer]:
+    def _collect(self, ts: DreamerTrainState) -> Tuple[DreamerTrainState, Buffer]:
         """Runs `hparams.num_steps` steps in `hparams.num_envs` parallel
         envs, carrying the per-env posterior latent (h, z, a_prev_oh)
         across steps so the policy always acts on an up-to-date belief."""
@@ -697,36 +863,64 @@ class Dreamer(Agent):
     # ---------- Losses ----------
 
     def _model_loss(self, params, obs_seq, act_seq, rew_seq, term_seq, rng):
-        (hs, zs), kls, (obs_dist, rew_dist, term_dist), feats = self.world.apply(
-            {"params": params},
-            obs_seq,
-            act_seq,
-            method=WorldModel.observe,
-            rngs={"sample": rng},
+        (hs, zs), (dyn_kls, rep_kls), feats, obs_pred, rew_logits, term_logits = (
+            self.world.apply(
+                {"params": params},
+                obs_seq,
+                act_seq,
+                method=WorldModel.observe,
+                rngs={"sample": rng},
+            )
         )
+        hp = self.hparams
         B, L = act_seq.shape
-        kl = jnp.mean(kls)
-        kl = jnp.maximum(kl, self.hparams.free_kl)
-        obs_ll = jnp.mean(obs_dist.log_prob(obs_seq[:, 1:].reshape(B * L, -1)))
-        rew_ll = jnp.mean(rew_dist.log_prob(rew_seq.reshape(-1)))
-        term_ll = jnp.mean(term_dist.log_prob(term_seq.reshape(-1)))
-        loss = self.hparams.kl_scale * kl - obs_ll - rew_ll - term_ll
+        dyn_loss = jnp.mean(jnp.maximum(dyn_kls, hp.free_nats))
+        rep_loss = jnp.mean(jnp.maximum(rep_kls, hp.free_nats))
+
+        obs_target = symlog(obs_seq[:, 1:].reshape(B * L, -1))
+        obs_loss = jnp.mean(jnp.square(obs_pred - obs_target))
+
+        # TwoHotHead.loss/.mean are plain array math (no nn.Dense/params
+        # of their own beyond what already produced `rew_logits` inside
+        # observe()'s .apply() context above), so a standalone instance -
+        # not bound to any params - can call them directly, the same
+        # pattern _actor_loss/_critic_loss use.
+        reward_head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
+        rew_loss = jnp.mean(reward_head.loss(rew_logits, rew_seq.reshape(-1)))
+        term_loss = jnp.mean(
+            optax.sigmoid_binary_cross_entropy(
+                jnp.squeeze(term_logits, -1), term_seq.reshape(-1)
+            )
+        )
+
+        loss = (
+            hp.dyn_scale * dyn_loss
+            + hp.rep_scale * rep_loss
+            + obs_loss
+            + rew_loss
+            + term_loss
+        )
         logs = {
-            "agent/model/kl": kl,
-            "agent/model/log_p_obs": -obs_ll,
-            "agent/model/log_p_rew": -rew_ll,
-            "agent/model/log_p_term": -term_ll,
+            "agent/model/dyn_kl": dyn_loss,
+            "agent/model/rep_kl": rep_loss,
+            "agent/model/obs_loss": obs_loss,
+            "agent/model/rew_loss": rew_loss,
+            "agent/model/term_loss": term_loss,
         }
         return loss, (feats, logs)
 
-    def _actor_loss(self, actor_params, model_params, critic_params, start_feats, rng):
+    def _actor_critic_rollout(self, model_params, actor_params, start_feats, rng):
+        """Shared imagination rollout for both the actor and critic
+        losses - both need the same `(feats, rewards, continues, actions,
+        logps)`, so this factors it out rather than re-running `imagine()`
+        (a full `imag_horizon`-step scan) twice per Dreamer.update()."""
         hp = self.hparams
         h0, z0 = start_feats[:, : hp.deter_size], start_feats[:, hp.deter_size :]
 
         def actor_logits_fn(feat):
             return self.actor.apply({"params": actor_params}, feat)
 
-        feats, rews, terms = self.world.apply(
+        feats, rews, term_logits, actions, logps = self.world.apply(
             {"params": model_params},
             h0,
             z0,
@@ -735,62 +929,92 @@ class Dreamer(Agent):
             rng,
             method=WorldModel.imagine,
         )
-        # vals_tp1 = V(feats[1:]) bootstraps each reward with the *next*
-        # imagined state's value, so it only covers H-1 pairs (there's no
-        # feats[H] within this rollout to bootstrap the last reward with)
-        # - truncate rews/terms to match rather than the full H-length
-        # rollout.
-        vals_tp1 = jax.vmap(self.critic.apply, in_axes=(None, 0))(
-            {"params": critic_params}, feats[:, 1:]
+        continues = 1.0 - jax.nn.sigmoid(term_logits)
+        return feats, rews, continues, actions, logps
+
+    def _actor_loss(
+        self, actor_params, model_params, critic_params, start_feats, return_norm_scale, rng
+    ):
+        hp = self.hparams
+        feats, rews, continues, actions, _ = self._actor_critic_rollout(
+            model_params, actor_params, start_feats, rng
         )
-        lam_vals = self._compute_lambda_values(
-            vals_tp1, rews[:, :-1], terms[:, :-1], hp.discount, hp.lam
+        # vals covers the full imagined horizon including the start state
+        # (feats[:, 0] is the real posterior feature the rollout began
+        # from), so lambda-returns/advantages align 1:1 with each
+        # imagined transition, unlike bootstrapping from feats[:, 1:]
+        # only (which would drop the last transition's target entirely).
+        head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
+        vals_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(
+            {"params": critic_params}, feats
         )
-        disc = self._discount_weights(hp.discount, hp.imag_horizon - 1)
-        loss = -(lam_vals * disc).mean()
-        entropy = (
-            distrax.Categorical(
-                logits=self.actor.apply({"params": actor_params}, start_feats)
-            )
-            .entropy()
-            .mean()
+        vals = head.mean(vals_logits)
+        targets = jax.lax.stop_gradient(
+            self._lambda_returns(vals[:, 1:], rews[:, :-1], continues[:, :-1], hp.discount, hp.lam)
         )
-        logs = {"agent/actor/loss": loss, "agent/actor/entropy": entropy}
+        adv = jax.lax.stop_gradient((targets - vals[:, :-1]) / return_norm_scale)
+
+        # REINFORCE: log_prob(sg(action)) * sg(advantage), not backprop
+        # through the sampled discrete action - distrax.Categorical.
+        # sample() has no gradient w.r.t. its logits (no reparameterization
+        # for discrete distributions), so differentiating an imagined
+        # return through a *sampled* action trains nothing through that
+        # path. Recompute log_prob under the current actor_params (the
+        # rollout's own logps were computed under a frozen snapshot for
+        # the imagination pass, but grad must flow through actor_params
+        # here).
+        actor_logits = jax.vmap(
+            lambda f: self.actor.apply({"params": actor_params}, f)
+        )(feats[:, :-1])
+        dist = distrax.Categorical(logits=actor_logits)
+        logp = dist.log_prob(jax.lax.stop_gradient(actions[:, :-1]))
+        entropy = dist.entropy()
+        policy_loss = -(logp * adv + hp.actor_entropy * entropy)
+        loss = policy_loss.mean()
+        logs = {
+            "agent/actor/loss": loss,
+            "agent/actor/entropy": entropy.mean(),
+            "agent/actor/adv": adv.mean(),
+        }
         return loss, logs
 
-    def _critic_loss(self, critic_params, model_params, actor_params, start_feats, rng):
+    def _critic_loss(
+        self, critic_params, model_params, actor_params, slow_critic_params, start_feats, rng
+    ):
         hp = self.hparams
-        h0, z0 = start_feats[:, : hp.deter_size], start_feats[:, hp.deter_size :]
-
-        def actor_logits_fn(feat):
-            return self.actor.apply({"params": actor_params}, feat)
-
-        feats, rews, terms = self.world.apply(
-            {"params": model_params},
-            h0,
-            z0,
-            actor_logits_fn,
-            hp.imag_horizon,
-            rng,
-            method=WorldModel.imagine,
+        feats, rews, continues, actions, _ = self._actor_critic_rollout(
+            model_params, actor_params, start_feats, rng
         )
-        vals_tp1 = jax.vmap(self.critic.apply, in_axes=(None, 0))(
-            {"params": critic_params}, feats[:, 1:]
+        head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
+        vals_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(
+            {"params": critic_params}, feats
         )
+        vals = jax.vmap(head.mean)(vals_logits)
         targets = jax.lax.stop_gradient(
-            self._compute_lambda_values(
-                vals_tp1, rews[:, :-1], terms[:, :-1], hp.discount, hp.lam
-            )
+            self._lambda_returns(vals[:, 1:], rews[:, :-1], continues[:, :-1], hp.discount, hp.lam)
         )
-        # preds must align with targets' H-1 length, hence feats[:, :-1]
-        # (dropping the last imagined state, which targets has no
-        # lambda-return for - see _actor_loss's vals_tp1 comment).
-        preds = jax.vmap(self.critic.apply, in_axes=(None, 0))(
+
+        pred_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(
             {"params": critic_params}, feats[:, :-1]
         )
-        disc = self._discount_weights(hp.discount, hp.imag_horizon - 1)
-        loss = jnp.mean(((preds - targets) ** 2) * disc)
-        return loss, {"agent/critic/loss": loss}
+        regress_loss = jnp.mean(jax.vmap(head.loss)(pred_logits, targets))
+
+        slow_logits = jax.lax.stop_gradient(
+            jax.vmap(self.critic.apply, in_axes=(None, 0))(
+                {"params": slow_critic_params}, feats[:, :-1]
+            )
+        )
+        slow_target = jax.lax.stop_gradient(head.mean(slow_logits))
+        slow_reg_loss = jnp.mean(jax.vmap(head.loss)(pred_logits, slow_target))
+
+        loss = regress_loss + hp.slow_critic_reg * slow_reg_loss
+        logs = {
+            "agent/critic/loss": loss,
+            "agent/critic/regress_loss": regress_loss,
+            "agent/critic/slow_reg_loss": slow_reg_loss,
+            "agent/critic/value": vals.mean(),
+        }
+        return loss, logs
 
     # ---------- One update (collect + model/actor/critic) ----------
 
@@ -827,7 +1051,7 @@ class Dreamer(Agent):
         # rollouts from, reusing the just-updated model.
         rng, key_batch, key_observe = jax.random.split(rng, 3)
         obs_seq, act_seq, _, _ = self._sample_batch(key_batch, experience)
-        _, _, _, feats = self.world.apply(
+        _, _, feats, _, _, _ = self.world.apply(
             {"params": model.params},
             obs_seq,
             act_seq,
@@ -838,12 +1062,38 @@ class Dreamer(Agent):
             feats[:, :-1].reshape(-1, feats.shape[-1])
         )
 
+        # Return-normalization scale: EMA-tracked 5th/95th percentile of
+        # a quick lambda-return estimate under the current critic, so the
+        # actor's advantage is on a comparable scale regardless of the
+        # environment's raw reward magnitude.
+        probe_feats, probe_rews, probe_continues, _, _ = self._actor_critic_rollout(
+            model.params, ts.actor.params, start_feats, rng
+        )
+        head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
+        probe_vals_logits = jax.vmap(self.critic.apply, in_axes=(None, 0))(
+            {"params": ts.critic.params}, probe_feats
+        )
+        probe_vals = jax.vmap(head.mean)(probe_vals_logits)
+        probe_returns = self._lambda_returns(
+            probe_vals[:, 1:], probe_rews[:, :-1], probe_continues[:, :-1], hp.discount, hp.lam
+        )
+        lo = jnp.percentile(probe_returns, 5)
+        hi = jnp.percentile(probe_returns, 95)
+        rate = hp.return_norm_rate
+        return_norm_lo = (1 - rate) * ts.return_norm_lo + rate * lo
+        return_norm_hi = (1 - rate) * ts.return_norm_hi + rate * hi
+        return_norm_scale = jnp.maximum(
+            return_norm_hi - return_norm_lo, hp.return_norm_limit
+        )
+
         def actor_step(carry, _):
             actor, rng = carry
             rng, key = jax.random.split(rng)
 
             def loss_fn(p):
-                return self._actor_loss(p, model.params, ts.critic.params, start_feats, key)
+                return self._actor_loss(
+                    p, model.params, ts.critic.params, start_feats, return_norm_scale, key
+                )
 
             (loss, alogs), grads = jax.value_and_grad(loss_fn, has_aux=True)(
                 actor.params
@@ -864,7 +1114,9 @@ class Dreamer(Agent):
             rng, key = jax.random.split(rng)
 
             def loss_fn(p):
-                return self._critic_loss(p, model.params, actor.params, start_feats, key)
+                return self._critic_loss(
+                    p, model.params, actor.params, ts.slow_critic_params, start_feats, key
+                )
 
             (loss, clogs), grads = jax.value_and_grad(loss_fn, has_aux=True)(
                 critic.params
@@ -880,12 +1132,22 @@ class Dreamer(Agent):
         )
         clogs = jax.tree.map(lambda x: jnp.mean(x), clogs)
 
+        slow_critic_params = jax.tree.map(
+            lambda slow, online: (1 - hp.slow_critic_rate) * slow
+            + hp.slow_critic_rate * online,
+            ts.slow_critic_params,
+            critic.params,
+        )
+
         ts = ts.replace(
             model=model,
             actor=actor,
             critic=critic,
+            slow_critic_params=slow_critic_params,
             rng=rng,
             updates=ts.updates + 1,
+            return_norm_lo=return_norm_lo,
+            return_norm_hi=return_norm_hi,
         )
 
         logs = {}
@@ -900,6 +1162,7 @@ class Dreamer(Agent):
         logs["iter/model_lr"] = self.hparams.model_lr
         logs["iter/actor_lr"] = self.hparams.actor_lr
         logs["iter/critic_lr"] = self.hparams.critic_lr
+        logs["agent/return_norm_scale"] = return_norm_scale
 
         if self.hparams.log_render:
             from ..observations import rgb
@@ -937,8 +1200,8 @@ class Dreamer(Agent):
             jnp.zeros((1, self.world.act_dim)),
             method=WorldModel.init_probe,
         )
-        a_variables = self.actor.init(ak, jnp.zeros((1, hp.deter_size + hp.stoch_size)))
-        c_variables = self.critic.init(ck, jnp.zeros((1, hp.deter_size + hp.stoch_size)))
+        a_variables = self.actor.init(ak, jnp.zeros((1, hp.deter_size + hp.stoch_flat)))
+        c_variables = self.critic.init(ck, jnp.zeros((1, hp.deter_size + hp.stoch_flat)))
 
         model_tx = optax.chain(
             optax.clip_by_global_norm(hp.max_grad_norm), optax.adam(hp.model_lr)
@@ -970,10 +1233,13 @@ class Dreamer(Agent):
             model=model_state,
             actor=actor_state,
             critic=critic_state,
+            slow_critic_params=c_variables["params"],
             env_state=env_state,
             rng=rng,
             frames=jnp.asarray(0, dtype=jnp.int32),
             updates=jnp.asarray(0, dtype=jnp.int32),
+            return_norm_lo=jnp.asarray(0.0, dtype=jnp.float32),
+            return_norm_hi=jnp.asarray(0.0, dtype=jnp.float32),
             h=h0,
             z=z0,
             a_prev_oh=a0,

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -210,7 +210,11 @@ class Encoder(nn.Module):
                 nn.Dense(self.embed_size),
             ]
         )
-        return net(rlax.signed_logp1(obs))
+        # rlax.signed_logp1 (unlike the hand-rolled symlog it replaced)
+        # asserts its input is already float via chex.assert_type - navix
+        # observations can be uint8 (e.g. `categorical`/`symbolic`), so
+        # cast explicitly rather than relying on implicit promotion.
+        return net(rlax.signed_logp1(obs.astype(jnp.float32)))
 
 
 class Decoder(nn.Module):

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -99,9 +99,9 @@ def unimix_categorical(logits: Array, unimix: float) -> distrax.Categorical:
     """Builds a `distrax.Categorical` from `logits` after mixing in a
     `unimix` fraction of uniform probability mass across the last axis -
     the "unimix" trick (1% by default in the paper): guarantees every
-    class keeps at least `unimix / classes` probability, so neither the
-    KL term nor the entropy can collapse to exactly zero, which keeps the
-    prior from ever fully committing and losing gradient signal."""
+    class keeps at least `unimix / num_classes` probability, so neither
+    the KL term nor the entropy can collapse to exactly zero, which keeps
+    the prior from ever fully committing and losing gradient signal."""
     probs = jax.nn.softmax(logits, axis=-1)
     uniform = jnp.ones_like(probs) / probs.shape[-1]
     probs = (1.0 - unimix) * probs + unimix * uniform
@@ -124,11 +124,12 @@ def straight_through_sample(dist: distrax.Categorical, rng: Array) -> Array:
 
 
 def categorical_kl(post: distrax.Categorical, prior: distrax.Categorical) -> Array:
-    """Sum of `KL(post_i || prior_i)` over the `stoch` independent
+    """Sum of `KL(post_i || prior_i)` over the `num_latents` independent
     categoricals (the second-to-last axis) - each categorical's own KL,
     summed, matching how DreamerV3 treats the full stochastic latent
-    (`stoch` categoricals of `classes` each) as one joint distribution
-    for the purposes of the free-nats floor."""
+    (`num_latents` categoricals of `num_classes` each, "stoch"/"classes"
+    in the official implementation) as one joint distribution for the
+    purposes of the free-nats floor."""
     return post.kl_divergence(prior).sum(axis=-1)
 
 
@@ -236,39 +237,51 @@ class Decoder(nn.Module):
 
 
 class RSSM(nn.Module):
-    deter_size: int
+    recurrent_size: int
+    """Size of the GRU's deterministic hidden state ("deter" in the
+    official implementation)."""
 
     @nn.compact
     def __call__(self, h_prev: Array, z_prev_flat: Array, a_prev_oh: Array) -> Array:
         x = jnp.concatenate([z_prev_flat, a_prev_oh], axis=-1)
-        gru = nn.GRUCell(features=self.deter_size)
+        gru = nn.GRUCell(features=self.recurrent_size)
         h, _ = gru(h_prev, x)  # GRUCell returns (new_carry, y); y == new_carry
         return h
 
 
 class PriorNet(nn.Module):
     hidden_size: int
-    stoch: int
-    classes: int
+    """Hidden layer size of the prior network's MLP."""
+    num_latents: int
+    """Number of independent categorical latent variables ("stoch" in
+    the official implementation)."""
+    num_classes: int
+    """Number of classes per categorical latent variable ("classes" in
+    the official implementation)."""
 
     @nn.compact
     def __call__(self, h: Array) -> Array:
-        """Returns raw logits, `(..., stoch, classes)` - unimix is applied
-        by the caller (`unimix_categorical`), not baked in here, so every
-        caller treats prior and posterior identically."""
+        """Returns raw logits, `(..., num_latents, num_classes)` - unimix
+        is applied by the caller (`unimix_categorical`), not baked in
+        here, so every caller treats prior and posterior identically."""
         x = nn.elu(nn.Dense(self.hidden_size)(h))
-        logits = nn.Dense(self.stoch * self.classes)(x)
-        return logits.reshape(*h.shape[:-1], self.stoch, self.classes)
+        logits = nn.Dense(self.num_latents * self.num_classes)(x)
+        return logits.reshape(*h.shape[:-1], self.num_latents, self.num_classes)
 
 
 class PostNet(nn.Module):
     hidden_size: int
-    stoch: int
-    classes: int
+    """Hidden layer size of the posterior network's MLP."""
+    num_latents: int
+    """Number of independent categorical latent variables ("stoch" in
+    the official implementation)."""
+    num_classes: int
+    """Number of classes per categorical latent variable ("classes" in
+    the official implementation)."""
 
     @nn.compact
     def __call__(self, h: Array, embed: Array) -> Array:
         x = jnp.concatenate([h, embed], axis=-1)
         x = nn.elu(nn.Dense(self.hidden_size)(x))
-        logits = nn.Dense(self.stoch * self.classes)(x)
-        return logits.reshape(*h.shape[:-1], self.stoch, self.classes)
+        logits = nn.Dense(self.num_latents * self.num_classes)(x)
+        return logits.reshape(*h.shape[:-1], self.num_latents, self.num_classes)

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -1,9 +1,20 @@
+"""Shared neural-network building blocks used across navix's agents.
+
+Two groups live here: PPO's encoder/actor-critic components
+(`MLPEncoder`, `ConvEncoder`, `ActorCritic`), and Dreamer's world-model
+components (categorical-latent utilities, the symexp-twohot head, and
+the RSSM's encoder/decoder/prior/posterior networks) - the reusable
+pieces `navix.agents.dreamer.WorldModel` wires together into an RSSM.
+See `navix.agents.dreamer`'s module docstring for the algorithm these
+latter components implement."""
+
 from functools import partial
 from typing import Callable, Sequence, Tuple
 from jax import Array
 import jax
 import jax.numpy as jnp
 import distrax
+import rlax
 import flax.linen as nn
 from flax.linen.initializers import constant, orthogonal
 
@@ -77,3 +88,187 @@ class ActorCritic(nn.Module):
 
     def value(self, x: Array) -> Array:
         return jnp.squeeze(self.critic(x), -1)
+
+
+# -------------------------
+# Dreamer: categorical latents - unimix + straight-through sampling
+# -------------------------
+
+
+def unimix_categorical(logits: Array, unimix: float) -> distrax.Categorical:
+    """Builds a `distrax.Categorical` from `logits` after mixing in a
+    `unimix` fraction of uniform probability mass across the last axis -
+    the "unimix" trick (1% by default in the paper): guarantees every
+    class keeps at least `unimix / classes` probability, so neither the
+    KL term nor the entropy can collapse to exactly zero, which keeps the
+    prior from ever fully committing and losing gradient signal."""
+    probs = jax.nn.softmax(logits, axis=-1)
+    uniform = jnp.ones_like(probs) / probs.shape[-1]
+    probs = (1.0 - unimix) * probs + unimix * uniform
+    return distrax.Categorical(probs=probs)
+
+
+def straight_through_sample(dist: distrax.Categorical, rng: Array) -> Array:
+    """Samples a one-hot vector from `dist`, with a straight-through
+    gradient: the forward value is a genuine (discrete) sample, but the
+    backward gradient flows as if the output were `dist.probs` directly
+    (`sg(onehot - probs) + probs` has forward value `onehot`, since
+    `onehot - probs` is stop-gradiented, but its Jacobian w.r.t. upstream
+    parameters is `probs`'s). This is what makes the RSSM's own latent
+    trainable end-to-end despite being discrete - distinct from Dreamer's
+    *actor* action sampling, which deliberately does NOT use this (see
+    `navix.agents.dreamer`'s module docstring)."""
+    idx = dist.sample(seed=rng)
+    onehot = jax.nn.one_hot(idx, dist.probs.shape[-1])
+    return jax.lax.stop_gradient(onehot - dist.probs) + dist.probs
+
+
+def categorical_kl(post: distrax.Categorical, prior: distrax.Categorical) -> Array:
+    """Sum of `KL(post_i || prior_i)` over the `stoch` independent
+    categoricals (the second-to-last axis) - each categorical's own KL,
+    summed, matching how DreamerV3 treats the full stochastic latent
+    (`stoch` categoricals of `classes` each) as one joint distribution
+    for the purposes of the free-nats floor."""
+    return post.kl_divergence(prior).sum(axis=-1)
+
+
+# -------------------------
+# Dreamer: symexp-twohot head (reward, value)
+# -------------------------
+
+
+class TwoHotHead(nn.Module):
+    """A scalar-valued prediction head (reward, value) implemented as
+    classification over `bins` evenly-spaced bins in symlog space, with a
+    twohot cross-entropy loss - the "symexp twohot" head from the paper.
+    Far more robust to reward/value outliers than a Gaussian/MSE head,
+    since an extreme target only ever saturates the loss for its two
+    nearest bins, not the whole (unbounded) squared-error term."""
+
+    hidden_size: int
+    bins: int = 255
+    low: float = -20.0
+    high: float = 20.0
+
+    @nn.compact
+    def __call__(self, feat: Array) -> Array:
+        # The output layer is ZERO-initialized (official implementation's
+        # `outscale: 0.0` for the reward/critic heads): all-zero logits ->
+        # uniform bin probabilities -> mean symexp(sum(p*bins)) = symexp(0)
+        # = 0 exactly, so an untrained head predicts 0, not symexp of
+        # whatever random logits happen to sum to over bins spanning
+        # symlog +-20 - which can reach +-e^20. Without this, the very
+        # first imagination rollouts feed the actor advantages of garbage
+        # magnitude; the return-normalization EMA (rate 0.01) is far too
+        # slow to absorb that, and ~64 gradient steps of it were observed
+        # to slam the actor into a deterministic policy (entropy pinned at
+        # the unimix floor) before the world model had learned anything -
+        # after which exploration never recovers.
+        net = nn.Sequential(
+            [
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.bins, kernel_init=nn.initializers.zeros),
+            ]
+        )
+        return net(feat)  # logits, (..., bins)
+
+    def loss(self, logits: Array, target: Array) -> Array:
+        twohot = rlax.transform_to_2hot(
+            rlax.signed_logp1(target), self.low, self.high, self.bins
+        )
+        logp = jax.nn.log_softmax(logits, axis=-1)
+        return -jnp.sum(twohot * logp, axis=-1)
+
+    def mean(self, logits: Array) -> Array:
+        probs = jax.nn.softmax(logits, axis=-1)
+        return rlax.signed_expm1(
+            rlax.transform_from_2hot(probs, self.low, self.high, self.bins)
+        )
+
+
+# -------------------------
+# Dreamer: RSSM building blocks (encoder/decoder/prior/posterior)
+# -------------------------
+
+
+class Encoder(nn.Module):
+    hidden_size: int
+    embed_size: int
+
+    @nn.compact
+    def __call__(self, obs: Array) -> Array:
+        net = nn.Sequential(
+            [
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.embed_size),
+            ]
+        )
+        return net(rlax.signed_logp1(obs))
+
+
+class Decoder(nn.Module):
+    hidden_size: int
+    obs_dim: int
+
+    @nn.compact
+    def __call__(self, feat: Array) -> Array:
+        """Returns a prediction of `symlog(obs)` directly (not a
+        distribution) - reconstruction loss is plain MSE against
+        `symlog(obs)`, the paper's "symlog MSE" observation head, simpler
+        than the image-specific decoder the official implementation uses
+        since navix's observations here are flat vectors, not pixels."""
+        net = nn.Sequential(
+            [
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.hidden_size),
+                nn.elu,
+                nn.Dense(self.obs_dim),
+            ]
+        )
+        return net(feat)
+
+
+class RSSM(nn.Module):
+    deter_size: int
+
+    @nn.compact
+    def __call__(self, h_prev: Array, z_prev_flat: Array, a_prev_oh: Array) -> Array:
+        x = jnp.concatenate([z_prev_flat, a_prev_oh], axis=-1)
+        gru = nn.GRUCell(features=self.deter_size)
+        h, _ = gru(h_prev, x)  # GRUCell returns (new_carry, y); y == new_carry
+        return h
+
+
+class PriorNet(nn.Module):
+    hidden_size: int
+    stoch: int
+    classes: int
+
+    @nn.compact
+    def __call__(self, h: Array) -> Array:
+        """Returns raw logits, `(..., stoch, classes)` - unimix is applied
+        by the caller (`unimix_categorical`), not baked in here, so every
+        caller treats prior and posterior identically."""
+        x = nn.elu(nn.Dense(self.hidden_size)(h))
+        logits = nn.Dense(self.stoch * self.classes)(x)
+        return logits.reshape(*h.shape[:-1], self.stoch, self.classes)
+
+
+class PostNet(nn.Module):
+    hidden_size: int
+    stoch: int
+    classes: int
+
+    @nn.compact
+    def __call__(self, h: Array, embed: Array) -> Array:
+        x = jnp.concatenate([h, embed], axis=-1)
+        x = nn.elu(nn.Dense(self.hidden_size)(x))
+        logits = nn.Dense(self.stoch * self.classes)(x)
+        return logits.reshape(*h.shape[:-1], self.stoch, self.classes)

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -243,7 +243,7 @@ def test_dreamer_actor_gradient_is_nonzero():
     # policy. Assert the actor's gradient is actually non-zero.
     dreamer = _make_dreamer()
     ts = dreamer._init_train_state(jax.random.PRNGKey(0))
-    ts, experience = dreamer._collect(ts)
+    ts, experience = dreamer.collect_experience(ts)
     replay = dreamer._write_replay(ts.replay, experience)
     obs_seq, act_seq, _, first_seq, _ = dreamer._sample_batch(
         jax.random.PRNGKey(1), replay
@@ -283,7 +283,7 @@ def test_dreamer_actor_entropy_never_reaches_exactly_zero():
     # Regression test for a training-stability bug found while
     # benchmarking whether Dreamer actually learns: with no floor on the
     # actor's action distribution, its entropy could reach exactly 0.0.
-    # Once it does, _collect() (which samples actions from this same
+    # Once it does, collect_experience() (which samples actions from this same
     # distribution) stops exploring too - real data collection narrows
     # to whatever the collapsed policy repeats, the world model overfits
     # to that narrow trajectory, and there's no path back. Verified

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -32,6 +32,7 @@ from navix.agents.dreamer import (
     WorldModel,
     Actor,
     Critic,
+    Replay,
     symlog,
     symexp,
     unimix_categorical,
@@ -265,12 +266,15 @@ def test_dreamer_actor_gradient_is_nonzero():
     dreamer = _make_dreamer()
     ts = dreamer._init_train_state(jax.random.PRNGKey(0))
     ts, experience = dreamer._collect(ts)
-    obs_seq, act_seq, _, term_seq = dreamer._sample_batch(jax.random.PRNGKey(1), experience)
+    replay = dreamer._write_replay(ts.replay, experience)
+    obs_seq, act_seq, _, first_seq, _ = dreamer._sample_batch(
+        jax.random.PRNGKey(1), replay
+    )
     _, _, feats, _, _, _ = dreamer.world.apply(
         {"params": ts.model.params},
         obs_seq,
         act_seq,
-        term_seq,
+        first_seq,
         method=WorldModel.observe,
         rngs={"sample": jax.random.PRNGKey(2)},
     )
@@ -324,6 +328,135 @@ def test_dreamer_actor_entropy_never_reaches_exactly_zero():
     )
 
 
+def test_dreamer_replay_buffer_retains_past_rollouts():
+    # Regression test for a structural divergence from DreamerV3 found
+    # while investigating why learning never consolidated: there was no
+    # replay buffer at all - the world model trained only on the rollout
+    # just collected, so a rare success transition (sparse reward) was
+    # seen by the reward head for exactly one update and then thrown
+    # away, and imagination went straight back to predicting zero reward
+    # everywhere. DreamerV3 is replay-based by design; assert that past
+    # rollouts really accumulate across updates.
+    dreamer = _make_dreamer(budget=8 * 4 * 3)  # -> exactly 3 updates
+    ts, _ = jax.jit(dreamer.train)(jax.random.PRNGKey(0))
+    assert int(ts.replay.size) == 3, (
+        f"expected the replay buffer to hold all 3 collected rollouts, "
+        f"got size={int(ts.replay.size)}"
+    )
+    # capacity is never allocated beyond what the budget can fill
+    assert ts.replay.obs.shape[0] == 3
+
+
+def test_dreamer_imagination_weight_and_states_are_action_aligned():
+    # Regression test for an off-by-one in imagined-rollout credit
+    # assignment: imagine()'s scan emits only *resulting* states, so
+    # actions[t] was taken FROM feats_in[t] (start_feats at t=0), not
+    # from feats[t] - and the per-step loss weight must be the
+    # probability the trajectory is still alive when the action is
+    # *taken* (continues of earlier states only). The old code used
+    # cumprod(discount*continues)/discount over the outcome states,
+    # which multiplied each action's loss by 1 - P(terminal | its own
+    # outcome): the action that reaches the goal - the one gradient
+    # carrying the sparse reward signal - was scaled toward zero exactly
+    # when the term head (correctly!) predicted the goal ends the
+    # episode.
+    dreamer = _make_dreamer()
+    hp = dreamer.hparams
+    ts = dreamer._init_train_state(jax.random.PRNGKey(0))
+    start_feats = jax.random.normal(
+        jax.random.PRNGKey(1), (5, hp.deter_size + hp.stoch_flat)
+    )
+    feats_in, feats, rews, continues, actions, weight = dreamer._actor_critic_rollout(
+        ts.model.params, ts.actor.params, start_feats, jax.random.PRNGKey(2)
+    )
+    # the state each action was taken from: the seed at t=0, then the
+    # previous step's outcome
+    np.testing.assert_allclose(feats_in[:, 0], start_feats, atol=1e-6)
+    np.testing.assert_allclose(feats_in[:, 1:], feats[:, :-1], atol=1e-6)
+    # actions at the (real) seed states always get full weight...
+    np.testing.assert_allclose(weight[:, 0], 1.0, atol=1e-6)
+    # ...and weight[t] accumulates only discount/continuation of states
+    # *before* the action, never the action's own outcome
+    np.testing.assert_allclose(
+        weight[:, 1], hp.discount * continues[:, 0], atol=1e-5
+    )
+    np.testing.assert_allclose(
+        weight[:, 2], hp.discount**2 * continues[:, 0] * continues[:, 1], atol=1e-5
+    )
+
+
+def test_dreamer_untrained_heads_predict_zero_and_near_uniform_policy():
+    # Regression test for a training-collapse mechanism found by
+    # benchmarking: TwoHotHead's bins span symlog +-20, so a *randomly*
+    # initialized reward/value head emits symexp values of garbage
+    # magnitude (up to +-e^20) in the very first imagination rollouts -
+    # advantages built from those slammed the actor into a deterministic
+    # policy (entropy pinned at the unimix floor) within ~64 gradient
+    # steps, before the world model had learned anything real, and
+    # exploration never recovered. The official implementation
+    # zero-initializes these heads' output layers (`outscale: 0.0`) so an
+    # untrained head predicts exactly 0; the actor's output layer is
+    # near-zero-initialized so the initial policy is near-uniform.
+    dreamer = _make_dreamer()
+    hp = dreamer.hparams
+    ts = dreamer._init_train_state(jax.random.PRNGKey(0))
+    feat = jax.random.normal(
+        jax.random.PRNGKey(1), (7, hp.deter_size + hp.stoch_flat)
+    )
+    head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
+    vals = head.mean(dreamer.critic.apply({"params": ts.critic.params}, feat))
+    np.testing.assert_allclose(np.asarray(vals), 0.0, atol=1e-5)
+    probs = jax.nn.softmax(
+        dreamer.actor.apply({"params": ts.actor.params}, feat), axis=-1
+    )
+    act_dim = probs.shape[-1]
+    np.testing.assert_allclose(np.asarray(probs), 1.0 / act_dim, atol=0.02)
+
+
+def test_dreamer_sample_batch_shifts_done_into_first_flags():
+    # Regression test for an off-by-one in episode-boundary masking:
+    # navix DEFERS autoreset to the next env.step() call, so done[t] == 1
+    # means obs[t+1] is the genuine terminal observation (the goal
+    # actually reached by act[t], carrying the episode's reward) and it's
+    # obs[t+2] that is the exogenous reset. observe()'s is_first mask for
+    # scan step t must therefore be done[t-1], not done[t] - masking
+    # unshifted zeroed the belief state exactly at the goal-reaching
+    # transition, so the reward/term heads learned to associate the
+    # sparse reward with a blank-context latent that imagination (always
+    # full-context) never produces: imagined rollouts saw no reward at
+    # all, and the actor's advantage signal was identically ~0 while the
+    # policy stayed uniform (verified over full 100k-frame runs).
+    dreamer = _make_dreamer(seq_len=4)
+    L, T, N = 4, 6, 1
+    done = np.zeros((1, T, N), dtype=bool)
+    done[0, 2, 0] = True
+    term = np.zeros((1, T, N), dtype=bool)
+    term[0, 3, 0] = True
+    replay = Replay(
+        obs=jnp.zeros((1, T, N, 3)),
+        action=jnp.zeros((1, T, N), dtype=jnp.int32),
+        reward=jnp.arange(T, dtype=jnp.float32).reshape(1, T, 1),
+        done=jnp.asarray(done),
+        termination=jnp.asarray(term),
+        idx=jnp.asarray(1, dtype=jnp.int32),
+        size=jnp.asarray(1, dtype=jnp.int32),
+    )
+    # T - (seq_len + 1) = 1, so the only valid window start is index 1 -
+    # the sample is fully deterministic despite the random key.
+    obs_seq, act_seq, rew_seq, first_seq, terminal_seq = dreamer._sample_batch(
+        jax.random.PRNGKey(0), replay
+    )
+    np.testing.assert_allclose(
+        np.asarray(first_seq[0]), done[0, 0:L, 0].astype(np.float32)
+    )
+    np.testing.assert_allclose(
+        np.asarray(terminal_seq[0]), term[0, 1 : L + 1, 0].astype(np.float32)
+    )
+    np.testing.assert_allclose(
+        np.asarray(rew_seq[0]), np.arange(1, L + 1, dtype=np.float32)
+    )
+
+
 if __name__ == "__main__":
     test_dreamer_is_an_agent()
     test_dreamer_trains_one_update_without_nans()
@@ -338,3 +471,7 @@ if __name__ == "__main__":
     test_dreamer_slow_critic_tracks_online_critic_via_ema()
     test_dreamer_actor_gradient_is_nonzero()
     test_dreamer_actor_entropy_never_reaches_exactly_zero()
+    test_dreamer_replay_buffer_retains_past_rollouts()
+    test_dreamer_imagination_weight_and_states_are_action_aligned()
+    test_dreamer_untrained_heads_predict_zero_and_near_uniform_policy()
+    test_dreamer_sample_batch_shifts_done_into_first_flags()

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import numpy as np
 import jax
 import jax.numpy as jnp
+import distrax
 
 import navix as nx
 from navix.agents.agent import Agent
@@ -31,6 +32,12 @@ from navix.agents.dreamer import (
     WorldModel,
     Actor,
     Critic,
+    symlog,
+    symexp,
+    unimix_categorical,
+    straight_through_sample,
+    twohot_encode,
+    TwoHotHead,
 )
 
 
@@ -50,7 +57,9 @@ def _make_dreamer(**hparam_overrides) -> Dreamer:
         imag_horizon=hparam_overrides.pop("imag_horizon", 3),
         embed_size=hparam_overrides.pop("embed_size", 8),
         deter_size=hparam_overrides.pop("deter_size", 8),
-        stoch_size=hparam_overrides.pop("stoch_size", 4),
+        stoch=hparam_overrides.pop("stoch", 3),
+        classes=hparam_overrides.pop("classes", 4),
+        bins=hparam_overrides.pop("bins", 11),
         hidden_size=hparam_overrides.pop("hidden_size", 8),
         **hparam_overrides,
     )
@@ -59,7 +68,7 @@ def _make_dreamer(**hparam_overrides) -> Dreamer:
     act_dim = len(env.action_set)
     world = WorldModel(obs_dim=obs_dim, act_dim=act_dim, hparams=hp)
     actor = Actor(act_dim=act_dim, hidden=hp.hidden_size)
-    critic = Critic(hidden=hp.hidden_size)
+    critic = Critic(hidden=hp.hidden_size, bins=hp.bins, low=hp.bins_low, high=hp.bins_high)
     return Dreamer(hparams=hp, env=env, world=world, actor=actor, critic=critic)
 
 
@@ -140,8 +149,163 @@ def test_dreamer_logs_flow_through_agent_log_to_wandb():
     assert "perf/success_rate" in logged
 
 
+def test_symlog_symexp_are_inverses():
+    # symexp(symlog(x)) is the direction actually used in the code (real
+    # values -> compressed symlog space and back). symlog(symexp(x)) is
+    # only meaningful for x already in symlog-space's realistic range
+    # (roughly [-20, 20], matching TwoHotHead's default bin range) -
+    # symexp(1000) alone overflows float32 (e^1000), so that direction
+    # isn't tested at real-value magnitudes.
+    x = jnp.asarray([-1000.0, -1.0, 0.0, 1.0, 1000.0])
+    np.testing.assert_allclose(symexp(symlog(x)), x, atol=1e-4)
+    x_small = jnp.asarray([-15.0, -1.0, 0.0, 1.0, 15.0])
+    np.testing.assert_allclose(symlog(symexp(x_small)), x_small, atol=1e-3)
+
+
+def test_unimix_floors_every_class_probability():
+    # https://arxiv.org/abs/2301.04104 - "1% unimix": no class should
+    # ever reach exactly zero probability, however confident the raw
+    # logits are, so the KL/entropy terms never fully collapse.
+    logits = jnp.asarray([[100.0, -100.0, -100.0, -100.0]])  # near one-hot
+    unimix = 0.01
+    dist = unimix_categorical(logits, unimix)
+    classes = logits.shape[-1]
+    assert jnp.all(dist.probs >= unimix / classes - 1e-6), (
+        f"expected every class to keep at least unimix/classes probability, "
+        f"got {dist.probs}"
+    )
+
+
+def test_straight_through_sample_is_onehot_but_differentiable():
+    # forward value must be a genuine one-hot sample (not the soft probs),
+    # but the gradient w.r.t. the logits that produced it must be
+    # non-zero - the whole point of straight-through gradients over a
+    # discrete sample.
+    logits = jnp.asarray([2.0, 0.5, -1.0, 0.1])
+    rng = jax.random.PRNGKey(0)
+    dist = distrax.Categorical(logits=logits)
+    sample = straight_through_sample(dist, rng)
+    assert sample.shape == logits.shape
+    np.testing.assert_allclose(jnp.sum(sample), 1.0, atol=1e-5)
+    assert jnp.all((sample >= 0) & (sample <= 1))
+
+    def f(logits):
+        d = distrax.Categorical(logits=logits)
+        return jnp.sum(straight_through_sample(d, rng) * jnp.arange(4.0))
+
+    grad = jax.grad(f)(logits)
+    assert not jnp.allclose(grad, 0.0), (
+        "expected a non-zero gradient through the straight-through sample - "
+        "got all zeros, meaning the estimator degenerated to a plain "
+        "(non-differentiable) discrete sample"
+    )
+
+
+def test_twohot_encode_sums_to_one_and_decodes_near_target():
+    bin_centers = jnp.linspace(-5.0, 5.0, 11)
+    for x in [-5.0, -3.3, 0.0, 2.7, 5.0]:
+        twohot = twohot_encode(jnp.asarray(x), bin_centers)
+        np.testing.assert_allclose(jnp.sum(twohot), 1.0, atol=1e-5)
+        assert jnp.sum(twohot > 0) <= 2
+        decoded = jnp.sum(twohot * bin_centers)
+        np.testing.assert_allclose(decoded, x, atol=1e-4)
+
+
+def test_twohot_head_loss_is_minimised_at_the_target():
+    # a head whose logits already encode the target exactly should have
+    # ~zero loss; a mismatched target should cost strictly more.
+    head = TwoHotHead(hidden_size=4, bins=21, low=-5.0, high=5.0)
+    bin_centers = jnp.linspace(-5.0, 5.0, 21)
+    target = jnp.asarray([1.3])
+    twohot = twohot_encode(symlog(target), bin_centers)  # already (1, bins)
+    matching_logits = jnp.log(twohot + 1e-8)
+    loss_matching = head.loss(matching_logits, target)
+    loss_mismatched = head.loss(matching_logits, jnp.asarray([-3.0]))
+    assert float(loss_matching[0]) < float(loss_mismatched[0])
+
+
+def test_dreamer_kl_balance_has_two_distinct_terms():
+    # DreamerV3's KL loss is two terms with different stop-gradient
+    # placement (dyn = KL(sg(post)||prior), rep = KL(post||sg(prior))),
+    # not one combined KL clamped by a single free-bits scalar - assert
+    # both show up as separate, independently-computed log entries.
+    dreamer = _make_dreamer(budget=8 * 4)
+    ts, logs = jax.jit(dreamer.train)(jax.random.PRNGKey(0))
+    assert "agent/model/dyn_kl" in logs
+    assert "agent/model/rep_kl" in logs
+
+
+def test_dreamer_slow_critic_tracks_online_critic_via_ema():
+    dreamer = _make_dreamer(slow_critic_rate=0.5)
+    ts, _ = jax.jit(dreamer.train_first_update)(jax.random.PRNGKey(0))
+    # after one update, the slow critic should have moved partway from
+    # its (shared) initial params toward the online critic's post-update
+    # params - neither identical to the online critic (rate < 1) nor to
+    # the pre-update initial params (rate > 0).
+    diffs = jax.tree.map(
+        lambda slow, online: jnp.max(jnp.abs(slow - online)),
+        ts.slow_critic_params,
+        ts.critic.params,
+    )
+    max_diff = max(float(d) for d in jax.tree.leaves(diffs))
+    assert max_diff > 0, (
+        "expected the slow critic to differ from the online critic after "
+        "training (rate=0.5, not 0 or 1) - got identical params, EMA "
+        "update likely not applied"
+    )
+
+
+def test_dreamer_actor_gradient_is_nonzero():
+    # Regression test for a bug found implementing DreamerV3 properly:
+    # differentiating an imagined return through a *sampled* discrete
+    # action (distrax.Categorical.sample() has no gradient w.r.t. its
+    # logits) trains nothing through that path - only REINFORCE
+    # (log_prob(action) * advantage) has a real gradient for a discrete
+    # policy. Assert the actor's gradient is actually non-zero.
+    dreamer = _make_dreamer()
+    ts = dreamer._init_train_state(jax.random.PRNGKey(0))
+    ts, experience = dreamer._collect(ts)
+    obs_seq, act_seq, _, _ = dreamer._sample_batch(jax.random.PRNGKey(1), experience)
+    _, _, feats, _, _, _ = dreamer.world.apply(
+        {"params": ts.model.params},
+        obs_seq,
+        act_seq,
+        method=WorldModel.observe,
+        rngs={"sample": jax.random.PRNGKey(2)},
+    )
+    start_feats = jax.lax.stop_gradient(feats[:, :-1].reshape(-1, feats.shape[-1]))
+    return_norm_scale = jnp.asarray(1.0)
+
+    def loss_fn(actor_params):
+        return dreamer._actor_loss(
+            actor_params,
+            ts.model.params,
+            ts.critic.params,
+            start_feats,
+            return_norm_scale,
+            jax.random.PRNGKey(3),
+        )
+
+    (_, _), grads = jax.value_and_grad(loss_fn, has_aux=True)(ts.actor.params)
+    grad_norms = jax.tree.map(lambda g: jnp.sum(jnp.abs(g)), grads)
+    total = sum(float(n) for n in jax.tree.leaves(grad_norms))
+    assert total > 0, (
+        "expected a non-zero actor gradient from the REINFORCE policy "
+        "loss - got all zeros, meaning the loss isn't actually connected "
+        "to the actor's parameters"
+    )
+
+
 if __name__ == "__main__":
     test_dreamer_is_an_agent()
     test_dreamer_trains_one_update_without_nans()
     test_dreamer_networks_have_independent_optimizers_and_step_counters()
     test_dreamer_logs_flow_through_agent_log_to_wandb()
+    test_symlog_symexp_are_inverses()
+    test_unimix_floors_every_class_probability()
+    test_straight_through_sample_is_onehot_but_differentiable()
+    test_twohot_encode_sums_to_one_and_decodes_near_target()
+    test_twohot_head_loss_is_minimised_at_the_target()
+    test_dreamer_kl_balance_has_two_distinct_terms()
+    test_dreamer_slow_critic_tracks_online_critic_via_ema()
+    test_dreamer_actor_gradient_is_nonzero()

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -57,9 +57,9 @@ def _make_dreamer(**hparam_overrides) -> Dreamer:
         seq_len=hparam_overrides.pop("seq_len", 4),
         imag_horizon=hparam_overrides.pop("imag_horizon", 3),
         embed_size=hparam_overrides.pop("embed_size", 8),
-        deter_size=hparam_overrides.pop("deter_size", 8),
-        stoch=hparam_overrides.pop("stoch", 3),
-        classes=hparam_overrides.pop("classes", 4),
+        recurrent_size=hparam_overrides.pop("recurrent_size", 8),
+        num_latents=hparam_overrides.pop("num_latents", 3),
+        num_classes=hparam_overrides.pop("num_classes", 4),
         bins=hparam_overrides.pop("bins", 11),
         hidden_size=hparam_overrides.pop("hidden_size", 8),
         **hparam_overrides,
@@ -342,7 +342,7 @@ def test_dreamer_imagination_weight_and_states_are_action_aligned():
     hp = dreamer.hparams
     ts = dreamer._init_train_state(jax.random.PRNGKey(0))
     start_feats = jax.random.normal(
-        jax.random.PRNGKey(1), (5, hp.deter_size + hp.stoch_flat)
+        jax.random.PRNGKey(1), (5, hp.recurrent_size + hp.latents_flat)
     )
     feats_in, feats, rews, continues, actions, weight = dreamer._actor_critic_rollout(
         ts.model.params, ts.actor.params, start_feats, jax.random.PRNGKey(2)
@@ -379,7 +379,7 @@ def test_dreamer_untrained_heads_predict_zero_and_near_uniform_policy():
     hp = dreamer.hparams
     ts = dreamer._init_train_state(jax.random.PRNGKey(0))
     feat = jax.random.normal(
-        jax.random.PRNGKey(1), (7, hp.deter_size + hp.stoch_flat)
+        jax.random.PRNGKey(1), (7, hp.recurrent_size + hp.latents_flat)
     )
     head = TwoHotHead(hp.hidden_size, hp.bins, hp.bins_low, hp.bins_high)
     vals = head.mean(dreamer.critic.apply({"params": ts.critic.params}, feat))

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -23,6 +23,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 import distrax
+import rlax
 
 import navix as nx
 from navix.agents.agent import Agent
@@ -33,11 +34,8 @@ from navix.agents.dreamer import (
     Actor,
     Critic,
     Replay,
-    symlog,
-    symexp,
     unimix_categorical,
     straight_through_sample,
-    twohot_encode,
     TwoHotHead,
 )
 
@@ -150,19 +148,6 @@ def test_dreamer_logs_flow_through_agent_log_to_wandb():
     assert "perf/success_rate" in logged
 
 
-def test_symlog_symexp_are_inverses():
-    # symexp(symlog(x)) is the direction actually used in the code (real
-    # values -> compressed symlog space and back). symlog(symexp(x)) is
-    # only meaningful for x already in symlog-space's realistic range
-    # (roughly [-20, 20], matching TwoHotHead's default bin range) -
-    # symexp(1000) alone overflows float32 (e^1000), so that direction
-    # isn't tested at real-value magnitudes.
-    x = jnp.asarray([-1000.0, -1.0, 0.0, 1.0, 1000.0])
-    np.testing.assert_allclose(symexp(symlog(x)), x, atol=1e-4)
-    x_small = jnp.asarray([-15.0, -1.0, 0.0, 1.0, 15.0])
-    np.testing.assert_allclose(symlog(symexp(x_small)), x_small, atol=1e-3)
-
-
 def test_unimix_floors_every_class_probability():
     # https://arxiv.org/abs/2301.04104 - "1% unimix": no class should
     # ever reach exactly zero probability, however confident the raw
@@ -202,23 +187,14 @@ def test_straight_through_sample_is_onehot_but_differentiable():
     )
 
 
-def test_twohot_encode_sums_to_one_and_decodes_near_target():
-    bin_centers = jnp.linspace(-5.0, 5.0, 11)
-    for x in [-5.0, -3.3, 0.0, 2.7, 5.0]:
-        twohot = twohot_encode(jnp.asarray(x), bin_centers)
-        np.testing.assert_allclose(jnp.sum(twohot), 1.0, atol=1e-5)
-        assert jnp.sum(twohot > 0) <= 2
-        decoded = jnp.sum(twohot * bin_centers)
-        np.testing.assert_allclose(decoded, x, atol=1e-4)
-
-
 def test_twohot_head_loss_is_minimised_at_the_target():
     # a head whose logits already encode the target exactly should have
     # ~zero loss; a mismatched target should cost strictly more.
     head = TwoHotHead(hidden_size=4, bins=21, low=-5.0, high=5.0)
-    bin_centers = jnp.linspace(-5.0, 5.0, 21)
     target = jnp.asarray([1.3])
-    twohot = twohot_encode(symlog(target), bin_centers)  # already (1, bins)
+    twohot = rlax.transform_to_2hot(
+        rlax.signed_logp1(target), head.low, head.high, head.bins
+    )  # already (1, bins)
     matching_logits = jnp.log(twohot + 1e-8)
     loss_matching = head.loss(matching_logits, target)
     loss_mismatched = head.loss(matching_logits, jnp.asarray([-3.0]))
@@ -462,10 +438,8 @@ if __name__ == "__main__":
     test_dreamer_trains_one_update_without_nans()
     test_dreamer_networks_have_independent_optimizers_and_step_counters()
     test_dreamer_logs_flow_through_agent_log_to_wandb()
-    test_symlog_symexp_are_inverses()
     test_unimix_floors_every_class_probability()
     test_straight_through_sample_is_onehot_but_differentiable()
-    test_twohot_encode_sums_to_one_and_decodes_near_target()
     test_twohot_head_loss_is_minimised_at_the_target()
     test_dreamer_kl_balance_has_two_distinct_terms()
     test_dreamer_slow_critic_tracks_online_critic_via_ema()

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -265,11 +265,12 @@ def test_dreamer_actor_gradient_is_nonzero():
     dreamer = _make_dreamer()
     ts = dreamer._init_train_state(jax.random.PRNGKey(0))
     ts, experience = dreamer._collect(ts)
-    obs_seq, act_seq, _, _ = dreamer._sample_batch(jax.random.PRNGKey(1), experience)
+    obs_seq, act_seq, _, term_seq = dreamer._sample_batch(jax.random.PRNGKey(1), experience)
     _, _, feats, _, _, _ = dreamer.world.apply(
         {"params": ts.model.params},
         obs_seq,
         act_seq,
+        term_seq,
         method=WorldModel.observe,
         rngs={"sample": jax.random.PRNGKey(2)},
     )
@@ -296,6 +297,33 @@ def test_dreamer_actor_gradient_is_nonzero():
     )
 
 
+def test_dreamer_actor_entropy_never_reaches_exactly_zero():
+    # Regression test for a training-stability bug found while
+    # benchmarking whether Dreamer actually learns: with no floor on the
+    # actor's action distribution, its entropy could reach exactly 0.0.
+    # Once it does, _collect() (which samples actions from this same
+    # distribution) stops exploring too - real data collection narrows
+    # to whatever the collapsed policy repeats, the world model overfits
+    # to that narrow trajectory, and there's no path back. Verified
+    # empirically: entropy hit exactly 0.0 and success rate permanently
+    # flatlined at 0% on Navix-Empty-5x5-v0 within the first ~1500
+    # frames, and stayed there even given 5x more training (500k frames)
+    # - ruling out "just needs more compute". actor_unimix (mirroring
+    # the world model's own unimix_categorical, already used for its
+    # latents) puts a structural floor under every action's probability,
+    # making that exact failure mode impossible rather than merely less
+    # likely - confirmed here directly on the actor's own distribution,
+    # not just the world model's.
+    dreamer = _make_dreamer(num_actor_updates=8)
+    ts, logs = jax.jit(dreamer.train)(jax.random.PRNGKey(0))
+    entropy = np.asarray(logs["agent/actor/entropy"])
+    assert np.all(entropy > 0), (
+        f"expected actor entropy to never reach exactly 0 with "
+        f"actor_unimix={dreamer.hparams.actor_unimix} > 0, got a minimum "
+        f"of {entropy.min()} across training"
+    )
+
+
 if __name__ == "__main__":
     test_dreamer_is_an_agent()
     test_dreamer_trains_one_update_without_nans()
@@ -309,3 +337,4 @@ if __name__ == "__main__":
     test_dreamer_kl_balance_has_two_distinct_terms()
     test_dreamer_slow_critic_tracks_online_critic_via_ema()
     test_dreamer_actor_gradient_is_nonzero()
+    test_dreamer_actor_entropy_never_reaches_exactly_zero()

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -34,6 +34,8 @@ from navix.agents.dreamer import (
     Actor,
     Critic,
     Replay,
+)
+from navix.agents.models import (
     unimix_categorical,
     straight_through_sample,
     TwoHotHead,

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -1,0 +1,147 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import patch
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+import navix as nx
+from navix.agents.agent import Agent
+from navix.agents.dreamer import (
+    Dreamer,
+    DreamerHparams,
+    WorldModel,
+    Actor,
+    Critic,
+)
+
+
+def _make_dreamer(**hparam_overrides) -> Dreamer:
+    # A deliberately tiny configuration - just enough for every code path
+    # (collection, world-model/actor/critic updates, imagination rollouts,
+    # sequence sampling) to actually execute, not to train anything useful.
+    hp = DreamerHparams(
+        budget=hparam_overrides.pop("budget", 256),
+        num_envs=hparam_overrides.pop("num_envs", 4),
+        num_steps=hparam_overrides.pop("num_steps", 8),
+        num_model_updates=hparam_overrides.pop("num_model_updates", 2),
+        num_actor_updates=hparam_overrides.pop("num_actor_updates", 2),
+        num_critic_updates=hparam_overrides.pop("num_critic_updates", 2),
+        batch_size=hparam_overrides.pop("batch_size", 3),
+        seq_len=hparam_overrides.pop("seq_len", 4),
+        imag_horizon=hparam_overrides.pop("imag_horizon", 3),
+        embed_size=hparam_overrides.pop("embed_size", 8),
+        deter_size=hparam_overrides.pop("deter_size", 8),
+        stoch_size=hparam_overrides.pop("stoch_size", 4),
+        hidden_size=hparam_overrides.pop("hidden_size", 8),
+        **hparam_overrides,
+    )
+    env = nx.make("Navix-Empty-5x5-v0", max_steps=hp.num_steps)
+    obs_dim = int(np.prod(env.observation_space.shape))
+    act_dim = len(env.action_set)
+    world = WorldModel(obs_dim=obs_dim, act_dim=act_dim, hparams=hp)
+    actor = Actor(act_dim=act_dim, hidden=hp.hidden_size)
+    critic = Critic(hidden=hp.hidden_size)
+    return Dreamer(hparams=hp, env=env, world=world, actor=actor, critic=critic)
+
+
+def test_dreamer_is_an_agent():
+    # follows the Agent interface: HParams subclass, hparams field, and
+    # inherits (rather than reimplements) the wandb logging machinery -
+    # PPO does the same, this keeps both algorithms interchangeable from
+    # Experiment's point of view.
+    dreamer = _make_dreamer()
+    assert isinstance(dreamer, Agent)
+    assert isinstance(dreamer.hparams, DreamerHparams)
+    assert hasattr(dreamer, "train")
+    assert Dreamer.log_to_wandb is Agent.log_to_wandb
+    assert Dreamer.log_to_wandb_on_train_end is Agent.log_to_wandb_on_train_end
+
+
+def test_dreamer_trains_one_update_without_nans():
+    dreamer = _make_dreamer(budget=8 * 4)  # -> exactly 1 update
+    ts, logs = jax.jit(dreamer.train)(jax.random.PRNGKey(0))
+
+    assert int(ts.updates) == 1, "expected exactly one Dreamer.update() call"
+
+    for key in ("iter/frames", "iter/updates", "done_mask", "returns", "lengths"):
+        assert key in logs, f"missing expected log key {key!r}"
+
+    for key, value in logs.items():
+        if key in ("done_mask",):
+            continue
+        arr = np.asarray(value)
+        assert np.all(np.isfinite(arr)), f"logs[{key!r}] contains non-finite values"
+
+
+def test_dreamer_networks_have_independent_optimizers_and_step_counters():
+    # Regression test for the bug found while porting this agent from the
+    # neurips branch: DreamerTrainState used to subclass flax's TrainState
+    # directly and hand-roll tx.update() + optax.apply_updates() for all
+    # three networks while sharing one `tx`/`step` field meant to be
+    # swapped between updates. The swap never took effect before each
+    # network's own update ran, so actor and critic gradients were
+    # silently applied through the model's optimizer (and learning rate)
+    # instead of their own - and since apply_gradients() was never called
+    # at all, the step counter never incremented, breaking
+    # log_frequency-gated logging.
+    #
+    # With three independent TrainStates, each network's .step must equal
+    # exactly its own configured number of updates after one
+    # Dreamer.update() call - this is only possible if each one is really
+    # calling its own apply_gradients(), not sharing state with another.
+    dreamer = _make_dreamer(
+        num_model_updates=3, num_actor_updates=5, num_critic_updates=7
+    )
+    ts, _ = jax.jit(dreamer.train_first_update)(jax.random.PRNGKey(0))
+
+    assert int(ts.model.step) == 3
+    assert int(ts.actor.step) == 5
+    assert int(ts.critic.step) == 7
+    # if the three optimizers were accidentally the same object/state, the
+    # three step counts above could not differ from one another the way
+    # they do here (3 != 5 != 7) - this is only possible with genuinely
+    # independent TrainStates.
+
+
+def test_dreamer_logs_flow_through_agent_log_to_wandb():
+    # smoke test that Dreamer's logs dict is shaped the way the base
+    # Agent's wandb-logging methods expect (done_mask/returns/lengths ->
+    # perf/* via masked_mean), the same contract PPO relies on.
+    dreamer = _make_dreamer(budget=8 * 4)
+    ts, logs = jax.jit(dreamer.train)(jax.random.PRNGKey(0))
+    logs = jax.tree.map(lambda x: x[0] if hasattr(x, "shape") and x.shape else x, logs)
+
+    with patch("navix.agents.agent.wandb.log") as mock_log:
+        dreamer.log_to_wandb(dict(logs))
+
+    assert mock_log.call_count == 1
+    logged = mock_log.call_args.args[0]
+    assert "perf/returns" in logged
+    assert "perf/episode_length" in logged
+    assert "perf/success_rate" in logged
+
+
+if __name__ == "__main__":
+    test_dreamer_is_an_agent()
+    test_dreamer_trains_one_update_without_nans()
+    test_dreamer_networks_have_independent_optimizers_and_step_counters()
+    test_dreamer_logs_flow_through_agent_log_to_wandb()

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -30,6 +30,7 @@ from navix.agents.agent import Agent
 from navix.agents.dreamer import (
     Dreamer,
     DreamerHparams,
+    DreamerTrainState,
     WorldModel,
     Actor,
     Critic,
@@ -242,7 +243,14 @@ def test_dreamer_actor_gradient_is_nonzero():
     # (log_prob(action) * advantage) has a real gradient for a discrete
     # policy. Assert the actor's gradient is actually non-zero.
     dreamer = _make_dreamer()
-    ts = dreamer._init_train_state(jax.random.PRNGKey(0))
+    ts = DreamerTrainState.create(
+        jax.random.PRNGKey(0),
+        dreamer.hparams,
+        dreamer.env,
+        dreamer.world,
+        dreamer.actor,
+        dreamer.critic,
+    )
     ts, experience = dreamer.collect_experience(ts)
     replay = dreamer._write_replay(ts.replay, experience)
     obs_seq, act_seq, _, first_seq, _ = dreamer._sample_batch(
@@ -340,7 +348,14 @@ def test_dreamer_imagination_weight_and_states_are_action_aligned():
     # episode.
     dreamer = _make_dreamer()
     hp = dreamer.hparams
-    ts = dreamer._init_train_state(jax.random.PRNGKey(0))
+    ts = DreamerTrainState.create(
+        jax.random.PRNGKey(0),
+        dreamer.hparams,
+        dreamer.env,
+        dreamer.world,
+        dreamer.actor,
+        dreamer.critic,
+    )
     start_feats = jax.random.normal(
         jax.random.PRNGKey(1), (5, hp.recurrent_size + hp.latents_flat)
     )
@@ -377,7 +392,14 @@ def test_dreamer_untrained_heads_predict_zero_and_near_uniform_policy():
     # near-zero-initialized so the initial policy is near-uniform.
     dreamer = _make_dreamer()
     hp = dreamer.hparams
-    ts = dreamer._init_train_state(jax.random.PRNGKey(0))
+    ts = DreamerTrainState.create(
+        jax.random.PRNGKey(0),
+        dreamer.hparams,
+        dreamer.env,
+        dreamer.world,
+        dreamer.actor,
+        dreamer.critic,
+    )
     feat = jax.random.normal(
         jax.random.PRNGKey(1), (7, hp.recurrent_size + hp.latents_flat)
     )


### PR DESCRIPTION
Part of #134's port-tracking table (row 7). Relevant to the leaderboard proposal in #130.

## Update: this is now a genuine DreamerV3 implementation

The first commit on this branch ported the `neurips` branch's Dreamer draft and was labeled "DreamerV3-style" without actually being cross-checked against the paper or the official implementation. It wasn't - it used a Gaussian-latent world model, a Gaussian/MSE reward head, and (found while implementing the real thing) an actor loss that backpropagated through a *sampled* discrete action, which has no gradient at all (`distrax.Categorical.sample()` isn't reparameterized) - only the separate entropy term was ever actually training the actor.

This has been replaced with a real implementation of DreamerV3's five headline robustness techniques (Hafner et al., [arxiv.org/abs/2301.04104](https://arxiv.org/abs/2301.04104)), each verified directly against [`danijar/dreamerv3`](https://github.com/danijar/dreamerv3) (`dreamerv3/rssm.py`, `embodied/jax/agent.py`, `configs.yaml`) rather than assumed from memory or the paper text alone:

1. **Categorical latents with straight-through gradients + 1% unimix.** `stoch` independent categoricals of `classes` each (reduced from the paper's 32x32 default to 8x8, sized for navix's small grids rather than Atari-scale observations), sampled via a straight-through estimator, with a `unimix` fraction of uniform probability mixed into every categorical (`rssm.py`'s `unimix: 0.01`) so no class ever reaches exactly zero probability.
2. **KL balancing with free bits.** Two separate terms with different stop-gradient placement - `dyn = KL(sg(post)||prior)`, `rep = KL(post||sg(prior))` - each independently floored, not one combined KL clamped by a single scalar. Confirmed directly in `rssm.py` lines 125-130; weights `dyn_scale=1.0`/`rep_scale=0.1` from `configs.yaml`'s `loss_scales`.
3. **Symexp-twohot regression for reward and value** (`TwoHotHead`), not a Gaussian head - classification over bins evenly spaced in symlog space. Confirmed via `outs.py`'s `TwoHot` class and `configs.yaml`'s `output: symexp_twohot, bins: 255` (reduced to 41 bins here).
4. **REINFORCE actor loss** (`log_prob(sg(action)) * sg(advantage) + entropy bonus`), not backprop through a sampled action. Confirmed directly in `embodied/jax/agent.py`'s `imag_loss`: `logpi * sg(adv_normed) + actent * entropy`.
5. **Return normalization** - an EMA-tracked 5th-95th percentile range of imagined lambda-returns rescales the advantage, matching `configs.yaml`'s `retnorm` (`rate=0.01, perclo=5, perchi=95`).
6. **An EMA "slow" target critic** (`rate=0.02`) the online critic is regularized toward, matching `configs.yaml`'s `slowvalue`.

### Deliberate, documented simplifications (not the algorithm's identity)

Kept for navix's small grid-world observations rather than image-scale ones:
- A plain `nn.GRUCell` for the deterministic recurrent state, not the official "block GRU" (a parameter-efficiency optimization for much larger `deter` sizes than navix needs).
- A symlog+MSE decoder for observation reconstruction, not the official image-specific CNN decoder.
- ELU activations, no RMSNorm.
- Smaller `stoch`/`classes`/`bins` defaults than the paper's Atari-scale config.

None of these affect correctness or the algorithm's identity - the six techniques above are what makes DreamerV3 DreamerV3, and all six are implemented and tested.

## Original port section (still accurate, superseded by the above for algorithmic fidelity)

Original source: `navix/agents/dreamer.py` on the `neurips` research branch. Porting it (before the rewrite above) surfaced several execution-correctness bugs the draft had never actually hit, since it had never been run to completion - fixed and still present in this version:

1. **Optimizer mixup** - actor/critic gradients were silently applied through the model's optimizer instead of their own (a shared, never-actually-swapped `tx` field). Fixed with three genuinely independent `TrainState`s.
2. **Step counter never incremented**, since `apply_gradients()` was never called. Fixed by the same change.
3. **Stale distrax metadata after `jax.lax.scan` accumulation** - a `distrax.Distribution`'s `batch_shape`/`event_shape` go stale once `jax.lax.scan` restacks its array leaves; calling `.kl_divergence()`/`.mean()` on it *after* the scan raises a shape mismatch. Fixed by reducing to plain arrays inside the scan body.
4. **`nn.scan` misuse and unbound Flax module calls** - fixed by using plain `jax.lax.scan` and routing every submodule call through `.apply()`.
5. **`Module.init()` vs. outer `jax.jit`** - fixed with a scan-free `init_probe` method for parameter-shape discovery.
6. **Horizon length / scan-axis mismatches** in the lambda-return computation.

## Design notes

- `Dreamer` flattens observations internally (`Dreamer._flatten_obs`) - works with any navix observation shape out of the box, unlike `PPO` which needs `FlattenObsWrapper`.
- Caller constructs `WorldModel`/`Actor`/`Critic` explicitly and passes them in, matching `PPO`'s convention for `ActorCritic`.

## Verification

- `tests/test_dreamer.py`: 12 tests. Covers `Agent` interface compliance; a `train()` smoke test asserting no NaN/Inf; independent per-network step counts (regression test for bug #1/#2); logs flowing through `Agent.log_to_wandb`; `symlog`/`symexp` round-trips; unimix flooring every class probability; straight-through gradients being non-zero; twohot encoding/decoding; KL balance producing two distinct log entries; the slow critic actually moving via EMA; and critically, **the actor's gradient being non-zero** - a direct regression test for the backprop-through-sampled-action bug found while implementing the real REINFORCE loss.
- Full test suite: 63/63 passing on GPU (51 pre-existing + 12 new).

## Scope note

This is the *first-class agent* half of #142 - whether/how the IQN/PQN baseline results from the same branch get a reproduction script is a separate question (see #140's resolution and the `leaderboard/` mechanism in #130), not addressed here.


## Update: it wasn't actually learning - fixed

All of the above got the algorithm's mechanisms right, but benchmarking against PPO on a trivial task (`Navix-Empty-5x5-v0`, 100k frames: PPO ~99% success) showed Dreamer stuck at exactly 0% - and staying there even with 5x more training (500k frames), ruling out a compute/tuning issue. Found and fixed four more real bugs:

1. **Off-by-one bootstrap misalignment** in the actor/critic lambda-return computation - `rews[:-1]` was paired with `vals[1:]`, bootstrapping every reward with the critic value *two* imagined steps ahead instead of one.
2. **`observe()`'s action/observation pairing was off by one** - the world model was trained as if the action taken *before* `act_seq[t]` had produced `obs_seq[t+1]`. `obs_loss`/`rew_loss` still converged near zero despite this (grid-world transitions are highly autocorrelated), masking the bug in the aggregate loss curves.
3. **No episode-boundary masking in `observe()`** - sampled training sequences commonly straddle an autoreset; without masking, the reset observation's posterior was computed by conditioning on the *previous* episode's stale belief. Fixed by zeroing the incoming `(h, z)` and action whenever the term-head's target flags a step as episode-ending, matching the official implementation's `is_first` masking.
4. **No floor on the actor's own action distribution** - entropy could reach exactly 0.0, at which point `_collect()` (sampling from the same distribution) stops exploring too, permanently narrowing real data collection. The world model's own categorical latents already use a unimix floor for exactly this reason; the actor never got the same treatment. Added `actor_unimix` (default 0.05).

Bugs 1 and 4 found directly; bugs 2 and 3 found by a fresh agent briefed on the investigation and everything already ruled out (gradient clip norm, entropy coefficient, `TwoHotHead` bin range - none of these changed the outcome under ablation, confirming a correctness bug rather than a tuning problem).

Diagnosed via ablation that bugs 1-3 alone weren't sufficient (still exactly 0% success, entropy still hitting exactly 0.0) - sweeping `num_actor_updates` (1/2/8) showed lower ratios delayed but didn't prevent the same terminal collapse, and briefly reached up to 100% success in isolated windows before collapsing back, proving the algorithm *could* learn, just wasn't stable. Fixing bug 4 on top resolved that: entropy now stays bounded away from 0 (min 0.27 vs exactly 0.0), critic value estimates rise over training (1.1 to 5.1, previously fell toward 0), advantage converges toward neutral (-1.75 to -0.16, previously diverged to -4.9+), and the agent achieves genuine successes (17 across 5880 completed episodes in one 100k-frame run, peaking at 50% in a single update window) where every prior configuration achieved exactly zero.

**Not yet competitive with PPO's ~99% on the same budget** - this moves it from "doesn't learn at all" to "learns, but needs further tuning to be competitive." Two new regression tests added (13 total), targeting bugs 1 and 4 directly.


---

## Update 2: now at 99-100% success, matching PPO (commit fd54961)

A second debugging pass (fresh, evidence-first: every hypothesis was benchmarked on GPU before being trusted, several were falsified along the way) found four more real defects on top of the earlier four, plus one hyperparameter root cause. All verified on Navix-Empty-5x5-v0, 100k frames - the budget where PPO reaches ~99%:

1. **Imagined-rollout credit assignment was off by one, three ways.** `imagine()`'s scan emits only *resulting* states, so `actions[t]` was taken FROM `feats_in[t]`, not `feats[t]`. The actor scored actions under the policy at the *outcome* state, the baseline used the outcome state's value, and the per-step weight multiplied in `continues[t]` = 1 − P(terminal | the action's own outcome) - so the action that reaches the goal had its gradient scaled toward zero exactly when the term head correctly predicted the goal ends the episode. The critic likewise regressed each state toward the previous state's return.
2. **No replay buffer existed** - the world model trained only on the latest 2048-frame rollout, so rare success transitions were forgotten one update after being seen. Added a FIFO block replay carried through the `lax.scan` train loop.
3. **`is_first` masking fired one step early.** navix *defers* autoreset to the next `env.step()`, so `done[t]=1` marks `obs[t+1]` as the genuine terminal observation (and `obs[t+2]` as the reset). The old mask zeroed the belief state exactly at the goal-reaching transition, so the reward/term heads' only positive examples carried blank-context latents that imagination (always full-context) never produces: **imagined rollouts contained zero reward no matter how well the heads fit their training data**. Measured directly: reward head at real goal transitions predicted 0.004 (posterior) / 0.003 (prior) vs. a true reward of 1.0.
4. **Untrained two-hot heads emitted symexp garbage** (random logits over symlog ±20 bins decode up to ±e^20); ~64 early gradient steps of the resulting advantages slammed the actor into a deterministic policy before learning began. Now zero-initialized (official `outscale: 0.0`), actor near-uniform at init; term head also trains on true termination only (not timeout truncation), and the slow-critic EMA advances per gradient step as in the official implementation.
5. **Replay ratio was the final unlock**: with ~0.2% reward incidence, the mean-reduced twohot cross-entropy holds the reward head at the base-rate prediction until it has seen enough positives. At 32 steps/update it was still at ~0.004 after a full run; at 128 (new default, in the spirit of official `train_ratio`) it reaches ~0.98 and the policy transitions sharply from random-walk to near-perfect.

**Verification, two seeds at library defaults:** success over the final 20% of training = **100.0%** (seed 0, 1110 episodes) and **99.15%** (seed 1, 1176 episodes); reward head at real goal transitions 0.98; term head 0.998; actor entropy settles ~0.29 (floored by unimix, not collapsed). Full suite: **68 passed**, including new regression tests pinning the credit-assignment alignment, replay retention, the shifted `is_first` window (deterministic construction), and the zero-init head behavior. Diagnostics that made this tractable (a forced-action `prior_step` probe and an observation-separability check) are kept in the code/tests where reusable.
