### PR TITLE
docs(agents): make CLAUDE.md's AGENTS.md pointer directive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,8 @@
-See [AGENTS.md](./AGENTS.md) for repository instructions — commit message
-conventions, test/lint commands, and PR scope guidance apply to Claude the
-same as any other agent.
+Read [AGENTS.md](./AGENTS.md) before working in this repo — it covers commit
+message conventions, test/lint commands, and PR scope, and applies to Claude
+the same as any other agent.
+
+**Reviewing a pull request** (e.g. triggered by "@claude review"): AGENTS.md
+has a mandatory reply format for this — its "Reviewing a pull request"
+section. Read that section and follow it exactly (the five sections, in
+that order, nothing else) rather than writing a freeform review.


### PR DESCRIPTION
The old CLAUDE.md wording ("see AGENTS.md for ... guidance") read as FYI, not as an instruction to actually open and follow it before acting.

Concretely: the GitHub review bot (and this Claude session, unprompted) skipped AGENTS.md's mandatory 5-section PR-review reply format on PR #186 - twice. Both the Action's `claude` CLI and an interactive session's CLI auto-load CLAUDE.md the same way, so making the pointer directive (and calling out the review-format requirement specifically) should fix both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT