### PR TITLE
fix(actions): drop() only moves the Pickable matching player.pocket

### DIFF
--- a/navix/actions.py
+++ b/navix/actions.py
@@ -215,7 +215,7 @@ def drop(state: State) -> State:
 
     Args:
         state (State): The current state.
-    
+
     Returns:
         State: The new state with the item in the pocket dropped in front of the player."""
     player = state.get_player(idx=0)
@@ -229,10 +229,29 @@ def drop(state: State) -> State:
     for k in state.entities:
         entity = state.entities[k]
         if isinstance(entity, Pickable):
-            cond = jnp.logical_and(can_drop, entity.position == DISCARD_PILE_COORDS)
-            position = jnp.where(cond, position_in_front, entity.position)
+            # match by id == player.pocket, not just "is this instance
+            # sitting at the discard pile" - the latter alone moves
+            # *every* already-consumed Pickable instance, not just the
+            # one actually in the player's pocket, once two Pickable
+            # entity types can coexist in one episode (see #188).
+            matches_pocket = entity.id == player.pocket
+            at_discard = jnp.all(entity.position == DISCARD_PILE_COORDS, axis=-1)
+            cond = can_drop & matches_pocket & at_discard
+            position = jnp.where(cond[:, None], position_in_front, entity.position)
             entity = entity.replace(position=position)
-            state.set_entity(k, entity)
+            state = state.set_entity(k, entity)
+
+    # the player's pocket must go back to empty on a successful drop -
+    # previously left stale (still holding the dropped item's id) after
+    # every drop, which is wrong regardless of the bug above.
+    player = jax.lax.cond(
+        can_drop, lambda: player.replace(pocket=EMPTY_POCKET_ID), lambda: player
+    )
+    state = state.set_player(player)
+    # _can_walk_there's events (e.g. a grid-hit record when the drop
+    # destination isn't walkable) were computed above but never applied
+    # to state - also fixed here while touching this function.
+    state = state.set_events(events)
     return state
 
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -316,6 +316,90 @@ def test_pickup():
     ), "Expected key to be at {}, got {}".format(DISCARD_PILE_COORDS, keys.position)
 
 
+def test_drop():
+    heigh, width = 5, 5
+    grid = jnp.zeros((heigh - 2, width - 2), dtype=jnp.int32)
+    grid = jnp.pad(grid, pad_width=1, mode="constant", constant_values=1)
+    key = jax.random.PRNGKey(0)
+    # player facing east (direction=0), holding a key it already picked up
+    # (position at the discard pile, id in its pocket) - dropping should
+    # place it on the empty tile in front and empty the pocket back out.
+    player = nx.entities.Player(
+        position=jnp.asarray((2, 1)), direction=jnp.asarray(0), pocket=jnp.asarray(1)
+    )
+    keys = nx.entities.Key(
+        position=DISCARD_PILE_COORDS, id=jnp.asarray(1), colour=PALETTE.YELLOW
+    )
+    cache = nx.rendering.cache.RenderingCache.init(grid)
+    entities = {Entities.PLAYER: player[None], Entities.KEY: keys[None]}
+    state = State(key=key, grid=grid, cache=cache, entities=entities)
+
+    state = nx.actions.drop(state)
+
+    keys = state.get_keys()
+    assert jnp.array_equal(
+        keys.position[0], jnp.asarray((2, 2))
+    ), "Expected key to be dropped in front of the player at (2, 2), got {}".format(
+        keys.position[0]
+    )
+    player = state.get_player()
+    assert jnp.array_equal(
+        player.pocket, EMPTY_POCKET_ID
+    ), "Expected pocket to be empty after drop, got {}".format(player.pocket)
+
+
+def test_drop_does_not_resurrect_a_different_pickable_type():
+    # PR #186 review / issue #188: drop() used to move *every* Pickable
+    # instance sitting at the discard pile, not just the one matching
+    # player.pocket - unreachable before two Pickable entity types
+    # (Key, Box) could coexist in one episode. Here the Key has already
+    # been consumed (e.g. used to unlock a door) and sits permanently at
+    # the discard pile, while the player is now separately holding a
+    # Box - dropping the Box must not resurrect the spent Key.
+    heigh, width = 5, 5
+    grid = jnp.zeros((heigh - 2, width - 2), dtype=jnp.int32)
+    grid = jnp.pad(grid, pad_width=1, mode="constant", constant_values=1)
+    key = jax.random.PRNGKey(0)
+    player = nx.entities.Player(
+        position=jnp.asarray((2, 1)), direction=jnp.asarray(0), pocket=jnp.asarray(2)
+    )
+    keys = nx.entities.Key(
+        position=DISCARD_PILE_COORDS, id=jnp.asarray(1), colour=PALETTE.YELLOW
+    )
+    boxes = nx.entities.Box(
+        position=DISCARD_PILE_COORDS,
+        id=jnp.asarray(2),
+        colour=PALETTE.RED,
+        pocket=jnp.asarray(-1),
+    )
+    cache = nx.rendering.cache.RenderingCache.init(grid)
+    entities = {
+        Entities.PLAYER: player[None],
+        Entities.KEY: keys[None],
+        Entities.BOX: boxes[None],
+    }
+    state = State(key=key, grid=grid, cache=cache, entities=entities)
+
+    state = nx.actions.drop(state)
+
+    boxes = state.get_boxes()
+    assert jnp.array_equal(
+        boxes.position[0], jnp.asarray((2, 2))
+    ), "Expected box to be dropped in front of the player at (2, 2), got {}".format(
+        boxes.position[0]
+    )
+    keys = state.get_keys()
+    assert jnp.array_equal(
+        keys.position[0], DISCARD_PILE_COORDS
+    ), "Expected the already-consumed key to stay at the discard pile, got {}".format(
+        keys.position[0]
+    )
+    player = state.get_player()
+    assert jnp.array_equal(
+        player.pocket, EMPTY_POCKET_ID
+    ), "Expected pocket to be empty after drop, got {}".format(player.pocket)
+
+
 def test_open():
     heigh, width = 5, 5
     grid = jnp.zeros((heigh - 2, width - 2), dtype=jnp.int32)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -348,14 +348,17 @@ def test_drop():
     ), "Expected pocket to be empty after drop, got {}".format(player.pocket)
 
 
-def test_drop_does_not_resurrect_a_different_pickable_type():
+def test_drop_does_not_resurrect_a_different_pickable_instance():
     # PR #186 review / issue #188: drop() used to move *every* Pickable
     # instance sitting at the discard pile, not just the one matching
-    # player.pocket - unreachable before two Pickable entity types
-    # (Key, Box) could coexist in one episode. Here the Key has already
-    # been consumed (e.g. used to unlock a door) and sits permanently at
-    # the discard pile, while the player is now separately holding a
-    # Box - dropping the Box must not resurrect the spent Key.
+    # player.pocket. Reproducible with two instances of the same
+    # Pickable type alone (no second Pickable *class* needed - the
+    # original report used Key+Box, but Box only gained an `id`/became
+    # Pickable in the still-unmerged PR #186, so this uses two Keys
+    # instead to stay independent of that PR): key id=1 has already
+    # been consumed (e.g. used to unlock a door) and sits permanently
+    # at the discard pile, while the player is now separately holding
+    # key id=2 - dropping it must not resurrect the spent key id=1.
     heigh, width = 5, 5
     grid = jnp.zeros((heigh - 2, width - 2), dtype=jnp.int32)
     grid = jnp.pad(grid, pad_width=1, mode="constant", constant_values=1)
@@ -363,35 +366,26 @@ def test_drop_does_not_resurrect_a_different_pickable_type():
     player = nx.entities.Player(
         position=jnp.asarray((2, 1)), direction=jnp.asarray(0), pocket=jnp.asarray(2)
     )
-    keys = nx.entities.Key(
-        position=DISCARD_PILE_COORDS, id=jnp.asarray(1), colour=PALETTE.YELLOW
-    )
-    boxes = nx.entities.Box(
-        position=DISCARD_PILE_COORDS,
-        id=jnp.asarray(2),
-        colour=PALETTE.RED,
-        pocket=jnp.asarray(-1),
+    keys = nx.entities.Key.create(
+        position=jnp.stack([DISCARD_PILE_COORDS, DISCARD_PILE_COORDS]),
+        id=jnp.asarray([1, 2]),
+        colour=jnp.asarray([PALETTE.YELLOW, PALETTE.RED]),
     )
     cache = nx.rendering.cache.RenderingCache.init(grid)
-    entities = {
-        Entities.PLAYER: player[None],
-        Entities.KEY: keys[None],
-        Entities.BOX: boxes[None],
-    }
+    entities = {Entities.PLAYER: player[None], Entities.KEY: keys}
     state = State(key=key, grid=grid, cache=cache, entities=entities)
 
     state = nx.actions.drop(state)
 
-    boxes = state.get_boxes()
-    assert jnp.array_equal(
-        boxes.position[0], jnp.asarray((2, 2))
-    ), "Expected box to be dropped in front of the player at (2, 2), got {}".format(
-        boxes.position[0]
-    )
     keys = state.get_keys()
     assert jnp.array_equal(
+        keys.position[1], jnp.asarray((2, 2))
+    ), "Expected key id=2 (in pocket) to be dropped in front of the player at (2, 2), got {}".format(
+        keys.position[1]
+    )
+    assert jnp.array_equal(
         keys.position[0], DISCARD_PILE_COORDS
-    ), "Expected the already-consumed key to stay at the discard pile, got {}".format(
+    ), "Expected the already-consumed key id=1 to stay at the discard pile, got {}".format(
         keys.position[0]
     )
     player = state.get_player()


### PR DESCRIPTION
Found during independent review of PR #186. Closes #188.

`drop()` moved *every* `Pickable` instance sitting at `DISCARD_PILE_COORDS` to the tile in front of the player, rather than only the one matching `player.pocket` - unreachable before two `Pickable` entity types could coexist in one episode. PR #186's `UnlockPickup` (`Key` + `Box`) is the first, which exposes it: after key -> unlock -> box pickup, dropping resurrects both the box and the already-consumed key.

Also fixed while touching this function:
- `player.pocket` was never reset to `EMPTY_POCKET_ID` after a successful drop, leaving it stale.
- `_can_walk_there`'s returned events (e.g. a grid-hit record when the drop destination isn't walkable) were computed but never applied to state via `state.set_events`.

**Behavior change**: because `drop()` now applies `_can_walk_there`'s events, calling `drop` while facing a non-walkable tile/entity now records a grid-hit/walk-into event for that step, where previously it silently didn't. This only affects code paths reading `state.events` after a `drop` action (e.g. an opt-in `rewards.wall_hit_cost`, not any default reward/termination fn) - narrow blast radius, and arguably a bug fix rather than a break, so no `BREAKING CHANGE:` footer, but flagging per AGENTS.md's "flag behavior-changing PRs explicitly" guidance.

New coverage: `test_drop`, `test_drop_does_not_resurrect_a_different_pickable_instance` in `tests/test_actions.py` (this function had no test coverage before) - the regression test uses two `Key` instances rather than Key+Box, so it doesn't depend on PR #186's still-unmerged `Box` schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT