### PR TITLE
Implement LavaCrossing family

### DIFF
--- a/navix/environments/crossings.py
+++ b/navix/environments/crossings.py
@@ -26,7 +26,7 @@ from flax import struct
 
 from navix import observations, rewards, terminations
 
-from ..components import EMPTY_POCKET_ID
+from ..components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
 from ..rendering.cache import RenderingCache
 from . import Environment
 from ..entities import Player, Goal, Lava
@@ -219,6 +219,10 @@ class Crossings(Environment):
         assert (
             self.height % 2 == 1 and self.width % 2 == 1
         ), "Crossings grid dimensions must be odd"
+        assert self.obstacle_type in (
+            "wall",
+            "lava",
+        ), f'obstacle_type must be "wall" or "lava", got {self.obstacle_type!r}'
 
         key, k1 = jax.random.split(key)
 
@@ -242,22 +246,34 @@ class Crossings(Environment):
             # grid stays fully walkable - Lava blocks nothing, it just
             # ends the episode on contact (via on_lava_fall). Every
             # selected river has exactly the same length (height ==
-            # width is asserted above, so Hi == Wi), so the obstacle
-            # count is always exactly n_crossings * (Hi - 1), regardless
-            # of how the random vertical/horizontal split comes out - a
-            # fixed, JIT-compatible entity count for every n_crossings
-            # actually used by a registered LavaCrossing variant.
-            # jnp.nonzero's size= handles the (here, unreachable for any
-            # registered variant) case where n_crossings exceeds the
-            # number of available rivers by padding with fill_value=Hi,
-            # which lands on the wall border once offset below - safely
-            # outside the player/goal/interior area.
+            # width is asserted above, so Hi == Wi), so
+            # n_crossings * (Hi - 1) is always a safe *upper* bound on
+            # the true obstacle count, regardless of how the random
+            # vertical/horizontal split comes out - a fixed, JIT-
+            # compatible entity count. It frequently overshoots though
+            # (whenever both a vertical and a horizontal river are
+            # selected, their one intersection cell is double-counted
+            # by the formula but only once in the real mask), so
+            # jnp.nonzero's size= often does pad. A padded slot's
+            # position must be pushed off-grid (DISCARD_PILE_COORDS,
+            # the same sentinel `actions.pickup`/`drop` already use for
+            # "not really here") rather than left at some fixed
+            # in-bounds fill_value - observations.symbolic/rgb write
+            # every entity's position unconditionally, so an in-bounds
+            # fill_value would overwrite whatever real symbol/sprite is
+            # already at that cell (confirmed: fill_value=Hi previously
+            # landed exactly on the grid's own bottom-right wall corner
+            # post-offset, replacing its wall symbol with a lava one).
             Hi = self.height - 2
             grid_interior = jnp.zeros((Hi, self.width - 2), dtype=jnp.int32)
-            rows, cols = jnp.nonzero(
-                obstacle_mask, size=self.n_crossings * (Hi - 1), fill_value=Hi
+            size = self.n_crossings * (Hi - 1)
+            rows, cols = jnp.nonzero(obstacle_mask, size=size, fill_value=0)
+            valid = jnp.arange(size) < jnp.sum(obstacle_mask)
+            lava_pos = jnp.where(
+                valid[:, None],
+                jnp.stack([rows + 1, cols + 1], axis=1),
+                DISCARD_PILE_COORDS,
             )
-            lava_pos = jnp.stack([rows + 1, cols + 1], axis=1)
             entities["lava"] = Lava.create(position=lava_pos)
         else:
             grid_interior = jnp.where(obstacle_mask, -1, 0).astype(jnp.int32)

--- a/navix/environments/crossings.py
+++ b/navix/environments/crossings.py
@@ -29,7 +29,7 @@ from navix import observations, rewards, terminations
 from ..components import EMPTY_POCKET_ID
 from ..rendering.cache import RenderingCache
 from . import Environment
-from ..entities import Player, Goal
+from ..entities import Player, Goal, Lava
 from ..states import State
 from . import Timestep
 from .registry import register_env
@@ -141,16 +141,19 @@ def _gaps_from_monotone_path(
     return gaps
 
 
-def _crossings_grid(key: Array, H: int, W: int, n: int) -> Array:
-    """Build the interior grid for SimpleCrossing.
+def _crossings_obstacle_mask(key: Array, H: int, W: int, n: int) -> Array:
+    """Boolean ``(H - 2, W - 2)`` mask of the crossing obstacle cells -
+    ``True`` where a river (with its one gap already carved out) runs.
 
     Places ``n`` complete river lines (horizontal or vertical, randomly
     selected from the ``odd_rows`` / ``odd_cols`` candidates) in a
     ``(H - 2, W - 2)`` interior grid, then carves a single gap in each
-    selected river along a monotone start-to-goal path.
-
-    Returns a ``jnp.int32`` interior grid where ``-1`` is wall and ``0`` is
-    floor; the caller pads it with a wall border.
+    selected river along a monotone start-to-goal path. Shared by both
+    `SimpleCrossing` (obstacle = `Wall`, baked into the grid - see
+    `_crossings_grid`) and `LavaCrossing` (obstacle = `Lava` entities,
+    grid stays fully walkable - see `Crossings._reset`'s `"lava"`
+    branch) - MiniGrid's own `CrossingEnv` generates both from the same
+    algorithm too, only `obstacle_type` differs.
     """
     Hi, Wi = H - 2, W - 2
     rows = jnp.arange(Hi)
@@ -183,12 +186,30 @@ def _crossings_grid(key: Array, H: int, W: int, n: int) -> Array:
         k_gap, Hi, Wi, odd_rows, odd_cols, sel_mask[:Nv], sel_mask[Nv:]
     )
 
-    obstacles = rivers & ~gaps
+    return rivers & ~gaps
+
+
+def _crossings_grid(key: Array, H: int, W: int, n: int) -> Array:
+    """Build the interior grid for `SimpleCrossing` (`obstacle_type=
+    "wall"`) - see `_crossings_obstacle_mask` for the algorithm.
+
+    Returns a ``jnp.int32`` interior grid where ``-1`` is wall and ``0`` is
+    floor; the caller pads it with a wall border.
+    """
+    obstacles = _crossings_obstacle_mask(key, H, W, n)
     return jnp.where(obstacles, -1, 0).astype(jnp.int32)
 
 
 class Crossings(Environment):
     n_crossings: int = struct.field(pytree_node=False, default=1)
+    obstacle_type: str = struct.field(pytree_node=False, default="wall")
+    """`"wall"` (`SimpleCrossing` - the obstacle blocks movement, no
+    termination beyond reaching the goal) or `"lava"` (`LavaCrossing` -
+    the obstacle is walkable but ends the episode via `on_lava_fall`).
+    Mirrors MiniGrid's own `CrossingEnv(obstacle_type=Wall | Lava)`
+    parametrization - both variants share the exact same river-
+    placement algorithm (`_crossings_obstacle_mask`), only how the
+    obstacle cells are materialized differs."""
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
         assert (
@@ -214,7 +235,33 @@ class Crossings(Environment):
             "goal": goals[None],
         }
 
-        grid_interior = _crossings_grid(k1, self.height, self.width, self.n_crossings)
+        obstacle_mask = _crossings_obstacle_mask(
+            k1, self.height, self.width, self.n_crossings
+        )
+        if self.obstacle_type == "lava":
+            # grid stays fully walkable - Lava blocks nothing, it just
+            # ends the episode on contact (via on_lava_fall). Every
+            # selected river has exactly the same length (height ==
+            # width is asserted above, so Hi == Wi), so the obstacle
+            # count is always exactly n_crossings * (Hi - 1), regardless
+            # of how the random vertical/horizontal split comes out - a
+            # fixed, JIT-compatible entity count for every n_crossings
+            # actually used by a registered LavaCrossing variant.
+            # jnp.nonzero's size= handles the (here, unreachable for any
+            # registered variant) case where n_crossings exceeds the
+            # number of available rivers by padding with fill_value=Hi,
+            # which lands on the wall border once offset below - safely
+            # outside the player/goal/interior area.
+            Hi = self.height - 2
+            grid_interior = jnp.zeros((Hi, self.width - 2), dtype=jnp.int32)
+            rows, cols = jnp.nonzero(
+                obstacle_mask, size=self.n_crossings * (Hi - 1), fill_value=Hi
+            )
+            lava_pos = jnp.stack([rows + 1, cols + 1], axis=1)
+            entities["lava"] = Lava.create(position=lava_pos)
+        else:
+            grid_interior = jnp.where(obstacle_mask, -1, 0).astype(jnp.int32)
+
         grid = jnp.pad(grid_interior, 1, mode="constant", constant_values=-1)
 
         state = State(
@@ -281,6 +328,82 @@ register_env(
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
         termination_fn=kwargs.pop("termination_fn", terminations.on_goal_reached),
+        *args,
+        **kwargs,
+    ),
+)
+register_env(
+    "Navix-LavaCrossingS9N1-v0",
+    lambda *args, **kwargs: Crossings.create(
+        height=9,
+        width=9,
+        n_crossings=1,
+        obstacle_type="lava",
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_goal_reached, terminations.on_lava_fall
+            ),
+        ),
+        *args,
+        **kwargs,
+    ),
+)
+register_env(
+    "Navix-LavaCrossingS9N2-v0",
+    lambda *args, **kwargs: Crossings.create(
+        height=9,
+        width=9,
+        n_crossings=2,
+        obstacle_type="lava",
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_goal_reached, terminations.on_lava_fall
+            ),
+        ),
+        *args,
+        **kwargs,
+    ),
+)
+register_env(
+    "Navix-LavaCrossingS9N3-v0",
+    lambda *args, **kwargs: Crossings.create(
+        height=9,
+        width=9,
+        n_crossings=3,
+        obstacle_type="lava",
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_goal_reached, terminations.on_lava_fall
+            ),
+        ),
+        *args,
+        **kwargs,
+    ),
+)
+register_env(
+    "Navix-LavaCrossingS11N5-v0",
+    lambda *args, **kwargs: Crossings.create(
+        height=11,
+        width=11,
+        n_crossings=5,
+        obstacle_type="lava",
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_goal_reached, terminations.on_lava_fall
+            ),
+        ),
         *args,
         **kwargs,
     ),

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -228,6 +228,81 @@ def test_crossings_always_solvable():
         )
 
 
+def test_lava_crossing_structure_and_solvability():
+    """LavaCrossing shares SimpleCrossing's exact river/gap algorithm
+    (`_crossings_obstacle_mask`) - only how the obstacle cells are
+    materialized differs (Lava entities, not baked into the grid as
+    walls), so the grid interior itself is fully walkable and a BFS
+    solvability check has to treat lava *entity positions* as blocked
+    instead of `grid == -1` (unlike test_crossings_always_solvable's
+    SimpleCrossing check, where the grid itself already encodes the
+    obstacles)."""
+    from collections import deque
+    import numpy as np
+    from navix.entities import Entities
+
+    def is_solvable(blocked, start, goal):
+        H, W = blocked.shape
+        seen = np.zeros_like(blocked, dtype=bool)
+        q = deque([start])
+        seen[start] = True
+        while q:
+            y, x = q.popleft()
+            if (y, x) == goal:
+                return True
+            for dy, dx in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+                ny, nx_ = y + dy, x + dx
+                if (
+                    0 <= ny < H
+                    and 0 <= nx_ < W
+                    and not seen[ny, nx_]
+                    and not blocked[ny, nx_]
+                ):
+                    seen[ny, nx_] = True
+                    q.append((ny, nx_))
+        return False
+
+    n_seeds = 256
+    for env_id, size in [
+        ("Navix-LavaCrossingS9N1-v0", 9),
+        ("Navix-LavaCrossingS9N2-v0", 9),
+        ("Navix-LavaCrossingS9N3-v0", 9),
+        ("Navix-LavaCrossingS11N5-v0", 11),
+    ]:
+        env = nx.make(env_id)
+        keys = jax.random.split(jax.random.PRNGKey(0), n_seeds)
+        states = jax.vmap(lambda k: env.reset(k).state)(keys)
+        grids = np.asarray(states.grid)
+        lava_positions = np.asarray(states.entities[Entities.LAVA].position)
+
+        unsolvable = []
+        for s in range(n_seeds):
+            grid = grids[s]
+            interior = grid[1:-1, 1:-1]
+            assert np.all(interior == 0), (
+                f"{env_id} seed={s}: interior grid should be fully walkable "
+                f"(lava is an entity overlay, not a grid obstacle)"
+            )
+            blocked = grid == -1  # the wall border only, interior is never -1
+            for r, c in lava_positions[s]:
+                if 1 <= r <= size - 2 and 1 <= c <= size - 2:  # skip safe padding entries
+                    blocked[r, c] = True
+            if not is_solvable(blocked, (1, 1), (size - 2, size - 2)):
+                unsolvable.append(s)
+        assert not unsolvable, (
+            f"{env_id}: {len(unsolvable)}/{n_seeds} seeds produced an "
+            f"unsolvable maze (goal not reachable from start avoiding lava). "
+            f"First failing seed indices: {unsolvable[:5]}"
+        )
+
+        # the last seed's state also gets the direct structural checks:
+        # no Wall entities (LavaCrossing has none, unlike SimpleCrossing
+        # which bakes obstacles into the grid), Lava entities present.
+        last_state = jax.tree.map(lambda x: x[-1], states)
+        assert Entities.WALL not in last_state.entities
+        assert Entities.LAVA in last_state.entities
+
+
 if __name__ == "__main__":
     # test_room()
     # jax.jit(test_room)()


### PR DESCRIPTION
## Summary
Closes #171. Implements `Navix-LavaCrossingS9N1-v0`/`S9N2`/`S9N3`/`S11N5` - the same river/gap procedural algorithm `SimpleCrossing` already implements, with obstacles materialized as walkable `Lava` entities (ending the episode via `on_lava_fall` on contact) instead of baked into the grid as non-walkable walls. Matches MiniGrid's own `CrossingEnv(obstacle_type=Wall | Lava)` parametrization, which generates both variants from one shared algorithm.

`Crossings` gains an `obstacle_type` field (`"wall"`, unchanged default; `"lava"` for the new variants). `_crossings_grid` is split into `_crossings_obstacle_mask` (the shared boolean river mask) plus a thin wall-baking wrapper. Full design/math rationale (fixed upper-bound entity count, safe padding) is in the commit message.

## Test plan
- [x] New `tests/test_environments.py::test_lava_crossing_structure_and_solvability` - 256 seeds x 4 variants, BFS-solvable (treating lava positions as blocked, since the grid itself stays fully walkable), plus structural checks
- [x] Full test suite (116 tests, excluding `test_dreamer.py`'s pre-existing unrelated environment issue) on berlin - all pass
- [x] Direct empirical solvability check: 20,000 random rollouts/seed across 5 seeds all found a return-1.0 trajectory, independent of any trained policy
- [x] `mypy`/`py_compile` - no new errors vs. `main`'s established baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
