### PR TITLE
fix(key_corridor): stop stacking two doors on one cell

### DIFF
--- a/navix/environments/key_corridor.py
+++ b/navix/environments/key_corridor.py
@@ -96,22 +96,17 @@ class KeyCorridor(Environment):
                 )
             )
         for row in range(n_rows - 1):
-            k9, k10, k11, k12 = jax.random.split(k9, num=4)
-            # first col
+            # Splits four ways though only two keys are used, so `k9` carries
+            # the same value into the next iteration as it always has.
+            k9, k10, _, _ = jax.random.split(k9, num=4)
+            # first col, one door per boundary: a second one from this same
+            # `door_pos` would stack on its cell.
             door_pos = grid.position_on_border(row, 0, 3, key=k9)
             doors.append(
                 Door.create(
                     position=door_pos,
                     requires=EMPTY_POCKET_ID,
                     colour=random_colour(k10),
-                    open=jnp.asarray(0),
-                )
-            )
-            doors.append(
-                Door.create(
-                    position=door_pos,
-                    requires=EMPTY_POCKET_ID,
-                    colour=random_colour(k12),
                     open=jnp.asarray(0),
                 )
             )

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -304,6 +304,39 @@ def test_141():
             )
 
 
+def test_160():
+    # https://github.com/epignatelli/navix/issues/160
+    # KeyCorridor built *two* Door entities per row boundary at the same
+    # cell: the `for row in range(n_rows - 1)` loop split `k9, k10, k11,
+    # k12` but reused the single `door_pos` from `k9` for both doors, so
+    # `k11` - clearly meant to draw a second, different position - was
+    # never used. The pair only differed in colour (`k10` vs `k12`).
+    # They behave as one door (`open` and `_walkable` both reduce over the
+    # whole door array), so this is not a dynamics bug, but it does corrupt
+    # rendering: `observations.rgb` writes every door sprite into the frame
+    # with a single `.at[idx].set(...)`, and a duplicate-index scatter is
+    # undefined in JAX - on GPU it resolves per element, so the tile comes
+    # out a per-pixel mix of two differently coloured door sprites.
+    for env_id in [
+        "Navix-KeyCorridorS3R1-v0",
+        "Navix-KeyCorridorS3R2-v0",
+        "Navix-KeyCorridorS3R3-v0",
+        "Navix-KeyCorridorS6R3-v0",
+    ]:
+        env = nx.make(env_id)
+        keys = jax.random.split(jax.random.PRNGKey(0), 32)
+        for k in keys:
+            timestep = env.reset(k)
+            positions = timestep.state.get_doors().position
+            n_unique = jnp.unique(positions, axis=0).shape[0]
+            assert n_unique == positions.shape[0], (
+                f"{env_id}: expected every door to occupy its own cell, got "
+                f"{positions.shape[0]} doors on {n_unique} distinct cells "
+                f"(positions={positions.tolist()}) - stacked doors make the "
+                "duplicated cell render as a mix of both sprites"
+            )
+
+
 if __name__ == "__main__":
     test_82()
     test_91()
@@ -312,3 +345,4 @@ if __name__ == "__main__":
     test_146()
     test_147()
     test_141()
+    test_160()


### PR DESCRIPTION
_Posted by an AI agent on behalf of @xweinp._

Fixes #160.

## What's wrong

In `KeyCorridor._reset`, the `for row in range(n_rows - 1)` loop splits four keys but draws `door_pos` once and reuses it for two `Door.create` calls:

```python
k9, k10, k11, k12 = jax.random.split(k9, num=4)
door_pos = grid.position_on_border(row, 0, 3, key=k9)
doors.append(Door.create(position=door_pos, ..., colour=random_colour(k10), ...))
doors.append(Door.create(position=door_pos, ..., colour=random_colour(k12), ...))
```

So every row boundary gets two doors on the same cell, differing only in colour. `k11` — clearly meant to draw the second position — is never used. Present since d520ad1 (Mar 2024) and in 0.11.0.

The dynamics are unaffected: `actions.open` and the walkability check both reduce over the whole door array, so the stacked pair opens together and behaves as one door. The visible symptom is rendering — `observations.rgb` writes every door sprite with a single `.at[idx].set(...)`, and a duplicate-index scatter is undefined in JAX, so on GPU the shared tile comes out as a per-pixel mix of the two sprites.

Reproduction on `Navix-KeyCorridorS3R3-v0` (seed 0), positions and colours:

```
[[1,4],[1,2],[3,4],[3,2],[5,4],[5,2],[2,1],[2,1],[4,1],[4,1]]
[   3,    3,    4,    5,    5,    3,    2,    5,    4,    5 ]
```

The last two pairs are the stacked doors.

## The fix

Drop the second `Door.create`, keeping one door per row boundary.

The split stays four wide though only two keys are now used. That's deliberate: it keeps `k9` carrying the same value into the next iteration, so every surviving door keeps the exact position and colour it had before. I verified this over 48 keys × 3 env IDs with 0 mismatches.

I did not repoint the second door at column 2 instead of deleting it: the right-column non-goal rooms are already reachable through the unlocked corridor doors, so a vertical door there would let the agent bypass the locked door and the key entirely.

## Behavior change

Per "Flag behavior-changing PRs explicitly" in `AGENTS.md` — this changes what existing `Navix-KeyCorridorS*R*-v0` IDs return:

- The `Entities.DOOR` array shrinks from `3·n_rows − 2` to `2·n_rows − 1` entries, so `observations.categorical`/`symbolic` and anything iterating doors sees one fewer entity per row boundary.
- `observations.rgb` changes on the affected tiles — that's the point of the fix.
- Layouts, door positions, door colours, key and goal placement are all unchanged.

It's cheaper, not costlier: fewer entities in every per-entity scan.

## Testing

- New `test_160` in `tests/test_issues.py`: asserts every door occupies its own cell across `S3R1`/`S3R2`/`S3R3`/`S6R3` × 32 seeds. Fails on `main`, passes here.
- Full suite: 76 passed.
- I did not run `examples/*.py` — they're wandb-backed training scripts and I had no credentials for them.
