### PR TITLE
ci(release): switch to weekly batched releases instead of per-merge

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -3,7 +3,7 @@ name: CD
 on:
   workflow_dispatch:
   schedule:
-    # weekly, Monday 09:00 UTC - batches every commit merged to main
+    # weekly, Monday 05:00 UTC - batches every commit merged to main
     # since the last release into one version bump/changelog/PyPI
     # publish, instead of releasing on every single push (previously
     # `on: push: branches: [main]` here) - conventional-changelog-action
@@ -11,7 +11,7 @@ on:
     # needs no changes beyond the trigger and skip-on-empty below.
     # workflow_dispatch above still allows an out-of-cycle release
     # (e.g. an urgent fix) without waiting for the next Monday.
-    - cron: "0 9 * * 1"
+    - cron: "0 5 * * 1"
 
 jobs:
   release:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -2,9 +2,16 @@ name: CD
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "main"
+  schedule:
+    # weekly, Monday 09:00 UTC - batches every commit merged to main
+    # since the last release into one version bump/changelog/PyPI
+    # publish, instead of releasing on every single push (previously
+    # `on: push: branches: [main]` here) - conventional-changelog-action
+    # already aggregates all commits since the last tag, so batching
+    # needs no changes beyond the trigger and skip-on-empty below.
+    # workflow_dispatch above still allows an out-of-cycle release
+    # (e.g. an urgent fix) without waiting for the next Monday.
+    - cron: "0 9 * * 1"
 
 jobs:
   release:
@@ -35,7 +42,11 @@ jobs:
           output-file: false
           skip-commit: true
           skip-tag: true
-          skip-on-empty: false
+          # a scheduled run with nothing new to release (a quiet week)
+          # must be a no-op, not an empty release - true (was false)
+          # only matters now that the trigger is time-based rather than
+          # one release attempt per push.
+          skip-on-empty: true
           tag-prefix: ""
           fallback-version: ${{ env.NAVIX_VERSION }}
 
@@ -77,18 +88,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
-
-  deploy-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - run: pip install --upgrade pip && pip install -r docs/requirements.txt
-      - run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
-      - name: Publish docs
-        run: mkdocs gh-deploy
-        

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install --upgrade pip && pip install -r docs/requirements.txt
+      - run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Publish docs
+        run: mkdocs gh-deploy


### PR DESCRIPTION
Every push to `main` currently triggers a full release cycle (version bump, GitHub Release, PyPI publish) - with several PRs merging in quick succession, this produces a release per PR, clogging the release/PyPI version history for often-small incremental changes.

## Change
- `CD.yml`'s trigger: `workflow_dispatch` + a weekly cron (Monday 09:00 UTC), instead of `push: branches: [main]`. `conventional-changelog-action` already aggregates every commit since the last tag into one changelog/version bump, so batching needs no logic changes beyond the trigger and `skip-on-empty: true` (was `false`) so a quiet week is a no-op rather than an empty release.
- `workflow_dispatch` stays as the escape hatch for an urgent out-of-cycle release.
- Docs deployment moved to its own `docs.yml`, **unchanged** (still push-triggered on every merge) - a `gh-pages` redeploy carries none of the release noise (no version bump/PyPI publish/Release entry), so no reason to batch it too. `on:` is workflow-level in GitHub Actions (not per-job), so decoupling the two schedules required splitting into two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT