### PR TITLE
ci(claude): allow Bash for the @claude review action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,5 +47,12 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          #
+          # Unrestricted Bash - lets review comments actually run the test
+          # suite (and anything else) instead of only tracing code by hand.
+          # This workflow only triggers for users with write access to the
+          # repo (see anthropics/claude-code-action's security docs), so the
+          # risk is bounded to already-trusted contributors, but note this is
+          # broader than scoping to e.g. just `Bash(python -m pytest:*)`.
+          claude_args: '--allowedTools Bash'
 


### PR DESCRIPTION
## Why

While reviewing PR #162, the `@claude` action reported it couldn't execute anything - Bash calls were denied by default in that non-interactive run, so it could only trace code by hand and couldn't run `python -m pytest ...` or the verification scripts a PR points it at.

## What

Adds `claude_args: '--allowedTools Bash'` to `.github/workflows/claude.yml`, granting the action unrestricted Bash rather than scoping to a specific command pattern (e.g. `Bash(python -m pytest:*)`).

## Risk

This workflow already only triggers for users with **write access** to the repo (`issue_comment`/`pull_request_review_comment`/`issues`/`pull_request_review`, all gated by `anthropics/claude-code-action`'s own actor-permission check per its security docs) - so this doesn't open Bash execution to arbitrary internet users, only to already-trusted contributors who could otherwise just push code directly. Worth knowing this is broader than the minimum needed to fix the original complaint (which was specifically about not being able to run tests) - a narrower `Bash(python -m pytest:*)` scope was considered and intentionally not used here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017r9M6ZNasyVJjmBGCA585J