### PR TITLE
Redesign EventsManager to support multiple simultaneous events per step

### DIFF
--- a/navix/actions.py
+++ b/navix/actions.py
@@ -198,7 +198,7 @@ def pickup(state: State) -> State:
     # update events
     events = jax.lax.cond(
         jnp.any(key_found),
-        lambda: state.events.record_key_pickup(keys, position_in_front),
+        lambda: state.events.record_key_pickup(keys, key_found),
         lambda: state.events,
     )
 
@@ -298,7 +298,7 @@ def open(state: State) -> State:
     # update events
     events = jax.lax.cond(
         jnp.any(do_open),
-        lambda: state.events.record_door_opening(doors, position_in_front),
+        lambda: state.events.record_door_opening(doors, do_open),
         lambda: state.events,
     )
 

--- a/navix/actions.py
+++ b/navix/actions.py
@@ -185,6 +185,15 @@ def pickup(state: State) -> State:
 
     key_found = positions_equal(position_in_front, keys.position)
 
+    # update events - before keys is moved to the discard pile below, so
+    # the recorded event keeps the key's real pickup position, not
+    # DISCARD_PILE_COORDS.
+    events = jax.lax.cond(
+        jnp.any(key_found),
+        lambda: state.events.record_key_pickup(keys, key_found),
+        lambda: state.events,
+    )
+
     # update keys
     positions = jnp.where(key_found, DISCARD_PILE_COORDS, keys.position)
     keys = keys.replace(position=positions)
@@ -193,13 +202,6 @@ def pickup(state: State) -> State:
     key = jnp.sum(keys.id * key_found, dtype=jnp.int32)
     player = jax.lax.cond(
         jnp.any(key_found), lambda: player.replace(pocket=key), lambda: player
-    )
-
-    # update events
-    events = jax.lax.cond(
-        jnp.any(key_found),
-        lambda: state.events.record_key_pickup(keys, key_found),
-        lambda: state.events,
     )
 
     state = state.set_player(player)

--- a/navix/environments/environment.py
+++ b/navix/environments/environment.py
@@ -28,7 +28,7 @@ from flax import struct
 
 from .. import rewards, terminations, observations, transitions
 from ..rendering.cache import RenderingCache, TILE_SIZE
-from ..states import State
+from ..states import EventsManager, State
 from ..actions import DEFAULT_ACTION_SET
 from ..spaces import Space, Discrete, Continuous
 from ..entities import EntityIds
@@ -186,8 +186,27 @@ class Environment(struct.PyTreeNode):
         Returns:
             (Timestep): The timestep at time $t + 1$
         """
+        # events are a per-step record - EventsManager's own docstring
+        # says "which events happened this timestep" - but
+        # EventsManager.merge_event only ever ORs new hits onto
+        # whatever a slot already holds (by design, see issue #139:
+        # that's what lets two events in the *same* step's transition
+        # pipeline both survive), so nothing actually clears a slot
+        # back to False between steps unless something does it here.
+        # Reset before the transition runs, not after, so a hit
+        # recorded during this step's own transition_fn call still
+        # counts - only carried-over history from earlier steps is
+        # dropped. Without this, a non-terminating reward like
+        # rewards.wall_hit_cost would keep firing every subsequent step
+        # after the first wall hit, not just the step it happened
+        # (terminating conditions like on_goal_reached/on_lava_fall/
+        # on_ball_hit were never actually affected by this in practice -
+        # the episode ends the first time they fire, so there's no
+        # "subsequent step" for the stale True to leak into before
+        # autoreset gives every entity a fresh EventsManager anyway).
+        reset_state = timestep.state.replace(events=EventsManager())
         # update agents
-        state = self.transitions_fn(timestep.state, action, self.action_set)
+        state = self.transitions_fn(reset_state, action, self.action_set)
         t = timestep.t + 1
 
         # calculate termination

--- a/navix/environments/go_to_door.py
+++ b/navix/environments/go_to_door.py
@@ -31,7 +31,7 @@ from navix import observations
 from .. import rewards, terminations
 from ..components import EMPTY_POCKET_ID
 from ..entities import Entities, Door, Player
-from ..states import EventType, State, Event
+from ..states import State, Event
 from ..grid import random_colour, random_directions
 from ..rendering.cache import RenderingCache
 from .environment import Environment, Timestep
@@ -94,7 +94,6 @@ class GoToDoor(Environment):
             position=target_door.position,
             colour=target_door.colour,
             happened=jnp.asarray(False),
-            event_type=EventType.REACH,
         )
 
         # systems

--- a/navix/events.py
+++ b/navix/events.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from jax import Array
 import jax.numpy as jnp
 
-from .states import State
+from .states import State, EventType, GRID
 from .grid import positions_equal, translate
 from .entities import Entities, Player
 
@@ -33,8 +33,9 @@ def on_goal_reached(state: State) -> Array:
         state (State): The current state of the game.
 
     Returns:
-        Array: A boolean array indicating whether the goal has been reached."""
-    return state.events.goal_reached.happened
+        Array: A boolean scalar indicating whether the goal has been reached
+        by any goal instance this step."""
+    return state.events.happened((Entities.GOAL, EventType.REACH))
 
 
 def on_lava_fall(state: State) -> Array:
@@ -44,8 +45,9 @@ def on_lava_fall(state: State) -> Array:
         state (State): The current state of the game.
 
     Returns:
-        Array: A boolean array indicating whether the lava has fallen."""
-    return state.events.lava_fall.happened
+        Array: A boolean scalar indicating whether the lava has fallen for
+        any lava instance this step."""
+    return state.events.happened((Entities.LAVA, EventType.FALL))
 
 
 def on_ball_hit(state: State) -> Array:
@@ -55,8 +57,9 @@ def on_ball_hit(state: State) -> Array:
         state (State): The current state of the game.
 
     Returns:
-        Array: A boolean array indicating whether the ball has hit something."""
-    return state.events.ball_hit.happened
+        Array: A boolean scalar indicating whether any ball hit the player
+        this step."""
+    return state.events.happened((Entities.BALL, EventType.HIT))
 
 
 def on_door_done(state: State) -> Array:
@@ -86,11 +89,17 @@ def on_door_done(state: State) -> Array:
 
 
 def on_wall_hit(state: State) -> Array:
-    """Checks whether the wall has been hit using the `wall_hit` event.
+    """Checks whether the wall has been hit using the `wall_hit` event -
+    either an actual `Wall` entity, or the grid boundary/a non-walkable
+    empty cell with no entity there (see `navix.states.GRID`).
 
     Args:
         state (State): The current state of the game.
 
     Returns:
-        Array: A boolean array indicating whether the wall has been hit."""
-    return state.events.wall_hit.happened
+        Array: A boolean scalar indicating whether a wall was hit this
+        step."""
+    return jnp.logical_or(
+        state.events.happened((Entities.WALL, EventType.HIT)),
+        state.events.happened((GRID, EventType.HIT)),
+    )

--- a/navix/states.py
+++ b/navix/states.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from __future__ import annotations
-from typing import Dict
+from typing import Dict, Tuple
 
 from jax import Array
 import jax.numpy as jnp
@@ -29,27 +29,42 @@ from .components import (
     Positionable,
     HasColour,
 )
+from .grid import positions_equal
 from .rendering.cache import RenderingCache
 from .rendering.registry import PALETTE, SPRITES_REGISTRY
 from .entities import Entity, Entities, Goal, Wall, Ball, Lava, Key, Door, Box, Player
 
 
 class EventType:
-    """Enumeration of the different types of events that can happen in the environment."""
+    """Enumeration of the different types of events that can happen in the environment.
 
-    NONE: Array = jnp.asarray(-1, dtype=jnp.int32)
-    REACH: Array = jnp.asarray(0, dtype=jnp.int32)
-    HIT: Array = jnp.asarray(1, dtype=jnp.int32)
-    FALL: Array = jnp.asarray(2, dtype=jnp.int32)
-    PICKUP: Array = jnp.asarray(3, dtype=jnp.int32)
-    OPEN: Array = jnp.asarray(4, dtype=jnp.int32)
-    UNLOCK: Array = jnp.asarray(5, dtype=jnp.int32)
+    Plain strings, not jax arrays - `EventsManager.events` keys off
+    `(entity_type, event_type)` tuples, and a jax pytree's dict keys
+    must be static, hashable Python values, not traced arrays."""
+
+    NONE: str = "none"
+    REACH: str = "reach"
+    HIT: str = "hit"
+    FALL: str = "fall"
+    PICKUP: str = "pickup"
+    OPEN: str = "open"
+    UNLOCK: str = "unlock"
+
+
+GRID = "grid"
+"""Pseudo entity-type key for a wall-hit against the grid boundary or a
+non-walkable empty cell, as opposed to hitting an actual `Wall` entity
+- `EventsManager.record_grid_hit`/`record_wall_hit` write to separate
+`(GRID, EventType.HIT)`/`(Entities.WALL, EventType.HIT)` slots so they
+never fight over the same one; `navix.events.on_wall_hit` ORs both
+together, so the distinction is invisible to callers that only care
+whether a wall was hit at all."""
 
 
 class Event(Positionable, HasColour):
     """A struct representing an event that happened in the environment. It contains the
-    position of the event, the colour of the entity involved in the event, whether the event
-    happened, and the type of event that happened.
+    position of the event, the colour of the entity involved in the event, and whether the
+    event happened.
 
     !!! note
         Notice that we need the `happened` property, which flags if an event has
@@ -57,19 +72,44 @@ class Event(Positionable, HasColour):
         This means that we cannot add an event to the list in the middle of training.
         Instead, we initialise all events, and mask them out as not happened.
 
+    Every field of an `Event` stored in `EventsManager.events` is batched to match
+    the entity type it tracks (see `empty_like`) - one slot per instance, not one
+    scalar per event type - so e.g. two balls hitting the player the same step are
+    two independent `True` entries, not collapsed into one (see issue #139).
 
     Attributes:
         position (Array): The (row, column) position of the event in the grid.
         colour (Array): The colour of the entity involved in the event.
         happened (Array): A boolean flag indicating whether the event happened.
-        event_type (Array): The type of event that happened."""
+    """
 
     position: Array = field(
         default_factory=lambda: jnp.asarray([-1, -1], dtype=jnp.int32)
     )
     colour: Array = field(default_factory=lambda: PALETTE.UNSET)
     happened: Array = field(default_factory=lambda: jnp.asarray(False, dtype=jnp.bool_))
-    event_type: Array = field(default_factory=lambda: EventType.NONE)
+
+    @classmethod
+    def empty_like(cls, entity: Entity) -> Event:
+        """An all-`happened=False` `Event`, batched to match `entity`'s own
+        shape (one slot per instance of `entity`) rather than a single
+        scalar slot.
+
+        Args:
+            entity (Entity): The entity type this event tracks - e.g.
+                `state.entities[Entities.BALL]`.
+
+        Returns:
+            Event: `position`/`colour`/`happened`, each broadcast to
+            `entity.shape` (plus `position`'s own trailing `(2,)`)."""
+        shape = entity.shape
+        return cls(
+            position=jnp.broadcast_to(
+                jnp.asarray([-1, -1], dtype=jnp.int32), (*shape, 2)
+            ),
+            colour=jnp.broadcast_to(PALETTE.UNSET, shape),
+            happened=jnp.broadcast_to(jnp.asarray(False, dtype=jnp.bool_), shape),
+        )
 
     def __eq__(self, other: Event) -> Array:
         return jnp.logical_and(
@@ -82,28 +122,126 @@ class Event(Positionable, HasColour):
 
 
 class EventsManager(struct.PyTreeNode):
-    """A struct that manages the events. It contains the different events that can happen
-    in the environment, such as the goal being reached, the player being hit by a ball, etc.
+    """A struct that manages the events that happened in the environment this
+    step, such as the goal being reached, the player being hit by a ball, etc.
+
+    Keyed by `(entity_type, event_type)` rather than one named field per
+    event type, and each slot's `Event` is batched to match that entity
+    type's own instance count (see `Event.empty_like`) - this is what lets
+    two independent occurrences of the same event type (e.g. two balls
+    both hitting the player) coexist within one step, rather than one
+    replacing the other (see issue #139). `record_*` merges new hits into
+    a slot rather than replacing it wholesale, so a call earlier in the
+    same step's transition pipeline (e.g. the player walking into a ball)
+    isn't discarded by a later one (e.g. a different ball moving onto the
+    player) writing the same slot.
 
     Attributes:
-        goal_reached (Event): An event indicating that the goal has been reached.
-        ball_hit (Event): An event indicating that the player has been hit by a ball.
-        wall_hit (Event): An event indicating that the player has hit a wall.
-        lava_fall (Event): An event indicating that the lava has fallen.
-        key_pickup (Event): An event indicating that the player has picked up a key.
-        door_opening (Event): An event indicating that the player has opened a door.
-        door_unlock (Event): An event indicating that the player has unlocked a door.
-        ball_pickup (Event): An event indicating that the player has picked up a ball.
+        events (Dict[Tuple[str, str], Event]): One `Event` slot per
+            `(entity_type, event_type)` this environment's entities can
+            actually produce - see `create`. Not meant to be constructed
+            directly; `State.__post_init__` calls `create` automatically
+            from `State.entities`.
     """
 
-    goal_reached: Event = Event()
-    ball_hit: Event = Event()
-    wall_hit: Event = Event()
-    lava_fall: Event = Event()
-    key_pickup: Event = Event()
-    door_opening: Event = Event()
-    door_unlock: Event = Event()
-    ball_pickup: Event = Event()
+    events: Dict[Tuple[str, str], Event] = struct.field(default_factory=dict)
+
+    @classmethod
+    def create(cls, entities: Dict[str, Entity]) -> EventsManager:
+        """Builds one all-`happened=False` `Event` slot per `(entity_type,
+        event_type)` this environment's `entities` can actually produce -
+        e.g. `(Entities.BALL, EventType.HIT)` only exists if
+        `Entities.BALL in entities`. Called automatically by
+        `State.__post_init__`; not meant to be called directly.
+
+        Args:
+            entities (Dict[str, Entity]): `State.entities`.
+
+        Returns:
+            EventsManager: A fresh, all-`happened=False` manager."""
+        events: Dict[Tuple[str, str], Event] = {(GRID, EventType.HIT): Event()}
+        if Entities.GOAL in entities:
+            events[Entities.GOAL, EventType.REACH] = Event.empty_like(
+                entities[Entities.GOAL]
+            )
+        if Entities.WALL in entities:
+            events[Entities.WALL, EventType.HIT] = Event.empty_like(
+                entities[Entities.WALL]
+            )
+        if Entities.LAVA in entities:
+            events[Entities.LAVA, EventType.FALL] = Event.empty_like(
+                entities[Entities.LAVA]
+            )
+        if Entities.KEY in entities:
+            events[Entities.KEY, EventType.PICKUP] = Event.empty_like(
+                entities[Entities.KEY]
+            )
+        if Entities.DOOR in entities:
+            events[Entities.DOOR, EventType.OPEN] = Event.empty_like(
+                entities[Entities.DOOR]
+            )
+            events[Entities.DOOR, EventType.UNLOCK] = Event.empty_like(
+                entities[Entities.DOOR]
+            )
+        if Entities.BALL in entities:
+            events[Entities.BALL, EventType.HIT] = Event.empty_like(
+                entities[Entities.BALL]
+            )
+            events[Entities.BALL, EventType.PICKUP] = Event.empty_like(
+                entities[Entities.BALL]
+            )
+        return cls(events=events)
+
+    def happened(self, key: Tuple[str, str]) -> Array:
+        """Whether any instance of `key`'s `(entity_type, event_type)` slot
+        fired this step - `False` (not a `KeyError`) if this environment's
+        `entities` never included that entity type at all (see `create`).
+
+        Args:
+            key (Tuple[str, str]): The `(entity_type, event_type)` slot to
+                check.
+
+        Returns:
+            Array: A boolean scalar."""
+        event = self.events.get(key)
+        if event is None:
+            return jnp.asarray(False)
+        return jnp.any(event.happened)
+
+    def merge_event(
+        self, key: Tuple[str, str], hit: Array, position: Array, colour: Array
+    ) -> EventsManager:
+        """Records `hit` into `key`'s `Event` slot, OR-merging onto
+        whatever already happened this step rather than replacing it
+        wholesale - so a call earlier in the same step's transition
+        pipeline isn't silently discarded by a later one writing the same
+        slot (see issue #139). `position`/`colour` are written only where
+        `hit` is newly `True`; already-`True` entries keep their existing
+        stored `position`/`colour`.
+
+        Args:
+            key (Tuple[str, str]): The `(entity_type, event_type)` slot to
+                update - must already exist (see `create`).
+            hit (Array): Boolean - per-instance for a batched slot (e.g.
+                `Entities.BALL, EventType.HIT`), a bare scalar for a
+                single-instance slot (e.g. `GRID, EventType.HIT`).
+            position (Array): This instance's own position - written
+                where `hit` is `True`.
+            colour (Array): This instance's own colour - written where
+                `hit` is `True`.
+
+        Returns:
+            EventsManager: The updated events manager."""
+        existing = self.events[key]
+        hit = jnp.asarray(hit, dtype=jnp.bool_)
+        happened = jnp.logical_or(existing.happened, hit)
+        new_position = jnp.where(hit[..., None], position, existing.position)
+        new_colour = jnp.where(hit, colour, existing.colour)
+        events = dict(self.events)
+        events[key] = existing.replace(
+            position=new_position, colour=new_colour, happened=happened
+        )
+        return self.replace(events=events)
 
     def record_walk_into(self, entity: Entity, position: Array) -> EventsManager:
         """Flags an event when the player walks into an entity as happened and returns the
@@ -115,15 +253,15 @@ class EventsManager(struct.PyTreeNode):
 
         Returns:
             EventsManager: The updated events manager."""
+        hit = positions_equal(entity.position, position)
         if isinstance(entity, Goal):
-            return self.record_goal_reached(entity, position)
+            return self.record_goal_reached(entity, hit)
         elif isinstance(entity, Wall):
-            return self.record_wall_hit(entity, position)
+            return self.record_wall_hit(entity, hit)
         elif isinstance(entity, Lava):
-            return self.record_lava_fall(entity, position)
+            return self.record_lava_fall(entity, hit)
         elif isinstance(entity, Ball):
-            idx = jnp.where(entity.position == position, size=1)[0][0]
-            return self.record_ball_hit(entity[idx])
+            return self.record_ball_hit(entity, hit)
         return self
 
     def record_pickup(self, entity: Entity, position: Array) -> EventsManager:
@@ -136,193 +274,138 @@ class EventsManager(struct.PyTreeNode):
 
         Returns:
             EventsManager: The updated events manager."""
+        hit = positions_equal(entity.position, position)
         if isinstance(entity, Key):
-            return self.record_key_pickup(entity, position)
+            return self.record_key_pickup(entity, hit)
         elif isinstance(entity, Ball):
-            return self.record_ball_pickup(entity, position)
+            return self.record_ball_pickup(entity, hit)
         return self
 
-    def record_goal_reached(self, goal: Goal, position: Array) -> EventsManager:
+    def record_goal_reached(self, goal: Goal, hit: Array) -> EventsManager:
         """Flags an event when the player reaches the goal as happened and returns the
         updated events manager.
 
         Args:
-            goal (Goal): The goal the player reached.
-            position (Array): The position of the goal in the grid.
+            goal (Goal): Every `Goal` instance in the environment.
+            hit (Array): Boolean, one entry per `goal` instance.
 
         Returns:
             EventsManager: The updated events manager."""
-        idx = jnp.where(goal.position == position, size=1)[0][0]
-        goal = goal[idx]
-        return self.replace(
-            goal_reached=Event(
-                position=position,
-                colour=PALETTE.UNSET,
-                happened=jnp.asarray(True, dtype=jnp.bool_),
-                event_type=EventType.REACH,
-            )
+        return self.merge_event(
+            (Entities.GOAL, EventType.REACH), hit, goal.position, PALETTE.UNSET
         )
 
-    def record_ball_hit(self, ball: Ball) -> EventsManager:
+    def record_ball_hit(self, ball: Ball, hit: Array) -> EventsManager:
         """Flags an event when the player is hit by a ball as happened and returns the
         updated events manager.
 
         Args:
-            ball (Ball): The ball that hit the player.
+            ball (Ball): Every `Ball` instance in the environment.
+            hit (Array): Boolean, one entry per `ball` instance.
 
         Returns:
             EventsManager: The updated events manager."""
-        return self.replace(
-            ball_hit=Event(
-                position=ball.position,
-                colour=ball.colour,
-                happened=jnp.asarray(True, dtype=jnp.bool_),
-                event_type=EventType.HIT,
-            )
+        return self.merge_event(
+            (Entities.BALL, EventType.HIT), hit, ball.position, ball.colour
         )
 
-    def record_wall_hit(self, wall: Wall, position: Array) -> EventsManager:
+    def record_wall_hit(self, wall: Wall, hit: Array) -> EventsManager:
         """Flags an event when the player hits a wall as happened and returns the
         updated events manager.
 
         Args:
-            wall (Wall): The wall the player hit.
-            position (Array): The position of the wall in the grid.
+            wall (Wall): Every `Wall` instance in the environment.
+            hit (Array): Boolean, one entry per `wall` instance.
 
         Returns:
             EventsManager: The updated events manager."""
-        idx = jnp.where(wall.position == position, size=1)[0][0]
-        wall = wall[idx]
-        return self.replace(
-            wall_hit=Event(
-                position=wall.position,
-                colour=PALETTE.UNSET,
-                happened=jnp.asarray(True, dtype=jnp.bool_),
-                event_type=EventType.HIT,
-            )
+        return self.merge_event(
+            (Entities.WALL, EventType.HIT), hit, wall.position, PALETTE.UNSET
         )
 
     def record_grid_hit(self, position: Array) -> EventsManager:
-        """Flags an event when the player hits a wall as happened and returns the
-        updated events manager.
+        """Flags an event when the player hits the grid boundary or a
+        non-walkable empty cell (no `Wall` entity there) as happened and
+        returns the updated events manager. Kept in a separate `GRID` slot
+        from `record_wall_hit` (see `GRID`'s docstring).
 
         Args:
-            position (Array): The position of the wall in the grid.
+            position (Array): The position hit.
 
         Returns:
             EventsManager: The updated events manager."""
-        return self.replace(
-            wall_hit=Event(
-                position=position,
-                colour=PALETTE.UNSET,
-                happened=jnp.asarray(True, dtype=jnp.bool_),
-                event_type=EventType.HIT,
-            )
+        return self.merge_event(
+            (GRID, EventType.HIT), jnp.asarray(True), position, PALETTE.UNSET
         )
 
-    def record_lava_fall(self, lava: Lava, position: Array) -> EventsManager:
+    def record_lava_fall(self, lava: Lava, hit: Array) -> EventsManager:
         """Flags an event when the lava falls as happened and returns the
         updated events manager.
 
         Args:
-            lava (Lava): The lava that fell.
-            position (Array): The position of the lava in the grid.
+            lava (Lava): Every `Lava` instance in the environment.
+            hit (Array): Boolean, one entry per `lava` instance.
 
         Returns:
             EventsManager: The updated events manager."""
-        idx = jnp.where(lava.position == position, size=1)[0][0]
-        lava = lava[idx]
-        return self.replace(
-            lava_fall=Event(
-                position=lava.position,
-                colour=PALETTE.UNSET,
-                happened=jnp.asarray(True, dtype=jnp.bool_),
-                event_type=EventType.FALL,
-            )
+        return self.merge_event(
+            (Entities.LAVA, EventType.FALL), hit, lava.position, PALETTE.UNSET
         )
 
-    def record_key_pickup(self, key: Key, position: Array) -> EventsManager:
+    def record_key_pickup(self, key: Key, hit: Array) -> EventsManager:
         """Flags an event when the player picks up a key as happened and returns the
         updated events manager.
 
         Args:
-            key (Key): The key the player picked up.
-            position (Array): The position of the key in the grid.
+            key (Key): Every `Key` instance in the environment.
+            hit (Array): Boolean, one entry per `key` instance.
 
         Returns:
             EventsManager: The updated events manager."""
-        idx = jnp.where(key.position == position, size=1)[0][0]
-        key = key[idx]
-        return self.replace(
-            key_pickup=Event(
-                position=key.position,
-                colour=key.colour,
-                happened=jnp.asarray(True, dtype=jnp.bool_),
-                event_type=EventType.PICKUP,
-            )
+        return self.merge_event(
+            (Entities.KEY, EventType.PICKUP), hit, key.position, key.colour
         )
 
-    def record_door_opening(self, door: Door, position: Array) -> EventsManager:
+    def record_door_opening(self, door: Door, hit: Array) -> EventsManager:
         """Flags an event when the player opens a door as happened and returns the
         updated events manager.
 
         Args:
-            door (Door): The door the player opened.
-            position (Array): The position of the door in the grid.
+            door (Door): Every `Door` instance in the environment.
+            hit (Array): Boolean, one entry per `door` instance.
 
         Returns:
             EventsManager: The updated events manager."""
-        idx = jnp.where(door.position == position, size=1)[0][0]
-        door = door[idx]
-        return self.replace(
-            door_opening=Event(
-                position=door.position,
-                colour=door.colour,
-                happened=jnp.asarray(True, dtype=jnp.bool_),
-                event_type=EventType.OPEN,
-            )
+        return self.merge_event(
+            (Entities.DOOR, EventType.OPEN), hit, door.position, door.colour
         )
 
-    def record_door_unlock(self, door: Door, position: Array) -> EventsManager:
+    def record_door_unlock(self, door: Door, hit: Array) -> EventsManager:
         """Flags an event when the player unlocks a door as happened and returns the
         updated events manager.
 
         Args:
-            door (Door): The door the player unlocked.
-            position (Array): The position of the door in the grid.
+            door (Door): Every `Door` instance in the environment.
+            hit (Array): Boolean, one entry per `door` instance.
 
         Returns:
             EventsManager: The updated events manager."""
-        idx = jnp.where(door.position == position, size=1)[0][0]
-        door = door[idx]
-        return self.replace(
-            door_opening=Event(
-                position=door.position,
-                colour=door.colour,
-                happened=jnp.asarray(True, dtype=jnp.bool_),
-                event_type=EventType.UNLOCK,
-            )
+        return self.merge_event(
+            (Entities.DOOR, EventType.UNLOCK), hit, door.position, door.colour
         )
 
-    def record_ball_pickup(self, ball: Ball, position: Array) -> EventsManager:
+    def record_ball_pickup(self, ball: Ball, hit: Array) -> EventsManager:
         """Flags an event when the player picks up a ball as happened and returns the
         updated events manager.
 
         Args:
-            ball (Ball): The ball the player picked up.
-            position (Array): The position of the ball in the grid.
+            ball (Ball): Every `Ball` instance in the environment.
+            hit (Array): Boolean, one entry per `ball` instance.
 
         Returns:
             EventsManager: The updated events manager."""
-        idx = jnp.where(ball.position == position, size=1)[0][0]
-        ball = ball[idx]
-        return self.replace(
-            ball_pickup=Event(
-                position=ball.position,
-                colour=ball.colour,
-                happened=jnp.asarray(True, dtype=jnp.bool_),
-                event_type=EventType.PICKUP,
-            )
+        return self.merge_event(
+            (Entities.BALL, EventType.PICKUP), hit, ball.position, ball.colour
         )
 
 
@@ -340,8 +423,20 @@ class State(struct.PyTreeNode):
     Batched over the number of entities for each type"""
     events: EventsManager = EventsManager()
     """A struct indicating which events happened this timestep. For example, the
-    goal is reached, or the player is hit by a ball."""
+    goal is reached, or the player is hit by a ball. Left at its default (empty)
+    here - `__post_init__` populates it from `entities` via `EventsManager.create`,
+    since a `struct.PyTreeNode` field's default can't see its sibling fields."""
     mission: Event | None = None
+
+    def __post_init__(self) -> None:
+        # events.events is only ever empty right after construction with no
+        # explicit `events=...` (the default `EventsManager()` above) - once
+        # populated, it's never emptied again (record_* only ever adds/merges
+        # entries into existing slots, see EventsManager.merge_event), so this
+        # correctly runs exactly once per episode (at _reset time), not on
+        # every subsequent .replace() call within an episode.
+        if not self.events.events:
+            object.__setattr__(self, "events", EventsManager.create(self.entities))
 
     def get_entity(self, entity_enum: str) -> Entity:
         """Get an entity from the state by its enum.

--- a/navix/transitions.py
+++ b/navix/transitions.py
@@ -25,7 +25,7 @@ from jax import Array
 import jax
 import jax.numpy as jnp
 from .entities import Entities, Ball
-from .states import EventsManager, State
+from .states import State
 from .grid import positions_equal, translate
 
 
@@ -69,53 +69,50 @@ def stochastic_transition(
 def update_balls(state: State) -> State:
     """Update the position of the balls in the game.
     Balls move in a random direction if they can, otherwise they stay in place.
-    
+
     Args:
         state (State): The current state of the game.
-    
+
     Returns:
         State: The new state of the game."""
-    def update_one(ball: Ball, key: Array) -> Tuple[Array, EventsManager]:
+    def update_one(ball: Ball, key: Array) -> Tuple[Array, Array]:
         direction = jax.random.randint(key, (), minval=0, maxval=4)
         new_position = translate(ball.position, direction)
         new_ball = ball.replace(position=new_position)
-        can_move, events = _can_spawn_there(state, new_ball)
-        return jnp.where(can_move, new_ball.position, ball.position), events
+        can_move, hit = _can_spawn_there(state, new_ball)
+        return jnp.where(can_move, new_ball.position, ball.position), hit
 
     if Entities.BALL in state.entities:
         balls: Ball = state.entities[Entities.BALL]  # type: ignore
         keys = jax.random.split(state.key, len(balls.position) + 1)
-        new_position, new_events = jax.jit(jax.vmap(update_one))(balls, keys[1:])
+        # hit is one boolean per ball, computed independently for every
+        # ball in the same vmapped call - merged into events.events in one
+        # shot below, so two different balls hitting the player the same
+        # step both survive (see EventsManager.record_ball_hit/merge_event,
+        # issue #139), instead of collapsing to only the first one found.
+        new_position, hit = jax.jit(jax.vmap(update_one))(balls, keys[1:])
         # update balls
         balls = balls.replace(position=new_position)
         state = state.set_balls(balls)
         # update events
-        # take only the first happened event (even if happened already)
-        idx = jnp.where(new_events.ball_hit.happened, size=1)[0][0]  # scalar
-        ball_hits = jax.tree.map(lambda x: x[idx], new_events.ball_hit)
-        events = state.events.replace(ball_hit=ball_hits)
+        events = state.events.record_ball_hit(balls, hit)
         state = state.replace(key=keys[0], events=events)
     return state
 
 
-def _can_spawn_there(state: State, ball: Ball) -> Tuple[Array, EventsManager]:
+def _can_spawn_there(state: State, ball: Ball) -> Tuple[Array, Array]:
     # according to the grid
     walkable = jnp.equal(state.grid[tuple(ball.position)], 0)
 
     # according to entities
-    events = state.events
+    hit = jnp.asarray(False)
     entities = state.entities
     for k in state.entities:
         obstructs = positions_equal(entities[k].position, ball.position)[0]
         if k == Entities.PLAYER:
-            events = jax.lax.cond(
-                obstructs,
-                lambda x: x.record_ball_hit(ball),
-                lambda x: x,
-                events,
-            )
+            hit = jnp.logical_or(hit, obstructs)
         walkable = jnp.logical_and(walkable, jnp.any(jnp.logical_not(obstructs)))
-    return jnp.asarray(walkable, dtype=jnp.bool_), events
+    return jnp.asarray(walkable, dtype=jnp.bool_), hit
 
 
 DEFAULT_TRANSITION = stochastic_transition

--- a/tests/issue_92.py
+++ b/tests/issue_92.py
@@ -2,7 +2,7 @@
 
 import jax
 import navix as nx
-from navix.states import Event, EventType
+from navix.states import Event
 
 
 def test_issue_92():
@@ -11,7 +11,6 @@ def test_issue_92():
         position=jax.numpy.asarray([-1, -1]),
         colour=jax.numpy.asarray([255, 0, 0]),
         happened=jax.numpy.asarray(False),
-        event_type=EventType.NONE,
     )
     # try instantiate environment
     env = nx.make("Navix-KeyCorridorS6R3-v0")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,401 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Thorough, hand-crafted-policy coverage of `EventsManager` (issue #139),
+one real registered environment/seed per event type, verified against the
+environment's actual map rather than a synthetic hand-built `State`
+wherever a real environment can exercise the same code path.
+`tests/test_issues.py::test_139` covers the exact original bug scenarios
+(multi-ball collapse, cross-call-site clobbering) with a seed-swept
+synthetic state; this file is the complementary "does every event
+actually fire correctly, with the right position/colour, in real
+gameplay" pass, plus direct coverage of the two `record_*` methods no
+current action ever reaches (`record_door_unlock`, `record_ball_pickup`
+- see their own tests below).
+
+Every test reads the actually-placed entity positions from the live
+reset state and derives its policy from those, rather than hardcoding
+literal coordinates - `jax.random.PRNGKey(seed)` is only deterministic
+*within* one jax version, not across them (confirmed the hard way: this
+file originally hardcoded positions hand-read on jax 0.4.30, which CI's
+jax 0.11.1 does not reproduce for the same seed - same environment code,
+same seed, genuinely different procedurally-generated layout). Reading
+positions from the live state instead of assuming them keeps these
+tests meaningful regardless of which jax version produced the layout.
+
+Every test calls `navix.actions`/`navix.transitions` functions directly
+(not `env.step`), so movement is fully deterministic - `env.step`'s
+`stochastic_transition` also runs `update_balls` (random per-step ball
+movement) after every action, which would make navigation
+non-reproducible."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+import navix as nx
+from navix.components import EMPTY_POCKET_ID
+from navix.entities import Entities
+from navix.states import EventType, GRID
+
+
+EAST, SOUTH, WEST, NORTH = 0, 1, 2, 3
+
+
+def face(state, direction: int):
+    """Rotates (0-3 times, whichever is fewer) until the player faces
+    `direction`."""
+    for _ in range(4):
+        if int(state.get_player().direction) == direction:
+            return state
+        state = nx.actions.rotate_cw(state)
+    raise AssertionError(f"could not face direction {direction}")
+
+
+def walk(state, direction: int, steps: int):
+    """Faces `direction`, then calls `actions.forward` `steps` times."""
+    state = face(state, direction)
+    for _ in range(steps):
+        state = nx.actions.forward(state)
+    return state
+
+
+def walk_to(state, row: int, col: int):
+    """Moves the player onto `(row, col)`, first aligning the row (N/S)
+    then the column (E/W). Only used between cells hand-verified (per
+    call site below) to have no obstacle along that L-shaped path - not
+    a general pathfinder."""
+    player = state.get_player()
+    delta_row = row - int(player.position[0])
+    if delta_row > 0:
+        state = walk(state, SOUTH, delta_row)
+    elif delta_row < 0:
+        state = walk(state, NORTH, -delta_row)
+    player = state.get_player()
+    delta_col = col - int(player.position[1])
+    if delta_col > 0:
+        state = walk(state, EAST, delta_col)
+    elif delta_col < 0:
+        state = walk(state, WEST, -delta_col)
+    return state
+
+
+def test_grid_hit_boundary_not_wall_entity():
+    # Navix-Empty-5x5-v0 is fully deterministic (no jax.random calls in
+    # its _reset at all) and has no Wall entities - its boundary is pure
+    # grid (grid[r, c] != 0), so walking into it must record (GRID,
+    # HIT), not (WALL, HIT).
+    env = nx.make("Navix-Empty-5x5-v0")
+    timestep = env.reset(jax.random.PRNGKey(0))
+    state = timestep.state
+    assert Entities.WALL not in state.entities, (
+        "test assumes Empty-5x5 has no Wall entities - if this changes, "
+        "this test needs a different environment for a clean GRID-only case"
+    )
+    player = state.get_player()
+    assert jnp.array_equal(player.position, jnp.asarray((1, 1)))
+    assert int(player.direction) == 0  # east
+
+    # face north then walk into the boundary one row above the player's
+    # start - (0, 1), a plain grid cell.
+    state = face(state, NORTH)
+    state = nx.actions.forward(state)
+
+    player = state.get_player()
+    assert jnp.array_equal(player.position, jnp.asarray((1, 1))), (
+        "player must not move into the (non-walkable) grid boundary"
+    )
+    assert state.events.happened((GRID, EventType.HIT)), (
+        "expected the grid-boundary hit to be recorded under the GRID "
+        "pseudo entity-type slot"
+    )
+    assert not state.events.happened((Entities.WALL, EventType.HIT)), (
+        "there is no Wall entity here - (WALL, HIT) must not fire"
+    )
+    assert state.events.events[GRID, EventType.HIT].position.tolist() == [
+        0,
+        1,
+    ], "the recorded grid-hit position should be the boundary cell that was hit"
+    assert not state.events.happened((Entities.GOAL, EventType.REACH))
+
+    # on_wall_hit must be True too - it ORs (GRID, HIT) and (WALL, HIT).
+    assert bool(nx.events.on_wall_hit(state))
+
+
+def test_wall_key_door_goal_sequence():
+    # Navix-DoorKey-5x5-v0: player/goal positions are fixed (random_start
+    # defaults to False), but door_row (and so which wall row has the
+    # gap, and which row of the single-column first room the key lands
+    # in) is genuinely randomised (navix/environments/door_key.py) - read
+    # every position from the live state and derive the policy from
+    # that. One coherent policy exercises WALL/HIT, KEY/PICKUP, DOOR/OPEN
+    # and GOAL/REACH in narrative order.
+    env = nx.make("Navix-DoorKey-5x5-v0")
+    timestep = env.reset(jax.random.PRNGKey(0))
+    state = timestep.state
+
+    doors = state.get_doors()
+    door_row, door_col = int(doors.position[0, 0]), int(doors.position[0, 1])
+    assert bool(doors.requires[0] != -1), "the door must start locked"
+
+    wall = state.entities[Entities.WALL]
+    assert wall.position[:, 1].tolist() == [door_col] * wall.position.shape[0], (
+        "every wall instance shares the door's own column"
+    )
+    wall_row = int(wall.position[0, 0])
+    assert wall_row != door_row, (
+        "the door's own row is excluded from the wall column by construction"
+    )
+
+    key = state.get_keys()
+    key_row, key_col = int(key.position[0, 0]), int(key.position[0, 1])
+    assert key_col == door_col - 1, "the key must be in the first room"
+
+    goal = state.get_goals()
+    goal_row, goal_col = int(goal.position[0, 0]), int(goal.position[0, 1])
+
+    player = state.get_player()
+    assert player.position.tolist() == [1, 1]
+    assert int(player.direction) == 0  # east
+
+    # 1. walk into a confirmed real Wall instance: blocked, WALL/HIT
+    # fires for that instance only, GRID/HIT must NOT also fire (real
+    # Wall entity, not a bare grid cell).
+    state = walk_to(state, wall_row, door_col - 1)
+    state = face(state, EAST)
+    assert not state.events.happened((Entities.WALL, EventType.HIT))
+    state = nx.actions.forward(state)
+    assert state.get_player().position.tolist() == [wall_row, door_col - 1], (
+        "must not move into a Wall"
+    )
+    wall_hit = state.events.events[Entities.WALL, EventType.HIT]
+    assert bool(jnp.any(wall_hit.happened))
+    hit_idx = int(jnp.argmax(wall_hit.happened))
+    assert wall_hit.position[hit_idx].tolist() == [wall_row, door_col]
+    assert not state.events.happened((GRID, EventType.HIT))
+    assert bool(nx.events.on_wall_hit(state))
+
+    # 2. pick up the key from the cell just before it (Key.walkable is
+    # False, so pickup has to happen from an adjacent cell facing it,
+    # not by stepping onto it).
+    state = walk_to(state, key_row - 1, key_col)
+    state = face(state, SOUTH)
+    assert not state.events.happened((Entities.KEY, EventType.PICKUP))
+    state = nx.actions.pickup(state)
+    player = state.get_player()
+    assert int(player.pocket) != int(EMPTY_POCKET_ID), (
+        "the key's id should now be in the player's pocket"
+    )
+    key_pickup = state.events.events[Entities.KEY, EventType.PICKUP]
+    assert bool(key_pickup.happened[0])
+    assert key_pickup.position[0].tolist() == [key_row, key_col]
+    assert int(key_pickup.colour[0]) == int(key.colour[0]), (
+        "the recorded colour should be the actual picked-up key's own colour"
+    )
+
+    # 3. step onto the now-vacated key cell, then to the door.
+    state = walk_to(state, key_row, key_col)
+    state = walk_to(state, door_row, door_col - 1)
+    state = face(state, EAST)
+
+    # 4. open the door - the player's key matches, so it unlocks and
+    # opens in the same action (see actions.open); DOOR/OPEN fires,
+    # DOOR/UNLOCK does not (no current action ever calls record_door_
+    # unlock - see test_door_unlock_and_ball_pickup_are_directly_
+    # testable below for why, and direct coverage of it).
+    assert not state.events.happened((Entities.DOOR, EventType.OPEN))
+    state = nx.actions.open(state)
+    doors_after = state.get_doors()
+    assert bool(doors_after.open[0]), "the door should now be open"
+    assert int(doors_after.requires[0]) == -1, "and unlocked"
+    door_opening = state.events.events[Entities.DOOR, EventType.OPEN]
+    assert bool(door_opening.happened[0])
+    assert door_opening.position[0].tolist() == [door_row, door_col]
+    assert not state.events.happened((Entities.DOOR, EventType.UNLOCK))
+
+    # 5. walk through the now-open door onto the goal - GOAL/REACH fires.
+    # (door_row can equal goal_row, in which case stepping through the
+    # door already lands on the goal - so the "not yet reached" check
+    # has to happen before any of these moves, not partway through.)
+    assert not state.events.happened((Entities.GOAL, EventType.REACH))
+    state = nx.actions.forward(state)  # onto the (now open) door cell
+    state = walk_to(state, door_row, door_col + 1)  # into the second room
+    state = walk_to(state, goal_row, goal_col)
+    player = state.get_player()
+    assert player.position.tolist() == [goal_row, goal_col]
+    goal_reached = state.events.events[Entities.GOAL, EventType.REACH]
+    assert bool(goal_reached.happened[0])
+    assert goal_reached.position[0].tolist() == [goal_row, goal_col]
+    assert bool(nx.events.on_goal_reached(state))
+
+    # every earlier event recorded in this same episode must still be
+    # True - EventsManager never resets happened back to False mid-
+    # episode (see State.__post_init__/EventsManager.merge_event).
+    assert bool(jnp.any(state.events.events[Entities.WALL, EventType.HIT].happened))
+    assert bool(state.events.events[Entities.KEY, EventType.PICKUP].happened[0])
+    assert bool(state.events.events[Entities.DOOR, EventType.OPEN].happened[0])
+
+
+def test_lava_fall():
+    # Navix-LavaGapS5-v0: player/goal positions are fixed, but the gap
+    # row (and so which of the two lava-column rows actually holds lava)
+    # is randomised (navix/environments/lava_gap.py) - read the live
+    # positions rather than assuming them. Lava.walkable is True
+    # (matching real MiniGrid semantics - stepping on lava ends the
+    # episode via on_lava_fall termination rather than blocking
+    # movement), so walking forward both moves the player onto it and
+    # records LAVA/FALL, in the same step.
+    env = nx.make("Navix-LavaGapS5-v0")
+    timestep = env.reset(jax.random.PRNGKey(0))
+    state = timestep.state
+
+    lava = state.get_lavas()
+    lava_row, lava_col = int(lava.position[0, 0]), int(lava.position[0, 1])
+    player = state.get_player()
+    assert player.position.tolist() == [1, 1]
+    assert int(player.direction) == 0  # east
+    assert lava_col > 1, "the lava column is always to the east of the player's start"
+
+    state = walk_to(state, lava_row, lava_col - 1)
+    state = face(state, EAST)
+    assert not state.events.happened((Entities.LAVA, EventType.FALL))
+    state = nx.actions.forward(state)
+
+    player = state.get_player()
+    assert player.position.tolist() == [lava_row, lava_col], (
+        "the player should have moved onto the (walkable) lava tile"
+    )
+    lava_fall = state.events.events[Entities.LAVA, EventType.FALL]
+    assert bool(jnp.any(lava_fall.happened))
+    hit_idx = int(jnp.argmax(lava_fall.happened))
+    assert lava_fall.position[hit_idx].tolist() == [lava_row, lava_col]
+    assert bool(nx.events.on_lava_fall(state))
+
+
+def test_ball_hit_walk_into():
+    # Navix-Dynamic-Obstacles-5x5-v0: ball positions are placed fully at
+    # random anywhere in the interior (navix/environments/
+    # dynamic_obstacles.py's random_positions, excluding the player/goal
+    # cells) - not confined to a predictable line the way DoorKey's key
+    # or LavaGap's lava column are, so there's no small L-shaped walk
+    # guaranteed obstacle-free between the player's start and an
+    # arbitrary ball. Real reset (real player/goal/grid), balls
+    # relocated to a fixed, hand-verifiable spot for the walk-into check
+    # specifically - real Ball entities/events machinery throughout,
+    # only the *position* is controlled. The genuinely-random-placement
+    # case (and two-balls-hit-in-one-step) is covered by
+    # tests/test_issues.py::test_139 instead, via a seed sweep rather
+    # than by controlling positions directly.
+    env = nx.make("Navix-Dynamic-Obstacles-5x5-v0")
+    timestep = env.reset(jax.random.PRNGKey(0))
+    state = timestep.state
+
+    player = state.get_player()
+    assert player.position.tolist() == [1, 1]
+    assert int(player.direction) == 0  # east
+
+    balls = state.get_balls()
+    balls = balls.replace(position=jnp.asarray([[3, 2], [2, 2]]))
+    state = state.replace(entities={**state.entities, Entities.BALL: balls})
+
+    state = walk_to(state, 2, 1)
+    state = face(state, EAST)
+
+    assert not state.events.happened((Entities.BALL, EventType.HIT))
+    state = nx.actions.forward(state)  # attempt (2, 1) -> (2, 2) = ball 1
+
+    player = state.get_player()
+    assert player.position.tolist() == [2, 1], (
+        "must not move into a Ball (Ball.walkable is False)"
+    )
+    ball_hit = state.events.events[Entities.BALL, EventType.HIT]
+    assert ball_hit.happened.tolist() == [False, True], (
+        "only ball index 1 (2, 2) was walked into, not index 0 (3, 2)"
+    )
+    assert ball_hit.position[1].tolist() == [2, 2]
+    assert int(ball_hit.colour[1]) == int(balls.colour[1])
+    assert bool(nx.events.on_ball_hit(state))
+
+
+def test_door_unlock_and_ball_pickup_are_directly_testable():
+    # record_door_unlock and record_ball_pickup are the two record_*
+    # methods no current navix action ever calls: actions.open only ever
+    # calls record_door_opening (even when it unlocks a locked door in
+    # the same step - see test_wall_key_door_goal_sequence above, where
+    # DOOR/UNLOCK stays False despite the door being both unlocked and
+    # opened), and actions.pickup only ever handles Key, never Ball
+    # (confirmed via grep across navix/ before writing this test - no
+    # call site for either exists outside states.py itself). That's a
+    # pre-existing gap unrelated to issue #139 (not something this PR
+    # changes), but merge_event's own correctness for these two slots
+    # is still worth verifying directly, the same way the reachable
+    # record_* methods are verified above through real gameplay.
+    env = nx.make("Navix-DoorKey-5x5-v0")
+    timestep = env.reset(jax.random.PRNGKey(0))
+    state = timestep.state
+    doors = state.get_doors()
+
+    assert not state.events.happened((Entities.DOOR, EventType.UNLOCK))
+    hit = jnp.asarray([True])
+    events = state.events.record_door_unlock(doors, hit)
+    door_unlock = events.events[Entities.DOOR, EventType.UNLOCK]
+    assert bool(door_unlock.happened[0])
+    assert door_unlock.position[0].tolist() == doors.position[0].tolist()
+    assert int(door_unlock.colour[0]) == int(doors.colour[0])
+    # the slot this didn't touch must be unaffected.
+    assert not events.happened((Entities.DOOR, EventType.OPEN))
+
+    env2 = nx.make("Navix-Dynamic-Obstacles-5x5-v0")
+    timestep2 = env2.reset(jax.random.PRNGKey(0))
+    state2 = timestep2.state
+    balls = state2.get_balls()
+
+    assert not state2.events.happened((Entities.BALL, EventType.PICKUP))
+    hit2 = jnp.asarray([False, True])
+    events2 = state2.events.record_ball_pickup(balls, hit2)
+    ball_pickup = events2.events[Entities.BALL, EventType.PICKUP]
+    assert ball_pickup.happened.tolist() == [False, True]
+    assert ball_pickup.position[1].tolist() == balls.position[1].tolist()
+    # BALL/HIT (a different slot for the same entity type) must be
+    # unaffected by writing BALL/PICKUP.
+    assert not events2.happened((Entities.BALL, EventType.HIT))
+
+
+def test_happened_returns_false_not_keyerror_for_absent_entity_type():
+    # Navix-Empty-5x5-v0 has no Wall/Key/Door/Lava/Ball entities at all -
+    # EventsManager.create never allocates those slots for it, so
+    # `happened` on any of them must gracefully return False, not raise.
+    env = nx.make("Navix-Empty-5x5-v0")
+    timestep = env.reset(jax.random.PRNGKey(0))
+    state = timestep.state
+
+    for entities in (Entities.WALL, Entities.KEY, Entities.DOOR, Entities.LAVA, Entities.BALL):
+        assert entities not in state.entities
+
+    assert not bool(state.events.happened((Entities.WALL, EventType.HIT)))
+    assert not bool(state.events.happened((Entities.KEY, EventType.PICKUP)))
+    assert not bool(state.events.happened((Entities.DOOR, EventType.OPEN)))
+    assert not bool(state.events.happened((Entities.DOOR, EventType.UNLOCK)))
+    assert not bool(state.events.happened((Entities.LAVA, EventType.FALL)))
+    assert not bool(state.events.happened((Entities.BALL, EventType.HIT)))
+    assert not bool(state.events.happened((Entities.BALL, EventType.PICKUP)))
+    # on_wall_hit must still work (falls back to the always-present GRID
+    # slot) even though this environment has no Wall entities.
+    assert not bool(nx.events.on_wall_hit(state))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -39,11 +39,15 @@ same seed, genuinely different procedurally-generated layout). Reading
 positions from the live state instead of assuming them keeps these
 tests meaningful regardless of which jax version produced the layout.
 
-Every test calls `navix.actions`/`navix.transitions` functions directly
-(not `env.step`), so movement is fully deterministic - `env.step`'s
-`stochastic_transition` also runs `update_balls` (random per-step ball
-movement) after every action, which would make navigation
-non-reproducible."""
+Every test but the last calls `navix.actions`/`navix.transitions`
+functions directly (not `env.step`), so movement is fully deterministic
+- `env.step`'s `stochastic_transition` also runs `update_balls` (random
+per-step ball movement) after every action, which would make navigation
+non-reproducible.
+`test_events_reset_each_step_not_persisted_across_episode` is the
+exception - it specifically tests `Environment._step`'s own per-step
+events reset, which only `env.step` (not bare `navix.actions` calls)
+goes through."""
 
 from __future__ import annotations
 
@@ -399,3 +403,62 @@ def test_happened_returns_false_not_keyerror_for_absent_entity_type():
     # on_wall_hit must still work (falls back to the always-present GRID
     # slot) even though this environment has no Wall entities.
     assert not bool(nx.events.on_wall_hit(state))
+
+
+def test_events_reset_each_step_not_persisted_across_episode():
+    # EventsManager's own docstring says events are "which events
+    # happened this timestep" - but merge_event only ever ORs new hits
+    # onto whatever a slot already holds (necessary within one step's
+    # own compound transition pipeline - see issue #139, e.g. an action
+    # and transitions.update_balls both recording a hit in the same
+    # step must not clobber each other), so something has to actually
+    # clear a slot back to False *between different* steps, or a
+    # non-terminating reward/observation reading state.events would see
+    # a stale hit from N steps ago as if it just happened again (this
+    # was never observable for the terminating conditions - on_goal_
+    # reached/on_lava_fall/on_ball_hit all end the episode the first
+    # time they fire, so there's no later step to leak into before
+    # autoreset gives every entity a fresh EventsManager anyway - but a
+    # non-terminating one like rewards.wall_hit_cost would be, checked
+    # here directly instead). Environment._step now resets state.events
+    # to fresh right before running transitions_fn each step - verified
+    # here via a real env.step() cycle (the only test in this file that
+    # does; see this module's own docstring for why every other test
+    # calls navix.actions directly instead).
+    env = nx.make("Navix-DoorKey-5x5-v0")
+    timestep = env.reset(jax.random.PRNGKey(0))
+    state = timestep.state
+
+    wall = state.entities[Entities.WALL]
+    wall_row = int(wall.position[0, 0])
+    doors = state.get_doors()
+    door_col = int(doors.position[0, 1])
+
+    # navix.actions.DEFAULT_ACTION_SET (Navix-DoorKey-5x5-v0 doesn't
+    # override action_set) is (rotate_ccw, rotate_cw, forward, pickup,
+    # drop, toggle, done).
+    ROTATE_CCW, ROTATE_CW, FORWARD = 0, 1, 2
+
+    # face south, walk down to the wall's own row, face east again -
+    # via real env.step() calls this time, not the bare navix.actions
+    # calls this file's other tests use.
+    timestep = env.step(timestep, jnp.asarray(ROTATE_CW))  # east -> south
+    for _ in range(wall_row - 1):
+        timestep = env.step(timestep, jnp.asarray(FORWARD))
+    timestep = env.step(timestep, jnp.asarray(ROTATE_CCW))  # south -> east
+
+    assert not timestep.state.events.happened((Entities.WALL, EventType.HIT))
+    timestep = env.step(timestep, jnp.asarray(FORWARD))  # walk into the wall
+    assert timestep.state.get_player().position.tolist() == [wall_row, door_col - 1]
+    assert timestep.state.events.happened((Entities.WALL, EventType.HIT)), (
+        "the wall hit should be recorded on the step it actually happened"
+    )
+
+    # a following step that doesn't hit anything (a pure rotation) must
+    # NOT still show the wall hit as True - it happened last step, not
+    # this one.
+    timestep = env.step(timestep, jnp.asarray(ROTATE_CCW))
+    assert not timestep.state.events.happened((Entities.WALL, EventType.HIT)), (
+        "WALL/HIT must reset once the step it happened on is over, not "
+        "persist for the rest of the episode"
+    )

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -29,7 +29,7 @@ from navix.components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
 from navix.entities import Ball, Entities, EntityIds, Goal, Key, Player
 from navix.rendering.cache import RenderingCache
 from navix.rendering.registry import PALETTE
-from navix.states import State
+from navix.states import EventType, State
 
 
 def test_82():
@@ -90,8 +90,78 @@ def test_91():
     assert jnp.array_equal(player.position, jnp.asarray((1, 1))), (
         "Expected the player to remain in place, since balls are not walkable"
     )
-    assert state.events.ball_hit.happened, (
+    assert state.events.happened((Entities.BALL, EventType.HIT)), (
         "Expected walking into a ball to record a ball_hit event"
+    )
+
+
+def test_139():
+    # https://github.com/epignatelli/navix/issues/139
+    # EventsManager used to store one scalar Event per event type, replaced
+    # wholesale on every record_* call - so two independent occurrences of
+    # the same event type within one step (e.g. two balls both hitting the
+    # player, or the player walking into a ball earlier in the same step's
+    # transition pipeline followed by a *different* ball moving onto the
+    # player later in that same pipeline) collapsed into one, discarding
+    # the other. EventsManager.events is now keyed by (entity_type,
+    # event_type), with each slot batched per-entity-instance and merged
+    # (OR'd) rather than replaced, so both survive.
+    height, width = 5, 5
+    grid = jnp.zeros((height - 2, width - 2), dtype=jnp.int32)
+    grid = jnp.pad(grid, pad_width=1, mode="constant", constant_values=1)
+    player = Player(
+        position=jnp.asarray((2, 2)), direction=jnp.asarray(0), pocket=EMPTY_POCKET_ID
+    )
+    cache = RenderingCache.init(grid)
+
+    # scenario 1: two balls, positioned so at least one PRNG seed makes
+    # both move onto the player's cell the same step - both must register.
+    balls = Ball.create(
+        position=jnp.asarray([[1, 2], [3, 2]]),
+        colour=jnp.asarray([PALETTE.BLUE, PALETTE.RED]),
+        probability=jnp.asarray([0.0, 0.0]),
+    )
+    found_both = False
+    for seed in range(200):
+        state = State(
+            key=jax.random.PRNGKey(seed),
+            grid=grid,
+            cache=cache,
+            entities={Entities.PLAYER: player[None], Entities.BALL: balls},
+        )
+        state = nx.transitions.update_balls(state)
+        hit = state.events.events[Entities.BALL, EventType.HIT].happened
+        if bool(jnp.all(hit)):
+            found_both = True
+            break
+    assert found_both, (
+        "expected at least one seed (of 200) to move both balls onto the "
+        "player in the same step, with both recorded as happened"
+    )
+
+    # scenario 2: walking into ball 0 (recorded first, via actions.forward)
+    # must survive update_balls running afterwards in the same step's
+    # pipeline, even though it writes the same (BALL, HIT) slot.
+    balls2 = Ball.create(
+        position=jnp.asarray([[2, 3], [1, 1]]),  # ball 0 directly in front
+        colour=jnp.asarray([PALETTE.BLUE, PALETTE.RED]),
+        probability=jnp.asarray([0.0, 0.0]),
+    )
+    state2 = State(
+        key=jax.random.PRNGKey(0),
+        grid=grid,
+        cache=cache,
+        entities={Entities.PLAYER: player[None], Entities.BALL: balls2},
+    )
+    state2 = nx.actions.forward(state2)
+    assert state2.events.events[Entities.BALL, EventType.HIT].happened[0], (
+        "walking into ball 0 should record its hit"
+    )
+
+    state2 = nx.transitions.update_balls(state2)
+    assert state2.events.events[Entities.BALL, EventType.HIT].happened[0], (
+        "ball 0's earlier walk-into hit must survive update_balls "
+        "running afterwards in the same step's transition pipeline"
     )
 
 


### PR DESCRIPTION
## Summary
Closes #139. `EventsManager` used to store one scalar `Event` per named field (`goal_reached`, `ball_hit`, `wall_hit`, ...), replaced wholesale on every `record_*` call - structurally unable to represent two independent occurrences of the same event type within one step:

- Two entity instances of the same type both triggering the same event (e.g. two balls both hitting the player) collapsed to one, since `transitions.update_balls` picked only the first ball whose `ball_hit` fired out of a vmapped population (`jnp.where(..., size=1)[0][0]`).
- An earlier `record_*` call in the same step's compound transition pipeline (e.g. the player walking into a ball) got silently discarded by a later one writing the same field (e.g. a different ball moving onto the player) - "something else had already claimed/overwritten the relevant slot that step", per issue #91/PR #125's original ad-hoc fix.

`EventsManager.events` is now `Dict[Tuple[str, str], Event]`, keyed by `(entity_type, event_type)` - each slot's `Event` is batched to match that entity type's own instance count (`Event.empty_like`), and `record_*` merges new hits into a slot (OR-ing `happened`, writing `position`/`colour` only where newly `True`) instead of replacing it wholesale (`EventsManager.merge_event`). Both bugs above are fixed by this.

`EventType`'s constants change from jax arrays to plain strings (dict keys must be static/hashable, not traced arrays), and `Event` drops its now-redundant `event_type` field (the dict key already encodes it - confirmed unused downstream via grep before removing). `EventsManager.happened(key)` is the new query surface, returning `False` (not `KeyError`) for an entity type a given environment never had. `State.__post_init__` populates `events` from `entities` automatically, so none of the ~10 call sites constructing `State(...)` directly needed to change.

Built on top of the direction an old unmerged WIP branch (`refactor-events`, June 2024) explored, but not a port of it - that branch had real bugs of its own (`jnp.array_equal` used where per-instance `positions_equal` was needed, in-place dict mutation instead of an immutable `.replace`-style return) and was based on a commit over a year stale relative to current `main`.

**Also fixed** (`f2ace3b`, raised by @claude's review as a "broader opportunity"): `EventsManager`'s own docstring says events are "which events happened this timestep", but nothing ever actually reset it between steps - once a slot's `happened` flipped `True` it stayed `True` for the rest of the episode. Never observable for the terminating conditions (`on_goal_reached`/`on_lava_fall`/`on_ball_hit` all end the episode the first time they fire), which is why PPO training stayed bit-identical to `main` across 5 environments despite this bug's presence - but a non-terminating reward like `rewards.wall_hit_cost` (currently unused by any registered environment, hence dormant) would have kept firing every subsequent step after the first wall hit. Fixed by resetting `state.events` to fresh right before `transitions_fn` runs each step in `Environment._step`, not after - a hit recorded during the step's own transition still counts, only carried-over history from earlier steps is dropped.

## Test plan
- [x] `pytest tests/` (excluding `test_dreamer.py`, pre-existing unrelated environment issue) on berlin (real JAX execution) - 114/114 passed on a clean `main`-based checkout of this branch
- [x] `tests/test_issues.py::test_139`, two scenarios against a synthetic seed-swept state: (1) two balls positioned so at least one PRNG seed (of 200 tried) moves both onto the player in the same step - both now record `happened=True`, not just one; (2) walking into ball 0 (`actions.forward`) followed by `transitions.update_balls` running afterwards in the same step's pipeline - ball 0's hit survives, not clobbered
- [x] `tests/test_events.py` (new): one hand-crafted, hand-verified-map policy per event type against a *real* registered environment/seed (not synthetic) - `Navix-Empty-5x5-v0` (GRID/HIT), `Navix-DoorKey-5x5-v0` (one coherent policy: WALL/HIT on the correct instance -> KEY/PICKUP -> DOOR/OPEN -> GOAL/REACH, checking every earlier event survives to the end), `Navix-LavaGapS5-v0` (LAVA/FALL), `Navix-Dynamic-Obstacles-5x5-v0` (BALL/HIT via walk-into, correct ball instance out of two), plus direct `record_door_unlock`/`record_ball_pickup` coverage (no current action reaches either) and `happened()`'s False-not-KeyError contract for entity types an environment never had
- [x] This surfaced a real, pre-existing bug (present in the old `record_key_pickup` too, just never caught - fixed in `8673f84`): `actions.pickup` called `record_key_pickup` with `keys` *after* it had already been reassigned to `DISCARD_PILE_COORDS`, so every recorded `KEY/PICKUP` event's position was the discard-pile sentinel `(0, -1)` instead of the key's real pickup location
- [x] `tests/test_events.py::test_events_reset_each_step_not_persisted_across_episode` (new): a real `env.step()` cycle confirms `WALL/HIT` fires on the step a wall is actually hit and resets to `False` on the very next step, instead of persisting for the rest of the episode
- [x] Re-ran the PPO regression check (5 environments, `budget=20_000` and `budget=500_000` with standard hyperparameters) against `main` after the events-reset fix too - still bit-identical, confirming no currently-shipped reward/termination composition is affected
- [x] `mypy`/`py_compile` on every touched file - no new errors vs. `main`'s established baseline

## Breaking change
- `EventsManager` no longer has `goal_reached`/`ball_hit`/`wall_hit`/`lava_fall`/`key_pickup`/`door_opening`/`door_unlock`/`ball_pickup` fields - use `events.happened((entity_type, event_type))` instead (see `navix.states.EventType`, `navix.entities.Entities`).
- `Event` no longer has an `event_type` field.
- `record_goal_reached`/`record_ball_hit`/`record_wall_hit`/`record_lava_fall`/`record_key_pickup`/`record_door_opening`/`record_door_unlock`/`record_ball_pickup` now take a per-instance boolean hit mask as their second argument instead of a position (`record_walk_into`/`record_pickup`/`record_grid_hit` keep their existing position-based signatures - they compute the hit mask internally, so `actions.py`'s `_can_walk_there` call sites didn't need to change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT