### PR TITLE
Implement RedBlueDoors, GoToObject, Fetch, PutNear, BlockedUnlockPickup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run unit tests with pytest
         run: |
           wandb offline
-          pytest
+          pytest -n auto
       - name: Run examples
         run: |
           for example in examples/*.py; do

--- a/navix/actions.py
+++ b/navix/actions.py
@@ -170,32 +170,31 @@ def left(state: State) -> State:
 
 
 def pickup(state: State) -> State:
-    """Picks up an item (`Key` or `Box`) in front of the player and puts
-    it in the pocket.
+    """Picks up an item (`Key`, `Box`, or `Ball`) in front of the player
+    and puts it in the pocket.
     Args:
         state (State): The current state.
     Returns:
         State: The new state with the player entity having the item in the pocket."""
 
-    def pickup_entity(state: State, entity_enum: str, entity, setter) -> State:
-        """Shared logic for one pickable entity type (`Key`/`Box`): if the
-        player is facing an instance of `entity`, discard it and put its
-        `id` in the player's pocket. A closure (not a module-level
-        function) specifically so it stays out of `actions.py`'s public
-        surface, where every other name is a real `State -> State`
-        action - unlike those, this needs `entity_enum`/`entity`/
+    def pickup_entity(state: State, entity, setter) -> State:
+        """Shared logic for one pickable entity type (`Key`/`Box`/
+        `Ball`): if the player is facing an instance of `entity`,
+        discard it and put its `id` in the player's pocket. A closure
+        (not a module-level function) specifically so it stays out of
+        `actions.py`'s public surface, where every other name is a real
+        `State -> State` action - unlike those, this needs `entity`/
         `setter` too, to stay parametrized over which pickable entity
-        type `pickup`'s two call sites (`Key`, `Box`) are handling.
+        type `pickup`'s call sites are handling.
 
         Args:
             state (State): The current state.
-            entity_enum (str): The entity type's `Entities.*` string,
-                used to dispatch to the matching `EventsManager.
-                record_*_pickup`.
             entity: Every instance of this entity type in the
-                environment (`state.get_keys()`/`state.get_boxes()`).
+                environment (`state.get_keys()`/`state.get_boxes()`/
+                `state.get_balls()`).
             setter (Callable[[Any], State]): `state.set_keys`/
-                `state.set_boxes` - writes the updated entity batch back.
+                `state.set_boxes`/`state.set_balls` - writes the updated
+                entity batch back.
 
         Returns:
             State: The new state with the item picked up, if the player
@@ -207,15 +206,13 @@ def pickup(state: State) -> State:
 
         # update events - before entity is moved to the discard pile
         # below, so the recorded event keeps the item's real pickup
-        # position, not DISCARD_PILE_COORDS.
-        record = (
-            state.events.record_key_pickup
-            if entity_enum == Entities.KEY
-            else state.events.record_box_pickup
-        )
+        # position, not DISCARD_PILE_COORDS. record_pickup already
+        # dispatches on isinstance(entity, Key/Box/Ball) internally, so
+        # this stays correct for any Pickable type without needing a
+        # per-type branch here.
         events = jax.lax.cond(
             jnp.any(found),
-            lambda: record(entity, found),
+            lambda: state.events.record_pickup(entity, position_in_front),
             lambda: state.events,
         )
 
@@ -235,9 +232,11 @@ def pickup(state: State) -> State:
         return state
 
     if Entities.KEY in state.entities:
-        state = pickup_entity(state, Entities.KEY, state.get_keys(), state.set_keys)
+        state = pickup_entity(state, state.get_keys(), state.set_keys)
     if Entities.BOX in state.entities:
-        state = pickup_entity(state, Entities.BOX, state.get_boxes(), state.set_boxes)
+        state = pickup_entity(state, state.get_boxes(), state.set_boxes)
+    if Entities.BALL in state.entities:
+        state = pickup_entity(state, state.get_balls(), state.set_balls)
     return state
 
 

--- a/navix/actions.py
+++ b/navix/actions.py
@@ -216,8 +216,17 @@ def pickup(state: State) -> State:
             lambda: state.events,
         )
 
-        # discard the picked-up instance
-        positions = jnp.where(found, DISCARD_PILE_COORDS, entity.position)
+        # discard the picked-up instance - found[:, None], not found:
+        # found has shape (n_instances,), and entity.position/
+        # DISCARD_PILE_COORDS both end in a (2,) row/col axis, so an
+        # unreshaped `found` broadcasts against the wrong axis whenever
+        # n_instances == 2 (JAX aligns trailing dims: (2,) vs (n,2)
+        # matches (2,) against the row/col axis, not the instance axis) -
+        # confirmed directly: with 2 balls, picking up one corrupted
+        # both balls' rows to the discard row while leaving both
+        # columns untouched, instead of moving only the picked one to
+        # DISCARD_PILE_COORDS entirely (see PR #191 review).
+        positions = jnp.where(found[:, None], DISCARD_PILE_COORDS, entity.position)
         entity = entity.replace(position=positions)
 
         # update player's pocket, if the pocket has something else, we overwrite it

--- a/navix/entities.py
+++ b/navix/entities.py
@@ -371,11 +371,24 @@ class Lava(Entity):
 
 
 class Ball(Entity, Pickable, HasColour, Stochastic):
-    """A pickable, stochastic obstacle - `id` (from `Pickable`) identifies
-    this ball instance for `actions.pickup`/`actions.drop`, the same way
-    `Key.id`/`Box.id` do; `probability` (from `Stochastic`, pre-existing)
-    is unrelated to pickup and is used elsewhere (e.g. `DynamicObstacles`'
-    random movement)."""
+    """A pickable obstacle - `id` (from `Pickable`) identifies this ball
+    instance for `actions.pickup`/`actions.drop`, the same way `Key.id`/
+    `Box.id` do. `probability` (from `Stochastic`, pre-existing) is
+    unrelated to pickup - unused by `Ball` itself; every `Ball`
+    instance actually moves unconditionally each step under the default
+    `transitions.stochastic_transition` (`transitions.update_balls`,
+    regardless of `probability`'s value), which is why any environment
+    wanting a static `Ball` (a pickup target/decoy, not a wandering
+    obstacle) must register with `transitions_fn=transitions.
+    deterministic_transition` instead - see `GoToObject`/`Fetch`/
+    `PutNear`/`BlockedUnlockPickup`.
+
+    BREAKING CHANGE: `Ball` becoming `Pickable` means `actions.pickup`
+    no longer no-ops facing a `Ball` in any environment whose
+    action_set includes `pickup` and whose transitions_fn is the
+    default `stochastic_transition` - concretely, this changes
+    `Navix-Dynamic-Obstacles-*`'s existing dynamics: `pickup` now
+    removes the faced obstacle from play instead of doing nothing."""
 
     @classmethod
     def create(

--- a/navix/entities.py
+++ b/navix/entities.py
@@ -370,8 +370,12 @@ class Lava(Entity):
         return jnp.broadcast_to(0, self.shape)
 
 
-class Ball(Entity, HasColour, Stochastic):
-    """Goals are entities that can be reached by the player"""
+class Ball(Entity, Pickable, HasColour, Stochastic):
+    """A pickable, stochastic obstacle - `id` (from `Pickable`) identifies
+    this ball instance for `actions.pickup`/`actions.drop`, the same way
+    `Key.id`/`Box.id` do; `probability` (from `Stochastic`, pre-existing)
+    is unrelated to pickup and is used elsewhere (e.g. `DynamicObstacles`'
+    random movement)."""
 
     @classmethod
     def create(
@@ -379,8 +383,10 @@ class Ball(Entity, HasColour, Stochastic):
         position: Array,
         colour: Array,
         probability: Array,
+        id: Array,
     ) -> Ball:
-        return cls(position=position, colour=colour, probability=probability)
+        colour = jnp.asarray(colour, dtype=jnp.uint8)
+        return cls(position=position, colour=colour, probability=probability, id=id)
 
     @property
     def walkable(self) -> Array:

--- a/navix/environments/__init__.py
+++ b/navix/environments/__init__.py
@@ -31,7 +31,7 @@ from .crossings import Crossings
 from .dynamic_obstacles import DynamicObstacles
 from .dist_shift import DistShift
 from .go_to_door import GoToDoor
-from .unlock import Unlock, UnlockPickup
+from .unlock import Unlock, UnlockPickup, BlockedUnlockPickup
 from .red_blue_doors import RedBlueDoors
 from .go_to_object import GoToObject
 from .fetch import Fetch

--- a/navix/environments/__init__.py
+++ b/navix/environments/__init__.py
@@ -33,3 +33,4 @@ from .dist_shift import DistShift
 from .go_to_door import GoToDoor
 from .unlock import Unlock, UnlockPickup
 from .red_blue_doors import RedBlueDoors
+from .go_to_object import GoToObject

--- a/navix/environments/__init__.py
+++ b/navix/environments/__init__.py
@@ -34,3 +34,4 @@ from .go_to_door import GoToDoor
 from .unlock import Unlock, UnlockPickup
 from .red_blue_doors import RedBlueDoors
 from .go_to_object import GoToObject
+from .fetch import Fetch

--- a/navix/environments/__init__.py
+++ b/navix/environments/__init__.py
@@ -35,3 +35,4 @@ from .unlock import Unlock, UnlockPickup
 from .red_blue_doors import RedBlueDoors
 from .go_to_object import GoToObject
 from .fetch import Fetch
+from .put_near import PutNear

--- a/navix/environments/__init__.py
+++ b/navix/environments/__init__.py
@@ -32,3 +32,4 @@ from .dynamic_obstacles import DynamicObstacles
 from .dist_shift import DistShift
 from .go_to_door import GoToDoor
 from .unlock import Unlock, UnlockPickup
+from .red_blue_doors import RedBlueDoors

--- a/navix/environments/dynamic_obstacles.py
+++ b/navix/environments/dynamic_obstacles.py
@@ -72,6 +72,13 @@ class DynamicObstacles(Environment):
             position=ball_pos,
             colour=jnp.tile(PALETTE.BLUE, (self.n_obstacles,)),
             probability=jnp.ones(self.n_obstacles),
+            # Ball became Pickable so Fetch/PutNear/BlockedUnlockPickup can
+            # use it - ids just need to be unique per instance here, they
+            # play no role in this env (DynamicObstacles relies on
+            # walk-into collision via on_ball_hit, not pickup, for its
+            # termination; see PR description for the resulting narrow
+            # behavior change: pickup() no longer no-ops on these balls).
+            id=jnp.arange(1, self.n_obstacles + 1, dtype=jnp.int32),
         )
 
         entities = {

--- a/navix/environments/dynamic_obstacles.py
+++ b/navix/environments/dynamic_obstacles.py
@@ -39,6 +39,36 @@ from .registry import register_env
 
 
 class DynamicObstacles(Environment):
+    """A room with `n_obstacles` `Ball`s that each take one random step
+    every turn; reach the goal without touching one.
+
+    Deliberately differs from real MiniGrid's `DynamicObstaclesEnv` in
+    one place: real MiniGrid removes `pickup`/`drop`/`toggle`/`done`
+    from this environment's action space entirely (`Discrete(3)`
+    instead of the usual `Discrete(7)`), since none of them mean
+    anything here. Navix keeps the full default action set instead, so
+    that an agent trained across the whole navix suite sees one
+    uniform action interface everywhere - and since `Ball` is
+    `Pickable` (needed elsewhere, for `Fetch`/`PutNear`/`GoToObject`/
+    `BlockedUnlockPickup`), picking one up here ends the episode the
+    same way walking into it already does (`termination_fn` composes
+    `on_ball_pickup` alongside `on_ball_hit`), rather than either
+    silently removing it from play or being unavailable.
+
+    To instantiate the exact MiniGrid-equivalent `Discrete(3)` action
+    space instead, pass `action_set` explicitly:
+
+    ```python
+    env = navix.make(
+        "Navix-Dynamic-Obstacles-5x5-v0",
+        action_set=(navix.actions.rotate_ccw, navix.actions.rotate_cw, navix.actions.forward),
+    )
+    ```
+
+    (verified directly: `env.action_set`/`env.action_space` both come
+    out as length/`Discrete(3)`, matching real MiniGrid, and
+    `env.step()` works normally with action indices `0`/`1`/`2`)."""
+
     random_start: bool = struct.field(pytree_node=False, default=False)
     n_obstacles: int = struct.field(pytree_node=False, default=2)
 
@@ -114,6 +144,18 @@ register_env(
         random_start=False,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        # picking up a ball now ends the episode the same way walking
+        # into one already does (rather than silently removing it from
+        # play), now that Ball is Pickable - see PR #191's review.
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_goal_reached,
+                terminations.on_lava_fall,
+                terminations.on_ball_hit,
+                terminations.on_ball_pickup,
+            ),
+        ),
         *args,
         **kwargs,
     ),
@@ -127,6 +169,18 @@ register_env(
         random_start=True,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        # picking up a ball now ends the episode the same way walking
+        # into one already does (rather than silently removing it from
+        # play), now that Ball is Pickable - see PR #191's review.
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_goal_reached,
+                terminations.on_lava_fall,
+                terminations.on_ball_hit,
+                terminations.on_ball_pickup,
+            ),
+        ),
         *args,
         **kwargs,
     ),
@@ -140,6 +194,18 @@ register_env(
         random_start=False,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        # picking up a ball now ends the episode the same way walking
+        # into one already does (rather than silently removing it from
+        # play), now that Ball is Pickable - see PR #191's review.
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_goal_reached,
+                terminations.on_lava_fall,
+                terminations.on_ball_hit,
+                terminations.on_ball_pickup,
+            ),
+        ),
         *args,
         **kwargs,
     ),
@@ -153,6 +219,18 @@ register_env(
         random_start=True,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        # picking up a ball now ends the episode the same way walking
+        # into one already does (rather than silently removing it from
+        # play), now that Ball is Pickable - see PR #191's review.
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_goal_reached,
+                terminations.on_lava_fall,
+                terminations.on_ball_hit,
+                terminations.on_ball_pickup,
+            ),
+        ),
         *args,
         **kwargs,
     ),
@@ -166,6 +244,18 @@ register_env(
         random_start=False,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        # picking up a ball now ends the episode the same way walking
+        # into one already does (rather than silently removing it from
+        # play), now that Ball is Pickable - see PR #191's review.
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_goal_reached,
+                terminations.on_lava_fall,
+                terminations.on_ball_hit,
+                terminations.on_ball_pickup,
+            ),
+        ),
         *args,
         **kwargs,
     ),
@@ -179,6 +269,18 @@ register_env(
         random_start=False,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
         reward_fn=kwargs.pop("reward_fn", rewards.on_goal_reached),
+        # picking up a ball now ends the episode the same way walking
+        # into one already does (rather than silently removing it from
+        # play), now that Ball is Pickable - see PR #191's review.
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_goal_reached,
+                terminations.on_lava_fall,
+                terminations.on_ball_hit,
+                terminations.on_ball_pickup,
+            ),
+        ),
         *args,
         **kwargs,
     ),

--- a/navix/environments/fetch.py
+++ b/navix/environments/fetch.py
@@ -1,0 +1,150 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`Fetch` (issue #177): a single room scattered with `n_objects`
+`Key`/`Ball` instances; one is the per-episode target via `State.
+mission` (same placement/target-selection shape as `GoToObject`). Unlike
+`GoToObject`, success requires *picking up* the target, not just
+reaching it - and, verified against MiniGrid's actual `FetchEnv.step`
+(this contradicted this issue's own original guess that a wrong pickup
+would be a no-op): picking up *any* object, right or wrong, ends the
+episode; only the reward differs (1 for the right one, 0 otherwise)."""
+
+from __future__ import annotations
+from typing import Union
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+from flax import struct
+
+from navix import observations, rewards, terminations
+
+from ..components import EMPTY_POCKET_ID
+from ..entities import Ball, Entities, Key, Player
+from ..grid import random_colour, random_directions, random_positions, room
+from ..rendering.cache import RenderingCache
+from ..states import Event, State
+from . import Environment, Timestep
+from .registry import register_env
+
+
+class Fetch(Environment):
+    n_objects: int = struct.field(pytree_node=False, default=2)
+
+    def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
+        k_pos, k_dir, k_obj_pos, k_colour, k_target = jax.random.split(key, 5)
+
+        grid = room(self.height, self.width)
+
+        player_pos = random_positions(k_pos, grid)
+        player = Player.create(
+            position=player_pos,
+            direction=random_directions(k_dir),
+            pocket=EMPTY_POCKET_ID,
+        )
+
+        colours = jnp.reshape(random_colour(k_colour, n=self.n_objects), (self.n_objects,))
+        positions = jnp.reshape(
+            random_positions(k_obj_pos, grid, n=self.n_objects, exclude=player_pos),
+            (self.n_objects, 2),
+        )
+        n_keys = self.n_objects // 2
+        n_balls = self.n_objects - n_keys
+
+        entities = {Entities.PLAYER: player[None]}
+        if n_keys > 0:
+            keys = Key.create(
+                position=positions[:n_keys],
+                colour=colours[:n_keys],
+                id=jnp.arange(1, n_keys + 1, dtype=jnp.int32),
+            )
+            entities[Entities.KEY] = keys
+        if n_balls > 0:
+            balls = Ball.create(
+                position=positions[n_keys:],
+                colour=colours[n_keys:],
+                probability=jnp.ones(n_balls),
+                id=jnp.arange(n_keys + 1, self.n_objects + 1, dtype=jnp.int32),
+            )
+            entities[Entities.BALL] = balls
+
+        target_idx = jax.random.randint(k_target, (), 0, self.n_objects)
+        mission = Event(
+            position=positions[target_idx],
+            colour=colours[target_idx],
+            happened=jnp.asarray(False),
+        )
+
+        state = State(
+            key=key,
+            grid=grid,
+            cache=cache or RenderingCache.init(grid),
+            entities=entities,
+            mission=mission,
+        )
+        return Timestep(
+            t=jnp.asarray(0, dtype=jnp.int32),
+            observation=self.observation_fn(state),
+            action=jnp.asarray(-1, dtype=jnp.int32),
+            reward=jnp.asarray(0.0, dtype=jnp.float32),
+            step_type=jnp.asarray(0, dtype=jnp.int32),
+            state=state,
+        )
+
+
+register_env(
+    "Navix-Fetch-5x5-N2-v0",
+    lambda *args, **kwargs: Fetch.create(
+        height=5,
+        width=5,
+        n_objects=2,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_target_fetched),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_any_target_pickup),
+        *args,
+        **kwargs,
+    ),
+)
+register_env(
+    "Navix-Fetch-6x6-N2-v0",
+    lambda *args, **kwargs: Fetch.create(
+        height=6,
+        width=6,
+        n_objects=2,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_target_fetched),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_any_target_pickup),
+        *args,
+        **kwargs,
+    ),
+)
+register_env(
+    "Navix-Fetch-8x8-N3-v0",
+    lambda *args, **kwargs: Fetch.create(
+        height=8,
+        width=8,
+        n_objects=3,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_target_fetched),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_any_target_pickup),
+        *args,
+        **kwargs,
+    ),
+)

--- a/navix/environments/fetch.py
+++ b/navix/environments/fetch.py
@@ -104,7 +104,7 @@ class Fetch(Environment):
             grid=grid,
             cache=cache or RenderingCache.init(grid),
             entities=entities,
-            mission=mission,
+            mission=(mission,),
         )
         return Timestep(
             t=jnp.asarray(0, dtype=jnp.int32),

--- a/navix/environments/fetch.py
+++ b/navix/environments/fetch.py
@@ -24,7 +24,13 @@ mission` (same placement/target-selection shape as `GoToObject`). Unlike
 reaching it - and, verified against MiniGrid's actual `FetchEnv.step`
 (this contradicted this issue's own original guess that a wrong pickup
 would be a no-op): picking up *any* object, right or wrong, ends the
-episode; only the reward differs (1 for the right one, 0 otherwise)."""
+episode; only the reward differs (1 for the right one, 0 otherwise).
+
+Registers with `transitions_fn=transitions.deterministic_transition` -
+see go_to_object.py's module docstring for why (the default
+`stochastic_transition` would otherwise walk every `Ball` entity a
+random step each turn, which real MiniGrid's `Ball` doesn't do outside
+`DynamicObstacles`)."""
 
 from __future__ import annotations
 from typing import Union
@@ -34,11 +40,11 @@ import jax.numpy as jnp
 from jax import Array
 from flax import struct
 
-from navix import observations, rewards, terminations
+from navix import observations, rewards, terminations, transitions
 
 from ..components import EMPTY_POCKET_ID
 from ..entities import Ball, Entities, Key, Player
-from ..grid import random_colour, random_directions, random_positions, room
+from ..grid import random_colour, random_directions, random_distinct_positions, random_positions, room
 from ..rendering.cache import RenderingCache
 from ..states import Event, State
 from . import Environment, Timestep
@@ -61,9 +67,10 @@ class Fetch(Environment):
         )
 
         colours = jnp.reshape(random_colour(k_colour, n=self.n_objects), (self.n_objects,))
-        positions = jnp.reshape(
-            random_positions(k_obj_pos, grid, n=self.n_objects, exclude=player_pos),
-            (self.n_objects, 2),
+        # mutually distinct positions - random_positions(..., n=n) alone
+        # would allow two objects to land on the same cell (see #177's PR).
+        positions = random_distinct_positions(
+            k_obj_pos, grid, n=self.n_objects, exclude=player_pos
         )
         n_keys = self.n_objects // 2
         n_balls = self.n_objects - n_keys
@@ -116,6 +123,7 @@ register_env(
         width=5,
         n_objects=2,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        transitions_fn=kwargs.pop("transitions_fn", transitions.deterministic_transition),
         reward_fn=kwargs.pop("reward_fn", rewards.on_target_fetched),
         termination_fn=kwargs.pop("termination_fn", terminations.on_any_target_pickup),
         *args,
@@ -129,6 +137,7 @@ register_env(
         width=6,
         n_objects=2,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        transitions_fn=kwargs.pop("transitions_fn", transitions.deterministic_transition),
         reward_fn=kwargs.pop("reward_fn", rewards.on_target_fetched),
         termination_fn=kwargs.pop("termination_fn", terminations.on_any_target_pickup),
         *args,
@@ -142,6 +151,7 @@ register_env(
         width=8,
         n_objects=3,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        transitions_fn=kwargs.pop("transitions_fn", transitions.deterministic_transition),
         reward_fn=kwargs.pop("reward_fn", rewards.on_target_fetched),
         termination_fn=kwargs.pop("termination_fn", terminations.on_any_target_pickup),
         *args,

--- a/navix/environments/go_to_door.py
+++ b/navix/environments/go_to_door.py
@@ -102,7 +102,7 @@ class GoToDoor(Environment):
             grid=grid,
             cache=RenderingCache.init(grid),
             entities=entities,
-            mission=mission,
+            mission=(mission,),
         )
 
         return Timestep(

--- a/navix/environments/go_to_object.py
+++ b/navix/environments/go_to_object.py
@@ -1,0 +1,152 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`GoToObject` (issue #173): a single room scattered with `n_objects`
+`Key`/`Ball` instances of distinct colours; one is chosen as the
+per-episode target via `State.mission` (same pattern `GoToDoor` already
+uses). Success requires calling `done` while facing the target (verified
+against MiniGrid's actual `GoToObjectEnv.step` - not just proximity, and
+calling `toggle` at all immediately fails), unlike the already-shipped
+`GoToDoor`/`events.on_door_done`, which doesn't check the action at all
+(a pre-existing gap, left as-is here - see PR description)."""
+
+from __future__ import annotations
+from typing import Union
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+from flax import struct
+
+from navix import observations, rewards, terminations
+
+from ..components import EMPTY_POCKET_ID
+from ..entities import Ball, Entities, Key, Player
+from ..grid import random_colour, random_directions, random_positions, room
+from ..rendering.cache import RenderingCache
+from ..states import Event, State
+from . import Environment, Timestep
+from .registry import register_env
+
+
+class GoToObject(Environment):
+    n_objects: int = struct.field(pytree_node=False, default=2)
+
+    def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
+        k_pos, k_dir, k_obj_pos, k_colour, k_target = jax.random.split(key, 5)
+
+        grid = room(self.height, self.width)
+
+        player_pos = random_positions(k_pos, grid)
+        player = Player.create(
+            position=player_pos,
+            direction=random_directions(k_dir),
+            pocket=EMPTY_POCKET_ID,
+        )
+
+        # n_objects distinct colours, split as evenly as possible between
+        # Key and Ball (n_objects=2 -> one of each, matching the
+        # registered sizes below); positions exclude the player.
+        colours = random_colour(k_colour, n=self.n_objects)
+        colours = jnp.reshape(colours, (self.n_objects,))
+        positions = random_positions(
+            k_obj_pos, grid, n=self.n_objects, exclude=player_pos
+        )
+        positions = jnp.reshape(positions, (self.n_objects, 2))
+        n_keys = self.n_objects // 2
+        n_balls = self.n_objects - n_keys
+
+        entities = {Entities.PLAYER: player[None]}
+        if n_keys > 0:
+            keys = Key.create(
+                position=positions[:n_keys],
+                colour=colours[:n_keys],
+                id=jnp.arange(1, n_keys + 1, dtype=jnp.int32),
+            )
+            entities[Entities.KEY] = keys
+        if n_balls > 0:
+            balls = Ball.create(
+                position=positions[n_keys:],
+                colour=colours[n_keys:],
+                probability=jnp.ones(n_balls),
+                id=jnp.arange(n_keys + 1, self.n_objects + 1, dtype=jnp.int32),
+            )
+            entities[Entities.BALL] = balls
+
+        # target: one of the n_objects positions/colours, chosen uniformly
+        target_idx = jax.random.randint(k_target, (), 0, self.n_objects)
+        mission = Event(
+            position=positions[target_idx],
+            colour=colours[target_idx],
+            happened=jnp.asarray(False),
+        )
+
+        state = State(
+            key=key,
+            grid=grid,
+            cache=cache or RenderingCache.init(grid),
+            entities=entities,
+            mission=mission,
+        )
+        return Timestep(
+            t=jnp.asarray(0, dtype=jnp.int32),
+            observation=self.observation_fn(state),
+            action=jnp.asarray(-1, dtype=jnp.int32),
+            reward=jnp.asarray(0.0, dtype=jnp.float32),
+            step_type=jnp.asarray(0, dtype=jnp.int32),
+            state=state,
+        )
+
+
+register_env(
+    "Navix-GoToObject-6x6-N2-v0",
+    lambda *args, **kwargs: GoToObject.create(
+        height=6,
+        width=6,
+        n_objects=2,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_target_done),
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_target_done, terminations.on_wrong_toggle
+            ),
+        ),
+        *args,
+        **kwargs,
+    ),
+)
+register_env(
+    "Navix-GoToObject-8x8-N2-v0",
+    lambda *args, **kwargs: GoToObject.create(
+        height=8,
+        width=8,
+        n_objects=2,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_target_done),
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_target_done, terminations.on_wrong_toggle
+            ),
+        ),
+        *args,
+        **kwargs,
+    ),
+)

--- a/navix/environments/go_to_object.py
+++ b/navix/environments/go_to_object.py
@@ -24,7 +24,16 @@ uses). Success requires calling `done` while facing the target (verified
 against MiniGrid's actual `GoToObjectEnv.step` - not just proximity, and
 calling `toggle` at all immediately fails), unlike the already-shipped
 `GoToDoor`/`events.on_door_done`, which doesn't check the action at all
-(a pre-existing gap, left as-is here - see PR description)."""
+(a pre-existing gap, left as-is here - see PR description).
+
+Registers with `transitions_fn=transitions.deterministic_transition`,
+overriding the default `stochastic_transition` - the latter
+unconditionally moves *every* `Ball` entity a random step each turn
+(`transitions.update_balls`, meant for `DynamicObstacles`), which would
+silently walk this environment's target/decoy objects around the room
+turn by turn. Real MiniGrid's `Ball` is static outside `DynamicObstacles`
+(confirmed empirically: without this override, mission.position stops
+matching any object's actual position after just a couple of steps)."""
 
 from __future__ import annotations
 from typing import Union
@@ -34,11 +43,11 @@ import jax.numpy as jnp
 from jax import Array
 from flax import struct
 
-from navix import observations, rewards, terminations
+from navix import observations, rewards, terminations, transitions
 
 from ..components import EMPTY_POCKET_ID
 from ..entities import Ball, Entities, Key, Player
-from ..grid import random_colour, random_directions, random_positions, room
+from ..grid import random_colour, random_directions, random_distinct_positions, random_positions, room
 from ..rendering.cache import RenderingCache
 from ..states import Event, State
 from . import Environment, Timestep
@@ -62,13 +71,14 @@ class GoToObject(Environment):
 
         # n_objects distinct colours, split as evenly as possible between
         # Key and Ball (n_objects=2 -> one of each, matching the
-        # registered sizes below); positions exclude the player.
+        # registered sizes below); positions mutually distinct and
+        # excluding the player (random_positions(..., n=n) alone would
+        # allow two objects to land on the same cell - see #172's PR).
         colours = random_colour(k_colour, n=self.n_objects)
         colours = jnp.reshape(colours, (self.n_objects,))
-        positions = random_positions(
+        positions = random_distinct_positions(
             k_obj_pos, grid, n=self.n_objects, exclude=player_pos
         )
-        positions = jnp.reshape(positions, (self.n_objects, 2))
         n_keys = self.n_objects // 2
         n_balls = self.n_objects - n_keys
 
@@ -121,6 +131,7 @@ register_env(
         width=6,
         n_objects=2,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        transitions_fn=kwargs.pop("transitions_fn", transitions.deterministic_transition),
         reward_fn=kwargs.pop("reward_fn", rewards.on_target_done),
         termination_fn=kwargs.pop(
             "termination_fn",
@@ -139,6 +150,7 @@ register_env(
         width=8,
         n_objects=2,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        transitions_fn=kwargs.pop("transitions_fn", transitions.deterministic_transition),
         reward_fn=kwargs.pop("reward_fn", rewards.on_target_done),
         termination_fn=kwargs.pop(
             "termination_fn",

--- a/navix/environments/go_to_object.py
+++ b/navix/environments/go_to_object.py
@@ -131,7 +131,7 @@ class GoToObject(Environment):
             grid=grid,
             cache=cache or RenderingCache.init(grid),
             entities=entities,
-            mission=mission,
+            mission=(mission,),
         )
         return Timestep(
             t=jnp.asarray(0, dtype=jnp.int32),

--- a/navix/environments/go_to_object.py
+++ b/navix/environments/go_to_object.py
@@ -18,13 +18,21 @@
 # under the License.
 
 """`GoToObject` (issue #173): a single room scattered with `n_objects`
-`Key`/`Ball` instances of distinct colours; one is chosen as the
+`Key`/`Ball`/`Box` instances of distinct colours; one is chosen as the
 per-episode target via `State.mission` (same pattern `GoToDoor` already
 uses). Success requires calling `done` while facing the target (verified
 against MiniGrid's actual `GoToObjectEnv.step` - not just proximity, and
 calling `toggle` at all immediately fails), unlike the already-shipped
 `GoToDoor`/`events.on_door_done`, which doesn't check the action at all
 (a pre-existing gap, left as-is here - see PR description).
+
+Each object's type is drawn independently (matching MiniGrid's own
+`types = ["key", "ball", "box"]` sampled per object, checked directly
+against source - not a fixed split), so the actual per-type counts vary
+by episode; implemented by always allocating `n_objects` Key/Ball/Box
+slots and pushing every slot not assigned that episode's type to
+`DISCARD_PILE_COORDS` - the same padding-sentinel pattern
+`LavaCrossing` already uses for its own variable-count entities.
 
 Registers with `transitions_fn=transitions.deterministic_transition`,
 overriding the default `stochastic_transition` - the latter
@@ -45,8 +53,8 @@ from flax import struct
 
 from navix import observations, rewards, terminations, transitions
 
-from ..components import EMPTY_POCKET_ID
-from ..entities import Ball, Entities, Key, Player
+from ..components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
+from ..entities import Ball, Box, Entities, Key, Player
 from ..grid import random_colour, random_directions, random_distinct_positions, random_positions, room
 from ..rendering.cache import RenderingCache
 from ..states import Event, State
@@ -58,7 +66,7 @@ class GoToObject(Environment):
     n_objects: int = struct.field(pytree_node=False, default=2)
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
-        k_pos, k_dir, k_obj_pos, k_colour, k_target = jax.random.split(key, 5)
+        k_pos, k_dir, k_obj_pos, k_colour, k_target, k_types = jax.random.split(key, 6)
 
         grid = room(self.height, self.width)
 
@@ -69,37 +77,48 @@ class GoToObject(Environment):
             pocket=EMPTY_POCKET_ID,
         )
 
-        # n_objects distinct colours, split as evenly as possible between
-        # Key and Ball (n_objects=2 -> one of each, matching the
-        # registered sizes below); positions mutually distinct and
-        # excluding the player (random_positions(..., n=n) alone would
-        # allow two objects to land on the same cell - see #172's PR).
-        colours = random_colour(k_colour, n=self.n_objects)
-        colours = jnp.reshape(colours, (self.n_objects,))
+        # n_objects distinct colours and positions - random_positions(...,
+        # n=n) alone would allow two objects to land on the same cell
+        # (see #172's PR).
+        colours = jnp.reshape(random_colour(k_colour, n=self.n_objects), (self.n_objects,))
         positions = random_distinct_positions(
             k_obj_pos, grid, n=self.n_objects, exclude=player_pos
         )
-        n_keys = self.n_objects // 2
-        n_balls = self.n_objects - n_keys
 
-        entities = {Entities.PLAYER: player[None]}
-        if n_keys > 0:
-            keys = Key.create(
-                position=positions[:n_keys],
-                colour=colours[:n_keys],
-                id=jnp.arange(1, n_keys + 1, dtype=jnp.int32),
-            )
-            entities[Entities.KEY] = keys
-        if n_balls > 0:
-            balls = Ball.create(
-                position=positions[n_keys:],
-                colour=colours[n_keys:],
-                probability=jnp.ones(n_balls),
-                id=jnp.arange(n_keys + 1, self.n_objects + 1, dtype=jnp.int32),
-            )
-            entities[Entities.BALL] = balls
+        # each object's type drawn independently, 0=Key/1=Ball/2=Box -
+        # see module docstring for why every slot is allocated for every
+        # type, with non-matching slots pushed off-grid.
+        type_idx = jax.random.randint(k_types, (self.n_objects,), 0, 3)
+        is_key, is_ball, is_box = type_idx == 0, type_idx == 1, type_idx == 2
+        key_pos = jnp.where(is_key[:, None], positions, DISCARD_PILE_COORDS)
+        ball_pos = jnp.where(is_ball[:, None], positions, DISCARD_PILE_COORDS)
+        box_pos = jnp.where(is_box[:, None], positions, DISCARD_PILE_COORDS)
+
+        keys = Key.create(
+            position=key_pos, colour=colours, id=jnp.arange(1, self.n_objects + 1, dtype=jnp.int32)
+        )
+        balls = Ball.create(
+            position=ball_pos,
+            colour=colours,
+            probability=jnp.ones(self.n_objects),
+            id=jnp.arange(self.n_objects + 1, 2 * self.n_objects + 1, dtype=jnp.int32),
+        )
+        boxes = Box.create(
+            position=box_pos,
+            colour=colours,
+            id=jnp.arange(2 * self.n_objects + 1, 3 * self.n_objects + 1, dtype=jnp.int32),
+            pocket=jnp.full((self.n_objects,), -1, dtype=jnp.int32),
+        )
+        entities = {
+            Entities.PLAYER: player[None],
+            Entities.KEY: keys,
+            Entities.BALL: balls,
+            Entities.BOX: boxes,
+        }
 
         # target: one of the n_objects positions/colours, chosen uniformly
+        # - position alone identifies the target regardless of which
+        # type ended up there, so no further change needed here.
         target_idx = jax.random.randint(k_target, (), 0, self.n_objects)
         mission = Event(
             position=positions[target_idx],

--- a/navix/environments/put_near.py
+++ b/navix/environments/put_near.py
@@ -1,0 +1,159 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`PutNear` (issue #178): a single room scattered with `n_objects`
+`Key`/`Ball` instances; two distinct ones are chosen as the per-episode
+"move" (`State.mission` - the object to carry) and "target" (`State.
+mission2` - the object to drop near) objects. The agent must pick up the
+move object and drop it within Chebyshev distance 1 of the target.
+Verified against MiniGrid's actual `PutNearEnv.step`: picking up the
+wrong object ends the episode immediately (0 reward); any genuine drop
+attempt (was holding something) also ends the episode, success
+determined by whether it landed near the target."""
+
+from __future__ import annotations
+from typing import Union
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+from flax import struct
+
+from navix import observations, rewards, terminations
+
+from ..components import EMPTY_POCKET_ID
+from ..entities import Ball, Entities, Key, Player
+from ..grid import random_colour, random_directions, random_positions, room
+from ..rendering.cache import RenderingCache
+from ..states import Event, State
+from . import Environment, Timestep
+from .registry import register_env
+
+
+class PutNear(Environment):
+    n_objects: int = struct.field(pytree_node=False, default=2)
+
+    def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
+        k_pos, k_dir, k_obj_pos, k_colour, k_targets = jax.random.split(key, 5)
+
+        grid = room(self.height, self.width)
+
+        player_pos = random_positions(k_pos, grid)
+        player = Player.create(
+            position=player_pos,
+            direction=random_directions(k_dir),
+            pocket=EMPTY_POCKET_ID,
+        )
+
+        colours = jnp.reshape(random_colour(k_colour, n=self.n_objects), (self.n_objects,))
+        positions = jnp.reshape(
+            random_positions(k_obj_pos, grid, n=self.n_objects, exclude=player_pos),
+            (self.n_objects, 2),
+        )
+        n_keys = self.n_objects // 2
+        n_balls = self.n_objects - n_keys
+
+        entities = {Entities.PLAYER: player[None]}
+        if n_keys > 0:
+            keys = Key.create(
+                position=positions[:n_keys],
+                colour=colours[:n_keys],
+                id=jnp.arange(1, n_keys + 1, dtype=jnp.int32),
+            )
+            entities[Entities.KEY] = keys
+        if n_balls > 0:
+            balls = Ball.create(
+                position=positions[n_keys:],
+                colour=colours[n_keys:],
+                probability=jnp.ones(n_balls),
+                id=jnp.arange(n_keys + 1, self.n_objects + 1, dtype=jnp.int32),
+            )
+            entities[Entities.BALL] = balls
+
+        # two distinct objects: move (to carry) and target (to drop near)
+        move_idx, target_idx = jax.random.choice(
+            k_targets, self.n_objects, shape=(2,), replace=False
+        )
+        mission = Event(
+            position=positions[move_idx],
+            colour=colours[move_idx],
+            happened=jnp.asarray(False),
+        )
+        mission2 = Event(
+            position=positions[target_idx],
+            colour=colours[target_idx],
+            happened=jnp.asarray(False),
+        )
+
+        state = State(
+            key=key,
+            grid=grid,
+            cache=cache or RenderingCache.init(grid),
+            entities=entities,
+            mission=mission,
+            mission2=mission2,
+        )
+        return Timestep(
+            t=jnp.asarray(0, dtype=jnp.int32),
+            observation=self.observation_fn(state),
+            action=jnp.asarray(-1, dtype=jnp.int32),
+            reward=jnp.asarray(0.0, dtype=jnp.float32),
+            step_type=jnp.asarray(0, dtype=jnp.int32),
+            state=state,
+        )
+
+
+register_env(
+    "Navix-PutNear-6x6-N2-v0",
+    lambda *args, **kwargs: PutNear.create(
+        height=6,
+        width=6,
+        n_objects=2,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_put_near_success),
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_put_near_wrong_pickup,
+                terminations.on_put_near_drop_attempted,
+            ),
+        ),
+        *args,
+        **kwargs,
+    ),
+)
+register_env(
+    "Navix-PutNear-8x8-N3-v0",
+    lambda *args, **kwargs: PutNear.create(
+        height=8,
+        width=8,
+        n_objects=3,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_put_near_success),
+        termination_fn=kwargs.pop(
+            "termination_fn",
+            terminations.compose(
+                terminations.on_put_near_wrong_pickup,
+                terminations.on_put_near_drop_attempted,
+            ),
+        ),
+        *args,
+        **kwargs,
+    ),
+)

--- a/navix/environments/put_near.py
+++ b/navix/environments/put_near.py
@@ -45,7 +45,14 @@ from navix import observations, rewards, terminations, transitions
 
 from ..components import EMPTY_POCKET_ID
 from ..entities import Ball, Entities, Key, Player
-from ..grid import random_colour, random_directions, random_distinct_positions, random_positions, room
+from ..grid import (
+    random_colour,
+    random_directions,
+    random_distinct_positions,
+    random_position_far_from,
+    random_positions,
+    room,
+)
 from ..rendering.cache import RenderingCache
 from ..states import Event, State
 from . import Environment, Timestep
@@ -56,7 +63,7 @@ class PutNear(Environment):
     n_objects: int = struct.field(pytree_node=False, default=2)
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
-        k_pos, k_dir, k_obj_pos, k_colour, k_targets = jax.random.split(key, 5)
+        k_pos, k_dir, k_obj_pos, k_colour, k_targets, k_target_pos = jax.random.split(key, 6)
 
         grid = room(self.height, self.width)
 
@@ -73,6 +80,38 @@ class PutNear(Environment):
         positions = random_distinct_positions(
             k_obj_pos, grid, n=self.n_objects, exclude=player_pos
         )
+
+        # two distinct objects: move (to carry) and target (to drop near).
+        # Determined before building entities, since the target's
+        # position may need correcting below.
+        move_idx, target_idx = jax.random.choice(
+            k_targets, self.n_objects, shape=(2,), replace=False
+        )
+
+        # random_distinct_positions alone doesn't stop the move/target
+        # pair from spawning already within "near" (Chebyshev <= 1) of
+        # each other - trivially "solved" with no real navigation
+        # needed (quantified: 36% of Navix-PutNear-6x6-N2-v0 episodes,
+        # see grid.random_position_far_from's docstring). If so,
+        # re-place just the target object, far enough from the move
+        # object and clear of every other already-placed position.
+        move_pos = positions[move_idx]
+        target_pos = positions[target_idx]
+        chebyshev = jnp.maximum(
+            jnp.abs(move_pos[0] - target_pos[0]), jnp.abs(move_pos[1] - target_pos[1])
+        )
+        too_close = chebyshev <= 1
+        resampled_target_pos = random_position_far_from(
+            k_target_pos,
+            grid,
+            reference=move_pos,
+            min_distance=2,
+            exclude=jnp.concatenate([positions, player_pos[None]], axis=0),
+        )
+        positions = positions.at[target_idx].set(
+            jnp.where(too_close, resampled_target_pos, target_pos)
+        )
+
         n_keys = self.n_objects // 2
         n_balls = self.n_objects - n_keys
 
@@ -93,10 +132,6 @@ class PutNear(Environment):
             )
             entities[Entities.BALL] = balls
 
-        # two distinct objects: move (to carry) and target (to drop near)
-        move_idx, target_idx = jax.random.choice(
-            k_targets, self.n_objects, shape=(2,), replace=False
-        )
         mission = Event(
             position=positions[move_idx],
             colour=colours[move_idx],

--- a/navix/environments/put_near.py
+++ b/navix/environments/put_near.py
@@ -19,13 +19,14 @@
 
 """`PutNear` (issue #178): a single room scattered with `n_objects`
 `Key`/`Ball`/`Box` instances; two distinct ones are chosen as the
-per-episode "move" (`State.mission` - the object to carry) and "target"
-(`State.mission2` - the object to drop near) objects. The agent must
-pick up the move object and drop it within Chebyshev distance 1 of the
-target. Verified against MiniGrid's actual `PutNearEnv.step`: picking
-up the wrong object ends the episode immediately (0 reward); any
-genuine drop attempt (was holding something) also ends the episode,
-success determined by whether it landed near the target.
+per-episode "move" (`State.mission[0]` - the object to carry) and
+"target" (`State.mission[1]` - the object to drop near) objects. The
+agent must pick up the move object and drop it within Chebyshev
+distance 1 of the target. Verified against MiniGrid's actual
+`PutNearEnv.step`: picking up the wrong object ends the episode
+immediately (0 reward); any genuine drop attempt (was holding
+something) also ends the episode, success determined by whether it
+landed near the target.
 
 Each object's type is drawn independently (matching MiniGrid's own
 `types = ["key", "ball", "box"]` sampled per object, checked directly
@@ -150,12 +151,14 @@ class PutNear(Environment):
             Entities.BOX: boxes,
         }
 
-        mission = Event(
+        # state.mission[0] = move (to carry), state.mission[1] = target
+        # (to drop near) - see states.py's State.mission docstring.
+        move = Event(
             position=positions[move_idx],
             colour=colours[move_idx],
             happened=jnp.asarray(False),
         )
-        mission2 = Event(
+        target = Event(
             position=positions[target_idx],
             colour=colours[target_idx],
             happened=jnp.asarray(False),
@@ -166,8 +169,7 @@ class PutNear(Environment):
             grid=grid,
             cache=cache or RenderingCache.init(grid),
             entities=entities,
-            mission=mission,
-            mission2=mission2,
+            mission=(move, target),
         )
         return Timestep(
             t=jnp.asarray(0, dtype=jnp.int32),

--- a/navix/environments/put_near.py
+++ b/navix/environments/put_near.py
@@ -25,7 +25,13 @@ move object and drop it within Chebyshev distance 1 of the target.
 Verified against MiniGrid's actual `PutNearEnv.step`: picking up the
 wrong object ends the episode immediately (0 reward); any genuine drop
 attempt (was holding something) also ends the episode, success
-determined by whether it landed near the target."""
+determined by whether it landed near the target.
+
+Registers with `transitions_fn=transitions.deterministic_transition` -
+see go_to_object.py's module docstring for why (the default
+`stochastic_transition` would otherwise walk every `Ball` entity a
+random step each turn, which real MiniGrid's `Ball` doesn't do outside
+`DynamicObstacles`)."""
 
 from __future__ import annotations
 from typing import Union
@@ -35,11 +41,11 @@ import jax.numpy as jnp
 from jax import Array
 from flax import struct
 
-from navix import observations, rewards, terminations
+from navix import observations, rewards, terminations, transitions
 
 from ..components import EMPTY_POCKET_ID
 from ..entities import Ball, Entities, Key, Player
-from ..grid import random_colour, random_directions, random_positions, room
+from ..grid import random_colour, random_directions, random_distinct_positions, random_positions, room
 from ..rendering.cache import RenderingCache
 from ..states import Event, State
 from . import Environment, Timestep
@@ -62,9 +68,10 @@ class PutNear(Environment):
         )
 
         colours = jnp.reshape(random_colour(k_colour, n=self.n_objects), (self.n_objects,))
-        positions = jnp.reshape(
-            random_positions(k_obj_pos, grid, n=self.n_objects, exclude=player_pos),
-            (self.n_objects, 2),
+        # mutually distinct positions - random_positions(..., n=n) alone
+        # would allow two objects to land on the same cell (see #178's PR).
+        positions = random_distinct_positions(
+            k_obj_pos, grid, n=self.n_objects, exclude=player_pos
         )
         n_keys = self.n_objects // 2
         n_balls = self.n_objects - n_keys
@@ -126,6 +133,7 @@ register_env(
         width=6,
         n_objects=2,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        transitions_fn=kwargs.pop("transitions_fn", transitions.deterministic_transition),
         reward_fn=kwargs.pop("reward_fn", rewards.on_put_near_success),
         termination_fn=kwargs.pop(
             "termination_fn",
@@ -145,6 +153,7 @@ register_env(
         width=8,
         n_objects=3,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        transitions_fn=kwargs.pop("transitions_fn", transitions.deterministic_transition),
         reward_fn=kwargs.pop("reward_fn", rewards.on_put_near_success),
         termination_fn=kwargs.pop(
             "termination_fn",

--- a/navix/environments/put_near.py
+++ b/navix/environments/put_near.py
@@ -18,14 +18,19 @@
 # under the License.
 
 """`PutNear` (issue #178): a single room scattered with `n_objects`
-`Key`/`Ball` instances; two distinct ones are chosen as the per-episode
-"move" (`State.mission` - the object to carry) and "target" (`State.
-mission2` - the object to drop near) objects. The agent must pick up the
-move object and drop it within Chebyshev distance 1 of the target.
-Verified against MiniGrid's actual `PutNearEnv.step`: picking up the
-wrong object ends the episode immediately (0 reward); any genuine drop
-attempt (was holding something) also ends the episode, success
-determined by whether it landed near the target.
+`Key`/`Ball`/`Box` instances; two distinct ones are chosen as the
+per-episode "move" (`State.mission` - the object to carry) and "target"
+(`State.mission2` - the object to drop near) objects. The agent must
+pick up the move object and drop it within Chebyshev distance 1 of the
+target. Verified against MiniGrid's actual `PutNearEnv.step`: picking
+up the wrong object ends the episode immediately (0 reward); any
+genuine drop attempt (was holding something) also ends the episode,
+success determined by whether it landed near the target.
+
+Each object's type is drawn independently (matching MiniGrid's own
+`types = ["key", "ball", "box"]` sampled per object, checked directly
+against source) - see go_to_object.py's module docstring for the
+padding-sentinel implementation this shares.
 
 Registers with `transitions_fn=transitions.deterministic_transition` -
 see go_to_object.py's module docstring for why (the default
@@ -43,8 +48,8 @@ from flax import struct
 
 from navix import observations, rewards, terminations, transitions
 
-from ..components import EMPTY_POCKET_ID
-from ..entities import Ball, Entities, Key, Player
+from ..components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
+from ..entities import Ball, Box, Entities, Key, Player
 from ..grid import (
     random_colour,
     random_directions,
@@ -63,7 +68,9 @@ class PutNear(Environment):
     n_objects: int = struct.field(pytree_node=False, default=2)
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
-        k_pos, k_dir, k_obj_pos, k_colour, k_targets, k_target_pos = jax.random.split(key, 6)
+        k_pos, k_dir, k_obj_pos, k_colour, k_targets, k_target_pos, k_types = jax.random.split(
+            key, 7
+        )
 
         grid = room(self.height, self.width)
 
@@ -112,25 +119,36 @@ class PutNear(Environment):
             jnp.where(too_close, resampled_target_pos, target_pos)
         )
 
-        n_keys = self.n_objects // 2
-        n_balls = self.n_objects - n_keys
+        # each object's type drawn independently, 0=Key/1=Ball/2=Box -
+        # every slot is allocated for every type, with non-matching
+        # slots pushed off-grid (see module docstring).
+        type_idx = jax.random.randint(k_types, (self.n_objects,), 0, 3)
+        is_key, is_ball, is_box = type_idx == 0, type_idx == 1, type_idx == 2
+        key_pos = jnp.where(is_key[:, None], positions, DISCARD_PILE_COORDS)
+        ball_pos = jnp.where(is_ball[:, None], positions, DISCARD_PILE_COORDS)
+        box_pos = jnp.where(is_box[:, None], positions, DISCARD_PILE_COORDS)
 
-        entities = {Entities.PLAYER: player[None]}
-        if n_keys > 0:
-            keys = Key.create(
-                position=positions[:n_keys],
-                colour=colours[:n_keys],
-                id=jnp.arange(1, n_keys + 1, dtype=jnp.int32),
-            )
-            entities[Entities.KEY] = keys
-        if n_balls > 0:
-            balls = Ball.create(
-                position=positions[n_keys:],
-                colour=colours[n_keys:],
-                probability=jnp.ones(n_balls),
-                id=jnp.arange(n_keys + 1, self.n_objects + 1, dtype=jnp.int32),
-            )
-            entities[Entities.BALL] = balls
+        keys = Key.create(
+            position=key_pos, colour=colours, id=jnp.arange(1, self.n_objects + 1, dtype=jnp.int32)
+        )
+        balls = Ball.create(
+            position=ball_pos,
+            colour=colours,
+            probability=jnp.ones(self.n_objects),
+            id=jnp.arange(self.n_objects + 1, 2 * self.n_objects + 1, dtype=jnp.int32),
+        )
+        boxes = Box.create(
+            position=box_pos,
+            colour=colours,
+            id=jnp.arange(2 * self.n_objects + 1, 3 * self.n_objects + 1, dtype=jnp.int32),
+            pocket=jnp.full((self.n_objects,), -1, dtype=jnp.int32),
+        )
+        entities = {
+            Entities.PLAYER: player[None],
+            Entities.KEY: keys,
+            Entities.BALL: balls,
+            Entities.BOX: boxes,
+        }
 
         mission = Event(
             position=positions[move_idx],

--- a/navix/environments/red_blue_doors.py
+++ b/navix/environments/red_blue_doors.py
@@ -22,10 +22,18 @@ into two chambers, with a red and a blue `Door` both embedded in that
 same wall (at two distinct rows) - both reachable from the left chamber
 alone, no need to ever cross into the right one. Reward + termination on
 opening blue while red is already open; opening blue first ends the
-episode with no reward. Verified against MiniGrid's actual
-`RedBlueDoorEnv._gen_grid`/`step` (both doors sit in the dividing wall,
-agent spawns in the left chamber, order - not position - determines
-success), not assumed."""
+episode with no reward.
+
+Deliberately simplified from MiniGrid's actual `RedBlueDoorEnv._gen_grid`
+(checked directly, after PR #191's review caught an earlier, incorrect
+claim of an exact match here): real MiniGrid places the agent in a
+*third*, middle chamber, with red and blue on two *different* walls
+leading to two separate outer chambers, not one shared wall - but since
+`toggle` only needs the player adjacent-and-facing a door (never
+actually walking through one), and termination fires the instant blue
+opens (before either outer chamber could ever be reached), the two
+layouts are behaviourally indistinguishable through gameplay: order,
+not position, is all that determines success either way."""
 
 from __future__ import annotations
 from typing import Union

--- a/navix/environments/red_blue_doors.py
+++ b/navix/environments/red_blue_doors.py
@@ -1,0 +1,132 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`RedBlueDoors` (issue #172): a single room split by one dividing wall
+into two chambers, with a red and a blue `Door` both embedded in that
+same wall (at two distinct rows) - both reachable from the left chamber
+alone, no need to ever cross into the right one. Reward + termination on
+opening blue while red is already open; opening blue first ends the
+episode with no reward. Verified against MiniGrid's actual
+`RedBlueDoorEnv._gen_grid`/`step` (both doors sit in the dividing wall,
+agent spawns in the left chamber, order - not position - determines
+success), not assumed."""
+
+from __future__ import annotations
+from typing import Union
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from navix import observations, rewards, terminations
+
+from ..components import EMPTY_POCKET_ID
+from ..entities import Door, Entities, Player
+from ..grid import mask_by_coordinates, random_directions, random_positions, two_rooms
+from ..rendering.cache import RenderingCache
+from ..rendering.registry import PALETTE
+from ..states import State
+from . import Environment, Timestep
+from .registry import register_env
+
+
+class RedBlueDoors(Environment):
+    def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
+        k_wall, k_rows, k_pos, k_dir = jax.random.split(key, 4)
+
+        grid, wall_col = two_rooms(self.height, self.width, k_wall)
+
+        # two distinct rows within the dividing wall's interior span for
+        # the red/blue doors - fixed construction order (red = index 0,
+        # blue = index 1) is relied on by events.on_ordered_doors_*, no
+        # colour search needed there.
+        rows = jax.random.choice(
+            k_rows, jnp.arange(1, self.height - 1), shape=(2,), replace=False
+        )
+        positions = jnp.stack([rows, jnp.full((2,), wall_col)], axis=1)
+        grid = grid.at[rows, wall_col].set(0)
+
+        doors = Door.create(
+            position=positions,
+            requires=jnp.asarray([-1, -1]),  # unlocked - just closed
+            colour=jnp.asarray([PALETTE.RED, PALETTE.BLUE]),
+            open=jnp.asarray([False, False]),
+        )
+
+        # agent starts in the left chamber only, matching MiniGrid
+        left_chamber_mask = mask_by_coordinates(
+            grid, (jnp.asarray(self.height), jnp.asarray(wall_col)), jnp.less
+        )
+        left_chamber = jnp.where(left_chamber_mask, grid, -1)
+        player_pos = random_positions(k_pos, left_chamber)
+        player = Player.create(
+            position=player_pos,
+            direction=random_directions(k_dir),
+            pocket=EMPTY_POCKET_ID,
+        )
+
+        entities = {
+            Entities.PLAYER: player[None],
+            Entities.DOOR: doors,
+        }
+
+        state = State(
+            key=key,
+            grid=grid,
+            cache=cache or RenderingCache.init(grid),
+            entities=entities,
+        )
+        return Timestep(
+            t=jnp.asarray(0, dtype=jnp.int32),
+            observation=self.observation_fn(state),
+            action=jnp.asarray(-1, dtype=jnp.int32),
+            reward=jnp.asarray(0.0, dtype=jnp.float32),
+            step_type=jnp.asarray(0, dtype=jnp.int32),
+            state=state,
+        )
+
+
+register_env(
+    "Navix-RedBlueDoors-6x6-v0",
+    lambda *args, **kwargs: RedBlueDoors.create(
+        height=6,
+        width=6,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_ordered_doors_success),
+        termination_fn=kwargs.pop(
+            "termination_fn", terminations.on_ordered_doors_resolved
+        ),
+        *args,
+        **kwargs,
+    ),
+)
+register_env(
+    "Navix-RedBlueDoors-8x8-v0",
+    lambda *args, **kwargs: RedBlueDoors.create(
+        height=8,
+        width=8,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_ordered_doors_success),
+        termination_fn=kwargs.pop(
+            "termination_fn", terminations.on_ordered_doors_resolved
+        ),
+        *args,
+        **kwargs,
+    ),
+)

--- a/navix/environments/unlock.py
+++ b/navix/environments/unlock.py
@@ -30,7 +30,7 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 
-from navix import observations, rewards, terminations
+from navix import observations, rewards, terminations, transitions
 
 from ..components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
 from ..entities import Ball, Box, Door, Entities, Entity, Key, Player
@@ -214,11 +214,16 @@ class UnlockPickup(Environment):
 class BlockedUnlockPickup(Environment):
     """`UnlockPickup` (#176), plus a `Ball` placed directly in front of
     the door on the first room's side, obstructing the direct approach
-    (#181) - the agent must move it out of the way (pick it up and
-    carry it elsewhere, or step around it if the room is wide enough)
-    before it can reach and unlock the door. Reuses
-    `two_equal_rooms_with_door(block_door=True)` directly - no
-    `RoomGrid` (#174) needed, despite this issue's own header
+    (#181). Unlike a Key/Box, picking the ball up doesn't need to be
+    followed by carrying it anywhere in particular - `actions.pickup`
+    moves it straight to the discard pile, so the blocked cell is clear
+    the instant it's picked up. It does need to be *dropped* again
+    before the key can be picked up, though (the player's pocket only
+    holds one id at a time) - "step around it" isn't a real option: the
+    door, like every `Openable`, can only be toggled from the one exact
+    cell directly in front of it, which is exactly where the ball
+    sits. Reuses `two_equal_rooms_with_door(block_door=True)` directly -
+    no `RoomGrid` (#174) needed, despite this issue's own header
     suggesting otherwise."""
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
@@ -286,6 +291,11 @@ register_env(
         height=6,
         width=11,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        # the default stochastic_transition would otherwise move the
+        # blocking Ball a random step each turn (transitions.
+        # update_balls, meant for DynamicObstacles) - real MiniGrid's
+        # Ball is static outside that one environment.
+        transitions_fn=kwargs.pop("transitions_fn", transitions.deterministic_transition),
         reward_fn=kwargs.pop("reward_fn", rewards.on_box_pickup),
         termination_fn=kwargs.pop("termination_fn", terminations.on_box_pickup),
         *args,

--- a/navix/environments/unlock.py
+++ b/navix/environments/unlock.py
@@ -32,8 +32,8 @@ from jax import Array
 
 from navix import observations, rewards, terminations
 
-from ..components import EMPTY_POCKET_ID
-from ..entities import Box, Door, Entities, Entity, Key, Player
+from ..components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
+from ..entities import Ball, Box, Door, Entities, Entity, Key, Player
 from ..grid import mask_by_coordinates, random_colour, random_directions, random_positions
 from ..rendering.cache import RenderingCache
 from ..states import State
@@ -42,7 +42,7 @@ from .registry import register_env
 
 
 def two_equal_rooms_with_door(
-    key: Array, height: int, width: int
+    key: Array, height: int, width: int, block_door: bool = False
 ) -> Tuple[Array, Array, int, Dict[str, Entity], Array, Array]:
     """Builds the shared layout `Unlock`/`UnlockPickup` both start from:
     two `height x height`-square rooms side by side (`wall_col =
@@ -57,15 +57,25 @@ def two_equal_rooms_with_door(
         key (Array): PRNG key.
         height (int): Height of each room (MiniGrid's `room_size`).
         width (int): Must be `2 * (height - 1) + 1`.
+        block_door (bool): If True (used by `BlockedUnlockPickup`, #181),
+            also places a `Ball` directly in front of the door on the
+            first room's side, and excludes that cell from player/key
+            placement - a static Python bool (not a traced value), so
+            this branches at trace-construction time, not runtime; the
+            door's position is already known at this point inside the
+            function (unlike a caller trying to add a blocking ball
+            afterwards, which would risk colliding with an
+            already-randomly-placed player/key).
 
     Returns:
         Tuple[Array, ...]: `(key, grid, wall_col, entities_dict, first_room,
         door_colour)` - `entities_dict` has `Entities.PLAYER`/`KEY`/`DOOR`
-        already batched (`[None]`-indexed) and ready to merge into a
-        `State`; `first_room` (the left room's own `grid`-shaped mask,
-        walls everywhere outside it) is returned too, so `UnlockPickup`
-        can build its own `second_room` mask from the same `wall_col`
-        without recomputing the base grid.
+        (and `Entities.BALL` if `block_door`) already batched
+        (`[None]`-indexed) and ready to merge into a `State`; `first_room`
+        (the left room's own `grid`-shaped mask, walls everywhere outside
+        it) is returned too, so `UnlockPickup` can build its own
+        `second_room` mask from the same `wall_col` without recomputing
+        the base grid.
     """
     assert (
         width == 2 * (height - 1) + 1
@@ -104,13 +114,16 @@ def two_equal_rooms_with_door(
     )
     first_room = jnp.where(first_room_mask, grid, -1)
 
-    player_pos = random_positions(k_player_pos, first_room)
+    block_pos = jnp.asarray([door_row, wall_col - 1])
+    player_exclude = block_pos if block_door else DISCARD_PILE_COORDS
+    player_pos = random_positions(k_player_pos, first_room, exclude=player_exclude)
     player_dir = random_directions(k_player_dir)
     player = Player.create(
         position=player_pos, direction=player_dir, pocket=EMPTY_POCKET_ID
     )
 
-    key_pos = random_positions(k_key_pos, first_room, exclude=player_pos)
+    key_exclude = jnp.stack([player_pos, block_pos]) if block_door else player_pos
+    key_pos = random_positions(k_key_pos, first_room, exclude=key_exclude)
     keys = Key.create(position=key_pos, id=jnp.asarray(1), colour=door_colour)
 
     entities = {
@@ -118,6 +131,14 @@ def two_equal_rooms_with_door(
         Entities.KEY: keys[None],
         Entities.DOOR: doors[None],
     }
+    if block_door:
+        blocker = Ball.create(
+            position=block_pos,
+            colour=door_colour,
+            probability=jnp.asarray(1.0),
+            id=jnp.asarray(3),
+        )
+        entities[Entities.BALL] = blocker[None]
     return key, grid, wall_col, entities, first_room, door_colour
 
 
@@ -190,6 +211,51 @@ class UnlockPickup(Environment):
         )
 
 
+class BlockedUnlockPickup(Environment):
+    """`UnlockPickup` (#176), plus a `Ball` placed directly in front of
+    the door on the first room's side, obstructing the direct approach
+    (#181) - the agent must move it out of the way (pick it up and
+    carry it elsewhere, or step around it if the room is wide enough)
+    before it can reach and unlock the door. Reuses
+    `two_equal_rooms_with_door(block_door=True)` directly - no
+    `RoomGrid` (#174) needed, despite this issue's own header
+    suggesting otherwise."""
+
+    def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
+        key, grid, wall_col, entities, _, _ = two_equal_rooms_with_door(
+            key, self.height, self.width, block_door=True
+        )
+
+        key, k_box_pos, k_box_colour = jax.random.split(key, 3)
+        second_room_mask = mask_by_coordinates(
+            grid, (jnp.asarray(0), jnp.asarray(wall_col)), jnp.greater
+        )
+        second_room = jnp.where(second_room_mask, grid, -1)
+        box_pos = random_positions(k_box_pos, second_room)
+        boxes = Box.create(
+            position=box_pos,
+            colour=random_colour(k_box_colour),
+            id=jnp.asarray(2),
+            pocket=jnp.asarray(-1),
+        )
+        entities[Entities.BOX] = boxes[None]
+
+        state = State(
+            key=key,
+            grid=grid,
+            cache=cache or RenderingCache.init(grid),
+            entities=entities,
+        )
+        return Timestep(
+            t=jnp.asarray(0, dtype=jnp.int32),
+            observation=self.observation_fn(state),
+            action=jnp.asarray(-1, dtype=jnp.int32),
+            reward=jnp.asarray(0.0, dtype=jnp.float32),
+            step_type=jnp.asarray(0, dtype=jnp.int32),
+            state=state,
+        )
+
+
 register_env(
     "Navix-Unlock-v0",
     lambda *args, **kwargs: Unlock.create(
@@ -205,6 +271,18 @@ register_env(
 register_env(
     "Navix-UnlockPickup-v0",
     lambda *args, **kwargs: UnlockPickup.create(
+        height=6,
+        width=11,
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_box_pickup),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_box_pickup),
+        *args,
+        **kwargs,
+    ),
+)
+register_env(
+    "Navix-BlockedUnlockPickup-v0",
+    lambda *args, **kwargs: BlockedUnlockPickup.create(
         height=6,
         width=11,
         observation_fn=kwargs.pop("observation_fn", observations.symbolic),

--- a/navix/events.py
+++ b/navix/events.py
@@ -83,7 +83,7 @@ def on_door_done(state: State) -> Array:
         Array: A boolean array indicating whether the action `done` has been called in front of a `Door` object with the correct colour.
     """
     assert (
-        state.mission is not None
+        len(state.mission) > 0
     ), "Termination on door done requires the state to specify a mission."
     player = state.entities[Entities.PLAYER][0]
     assert isinstance(player, Player)
@@ -94,8 +94,8 @@ def on_door_done(state: State) -> Array:
     doors = state.get_doors()
     idx = jnp.where(positions_equal(doors.position, fwd_pos), size=1)[0][0]
     doors = doors[idx]
-    pos_match = jnp.array_equal(fwd_pos, state.mission.position)
-    colour_match = jnp.array_equal(doors.colour, state.mission.colour)
+    pos_match = jnp.array_equal(fwd_pos, state.mission[0].position)
+    colour_match = jnp.array_equal(doors.colour, state.mission[0].colour)
     return jnp.logical_and(pos_match, colour_match)
 
 
@@ -230,12 +230,12 @@ def on_target_done(action: Array, state: State) -> Array:
     Returns:
         Array: A boolean scalar."""
     assert (
-        state.mission is not None
+        len(state.mission) > 0
     ), "on_target_done requires the state to specify a mission."
     player = state.entities[Entities.PLAYER][0]
     assert isinstance(player, Player)
-    row_diff = player.position[0] - state.mission.position[0]
-    col_diff = player.position[1] - state.mission.position[1]
+    row_diff = player.position[0] - state.mission[0].position[0]
+    col_diff = player.position[1] - state.mission[0].position[1]
     adjacent = jnp.logical_or(
         jnp.logical_and(row_diff == 0, jnp.abs(col_diff) == 1),
         jnp.logical_and(col_diff == 0, jnp.abs(row_diff) == 1),
@@ -270,13 +270,13 @@ def on_target_fetched(state: State) -> Array:
     Returns:
         Array: A boolean scalar."""
     assert (
-        state.mission is not None
+        len(state.mission) > 0
     ), "on_target_fetched requires the state to specify a mission."
     fetched_key = state.events.happened_at(
-        (Entities.KEY, EventType.PICKUP), state.mission.position
+        (Entities.KEY, EventType.PICKUP), state.mission[0].position
     )
     fetched_ball = state.events.happened_at(
-        (Entities.BALL, EventType.PICKUP), state.mission.position
+        (Entities.BALL, EventType.PICKUP), state.mission[0].position
     )
     return jnp.logical_or(fetched_key, fetched_ball)
 
@@ -309,13 +309,13 @@ def on_put_near_wrong_pickup(state: State) -> Array:
     Returns:
         Array: A boolean scalar."""
     assert (
-        state.mission is not None
+        len(state.mission) > 0
     ), "on_put_near_wrong_pickup requires the state to specify a mission."
     any_pickup = on_any_target_pickup(state)
     right_pickup = (
-        state.events.happened_at((Entities.KEY, EventType.PICKUP), state.mission.position)
-        | state.events.happened_at((Entities.BALL, EventType.PICKUP), state.mission.position)
-        | state.events.happened_at((Entities.BOX, EventType.PICKUP), state.mission.position)
+        state.events.happened_at((Entities.KEY, EventType.PICKUP), state.mission[0].position)
+        | state.events.happened_at((Entities.BALL, EventType.PICKUP), state.mission[0].position)
+        | state.events.happened_at((Entities.BOX, EventType.PICKUP), state.mission[0].position)
     )
     return jnp.logical_and(any_pickup, jnp.logical_not(right_pickup))
 
@@ -341,13 +341,13 @@ def on_put_near_success(prev_state: State, action: Array, state: State) -> Array
     `on_put_near_drop_attempted`) that actually placed the item (the
     player's pocket went from holding something to empty - `actions.
     drop` only clears the pocket on a *successful* drop, see #189) at a
-    cell within Chebyshev distance 1 of `state.mission2`'s tracked
+    cell within Chebyshev distance 1 of `state.mission[1]`'s tracked
     position (the "object to drop near"). Note: by the time a `drop`
     action is reached without the episode already having ended via
     `on_put_near_wrong_pickup`, the held item is guaranteed to be the
-    right one (`state.mission`'s object) - wrong pickups end the episode
-    immediately, so no separate "is this the right item" check is
-    needed here.
+    right one (`state.mission[0]`'s object) - wrong pickups end the
+    episode immediately, so no separate "is this the right item" check
+    is needed here.
 
     Args:
         prev_state (State): The state before this step's action.
@@ -357,13 +357,13 @@ def on_put_near_success(prev_state: State, action: Array, state: State) -> Array
     Returns:
         Array: A boolean scalar."""
     assert (
-        state.mission2 is not None
+        len(state.mission) > 1
     ), "on_put_near_success requires the state to specify a second mission target."
     drop_attempted = on_put_near_drop_attempted(prev_state, action)
     drop_succeeded = jnp.logical_and(drop_attempted, state.get_player().pocket == -1)
     prev_player = prev_state.get_player()
     drop_position = translate(prev_player.position, prev_player.direction)
-    row_diff = jnp.abs(drop_position[0] - state.mission2.position[0])
-    col_diff = jnp.abs(drop_position[1] - state.mission2.position[1])
+    row_diff = jnp.abs(drop_position[0] - state.mission[1].position[0])
+    col_diff = jnp.abs(drop_position[1] - state.mission[1].position[1])
     near_target = jnp.maximum(row_diff, col_diff) <= 1
     return jnp.logical_and(drop_succeeded, near_target)

--- a/navix/events.py
+++ b/navix/events.py
@@ -21,9 +21,20 @@ from __future__ import annotations
 from jax import Array
 import jax.numpy as jnp
 
+from . import actions
 from .states import State, EventType, GRID
 from .grid import positions_equal, translate
 from .entities import Entities, Player
+
+
+# Indices into navix.actions.MINIGRID_ACTION_SET/DEFAULT_ACTION_SET -
+# derived, not hardcoded, so they stay correct if that tuple's ordering
+# ever changes. Only meaningful for an environment actually using that
+# default action_set (matches the existing precedent of
+# `rewards.action_cost` hardcoding an action index the same way).
+DONE_ACTION = jnp.asarray(actions.MINIGRID_ACTION_SET.index(actions.done))
+TOGGLE_ACTION = jnp.asarray(actions.MINIGRID_ACTION_SET.index(actions.toggle))
+DROP_ACTION = jnp.asarray(actions.MINIGRID_ACTION_SET.index(actions.drop))
 
 
 def on_goal_reached(state: State) -> Array:
@@ -129,3 +140,216 @@ def on_wall_hit(state: State) -> Array:
         state.events.happened((Entities.WALL, EventType.HIT)),
         state.events.happened((GRID, EventType.HIT)),
     )
+
+
+def on_key_pickup(state: State) -> Array:
+    """Checks whether any key was picked up using the `key_pickup` event.
+
+    Args:
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean scalar indicating whether any key was picked up
+        this step."""
+    return state.events.happened((Entities.KEY, EventType.PICKUP))
+
+
+def on_ball_pickup(state: State) -> Array:
+    """Checks whether any ball was picked up using the `ball_pickup` event.
+
+    Args:
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean scalar indicating whether any ball was picked up
+        this step."""
+    return state.events.happened((Entities.BALL, EventType.PICKUP))
+
+
+def on_ordered_doors_success(prev_state: State, state: State) -> Array:
+    """`RedBlueDoors`' win condition: `doors[1]` (blue - see
+    `RedBlueDoors._reset`'s fixed construction order, no colour search
+    needed) transitions closed -> open exactly this step, while
+    `doors[0]` (red) was *already* open in `prev_state`.
+
+    Unlike every other function in this module, this needs both
+    `prev_state` and `state` - the win condition is about the *order*
+    two doors were opened in, which no single state can encode on its
+    own (events are reset every step, and a `Door.open` flag alone can't
+    tell you whether it just changed or has been open for a while).
+
+    Args:
+        prev_state (State): The state before this step's action.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean scalar."""
+    red_already_open = jnp.asarray(prev_state.get_doors().open[0], dtype=jnp.bool_)
+    blue_just_opened = jnp.logical_and(
+        jnp.logical_not(jnp.asarray(prev_state.get_doors().open[1], dtype=jnp.bool_)),
+        jnp.asarray(state.get_doors().open[1], dtype=jnp.bool_),
+    )
+    return jnp.logical_and(red_already_open, blue_just_opened)
+
+
+def on_ordered_doors_failure(prev_state: State, state: State) -> Array:
+    """`RedBlueDoors`' fail condition: `doors[1]` (blue) transitions
+    closed -> open exactly this step, while `doors[0]` (red) was *not*
+    already open - i.e. blue was opened first (or simultaneously).
+
+    Args:
+        prev_state (State): The state before this step's action.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean scalar."""
+    red_already_open = jnp.asarray(prev_state.get_doors().open[0], dtype=jnp.bool_)
+    blue_just_opened = jnp.logical_and(
+        jnp.logical_not(jnp.asarray(prev_state.get_doors().open[1], dtype=jnp.bool_)),
+        jnp.asarray(state.get_doors().open[1], dtype=jnp.bool_),
+    )
+    return jnp.logical_and(jnp.logical_not(red_already_open), blue_just_opened)
+
+
+def on_target_done(action: Array, state: State) -> Array:
+    """`GoToObject`'s real win condition (verified against MiniGrid's
+    `GoToObjectEnv.step`): the `done` action was called while facing
+    `state.mission`'s target position - unlike `on_door_done` (kept
+    as-is for `GoToDoor`'s existing, already-shipped behavior), this
+    actually checks `action`, matching MiniGrid precisely.
+
+    Args:
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean scalar."""
+    assert (
+        state.mission is not None
+    ), "on_target_done requires the state to specify a mission."
+    player = state.entities[Entities.PLAYER][0]
+    assert isinstance(player, Player)
+    fwd_pos = translate(player.position, player.direction)
+    facing_target = jnp.array_equal(fwd_pos, state.mission.position)
+    called_done = jnp.asarray(action == DONE_ACTION)
+    return jnp.logical_and(facing_target, called_done)
+
+
+def on_wrong_toggle(action: Array) -> Array:
+    """`GoToObject`'s real fail condition (verified against MiniGrid):
+    calling `toggle` at all, regardless of what's in front, immediately
+    fails the episode.
+
+    Args:
+        action (Array): The action taken by the player.
+
+    Returns:
+        Array: A boolean scalar."""
+    return jnp.asarray(action == TOGGLE_ACTION)
+
+
+def on_target_fetched(state: State) -> Array:
+    """`Fetch`'s success signal: a `Key`/`Ball` pickup event fired this
+    step at `state.mission`'s tracked position - `Event.position` keeps
+    the picked-up instance's real (pre-discard-pile) position, and
+    positions are unique per instance, so this alone identifies whether
+    the *specific* target object (not just any object) was picked up.
+
+    Args:
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean scalar."""
+    assert (
+        state.mission is not None
+    ), "on_target_fetched requires the state to specify a mission."
+    fetched_key = state.events.happened_at(
+        (Entities.KEY, EventType.PICKUP), state.mission.position
+    )
+    fetched_ball = state.events.happened_at(
+        (Entities.BALL, EventType.PICKUP), state.mission.position
+    )
+    return jnp.logical_or(fetched_key, fetched_ball)
+
+
+def on_any_target_pickup(state: State) -> Array:
+    """`Fetch`'s termination trigger: MiniGrid's real `FetchEnv` ends the
+    episode on *any* `Key`/`Ball` pickup, right or wrong - only the
+    reward differs (see `on_target_fetched`).
+
+    Args:
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean scalar."""
+    return jnp.logical_or(on_key_pickup(state), on_ball_pickup(state))
+
+
+def on_put_near_wrong_pickup(state: State) -> Array:
+    """`PutNear`'s fail-on-pickup condition: a `Key`/`Ball` pickup
+    happened this step, but not at `state.mission`'s tracked position
+    (the "object to carry") - matches MiniGrid's real `PutNearEnv`,
+    which ends the episode immediately if the wrong object is picked up.
+
+    Args:
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean scalar."""
+    assert (
+        state.mission is not None
+    ), "on_put_near_wrong_pickup requires the state to specify a mission."
+    any_pickup = on_any_target_pickup(state)
+    right_pickup = state.events.happened_at(
+        (Entities.KEY, EventType.PICKUP), state.mission.position
+    ) | state.events.happened_at((Entities.BALL, EventType.PICKUP), state.mission.position)
+    return jnp.logical_and(any_pickup, jnp.logical_not(right_pickup))
+
+
+def on_put_near_drop_attempted(prev_state: State, action: Array) -> Array:
+    """`PutNear`'s termination trigger for a drop: MiniGrid's real
+    `PutNearEnv` ends the episode on any genuine drop attempt (a `drop`
+    action while actually holding something) - success or failure is
+    determined separately by `on_put_near_success`.
+
+    Args:
+        prev_state (State): The state before this step's action.
+        action (Array): The action taken by the player.
+
+    Returns:
+        Array: A boolean scalar."""
+    was_holding = prev_state.get_player().pocket != -1
+    return jnp.logical_and(was_holding, action == DROP_ACTION)
+
+
+def on_put_near_success(prev_state: State, action: Array, state: State) -> Array:
+    """`PutNear`'s win condition: a genuine drop attempt (see
+    `on_put_near_drop_attempted`) that actually placed the item (the
+    player's pocket went from holding something to empty - `actions.
+    drop` only clears the pocket on a *successful* drop, see #189) at a
+    cell within Chebyshev distance 1 of `state.mission2`'s tracked
+    position (the "object to drop near"). Note: by the time a `drop`
+    action is reached without the episode already having ended via
+    `on_put_near_wrong_pickup`, the held item is guaranteed to be the
+    right one (`state.mission`'s object) - wrong pickups end the episode
+    immediately, so no separate "is this the right item" check is
+    needed here.
+
+    Args:
+        prev_state (State): The state before this step's action.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean scalar."""
+    assert (
+        state.mission2 is not None
+    ), "on_put_near_success requires the state to specify a second mission target."
+    drop_attempted = on_put_near_drop_attempted(prev_state, action)
+    drop_succeeded = jnp.logical_and(drop_attempted, state.get_player().pocket == -1)
+    prev_player = prev_state.get_player()
+    drop_position = translate(prev_player.position, prev_player.direction)
+    row_diff = jnp.abs(drop_position[0] - state.mission2.position[0])
+    col_diff = jnp.abs(drop_position[1] - state.mission2.position[1])
+    near_target = jnp.maximum(row_diff, col_diff) <= 1
+    return jnp.logical_and(drop_succeeded, near_target)

--- a/navix/events.py
+++ b/navix/events.py
@@ -284,18 +284,21 @@ def on_target_fetched(state: State) -> Array:
 def on_any_target_pickup(state: State) -> Array:
     """`Fetch`'s termination trigger: MiniGrid's real `FetchEnv` ends the
     episode on *any* `Key`/`Ball` pickup, right or wrong - only the
-    reward differs (see `on_target_fetched`).
+    reward differs (see `on_target_fetched`). Also reused by `PutNear`
+    (below), which additionally places `Box` - safe for `Fetch` either
+    way, since `on_box_pickup` is always `False` for an environment that
+    never constructs any `Box` entities.
 
     Args:
         state (State): The current state of the game.
 
     Returns:
         Array: A boolean scalar."""
-    return jnp.logical_or(on_key_pickup(state), on_ball_pickup(state))
+    return on_key_pickup(state) | on_ball_pickup(state) | on_box_pickup(state)
 
 
 def on_put_near_wrong_pickup(state: State) -> Array:
-    """`PutNear`'s fail-on-pickup condition: a `Key`/`Ball` pickup
+    """`PutNear`'s fail-on-pickup condition: a `Key`/`Ball`/`Box` pickup
     happened this step, but not at `state.mission`'s tracked position
     (the "object to carry") - matches MiniGrid's real `PutNearEnv`,
     which ends the episode immediately if the wrong object is picked up.
@@ -309,9 +312,11 @@ def on_put_near_wrong_pickup(state: State) -> Array:
         state.mission is not None
     ), "on_put_near_wrong_pickup requires the state to specify a mission."
     any_pickup = on_any_target_pickup(state)
-    right_pickup = state.events.happened_at(
-        (Entities.KEY, EventType.PICKUP), state.mission.position
-    ) | state.events.happened_at((Entities.BALL, EventType.PICKUP), state.mission.position)
+    right_pickup = (
+        state.events.happened_at((Entities.KEY, EventType.PICKUP), state.mission.position)
+        | state.events.happened_at((Entities.BALL, EventType.PICKUP), state.mission.position)
+        | state.events.happened_at((Entities.BOX, EventType.PICKUP), state.mission.position)
+    )
     return jnp.logical_and(any_pickup, jnp.logical_not(right_pickup))
 
 

--- a/navix/events.py
+++ b/navix/events.py
@@ -212,11 +212,16 @@ def on_ordered_doors_failure(prev_state: State, state: State) -> Array:
 
 
 def on_target_done(action: Array, state: State) -> Array:
-    """`GoToObject`'s real win condition (verified against MiniGrid's
-    `GoToObjectEnv.step`): the `done` action was called while facing
-    `state.mission`'s target position - unlike `on_door_done` (kept
-    as-is for `GoToDoor`'s existing, already-shipped behavior), this
-    actually checks `action`, matching MiniGrid precisely.
+    """`GoToObject`'s real win condition (verified directly against
+    MiniGrid's actual `GoToObjectEnv.step` source): the `done` action
+    was called while orthogonally adjacent to `state.mission`'s target -
+    NOT while facing it. An earlier version of this function required
+    facing too, which was a misreading of the source: real MiniGrid's
+    check is pure position, `(ax==tx and abs(ay-ty)==1) or (ay==ty and
+    abs(ax-tx)==1)`, with no facing/direction test at all (PR #191
+    review caught this - reproduced directly: with the player adjacent
+    but facing perpendicular to the target, this function used to
+    return `False` where real MiniGrid rewards it).
 
     Args:
         action (Array): The action taken by the player.
@@ -229,10 +234,14 @@ def on_target_done(action: Array, state: State) -> Array:
     ), "on_target_done requires the state to specify a mission."
     player = state.entities[Entities.PLAYER][0]
     assert isinstance(player, Player)
-    fwd_pos = translate(player.position, player.direction)
-    facing_target = jnp.array_equal(fwd_pos, state.mission.position)
+    row_diff = player.position[0] - state.mission.position[0]
+    col_diff = player.position[1] - state.mission.position[1]
+    adjacent = jnp.logical_or(
+        jnp.logical_and(row_diff == 0, jnp.abs(col_diff) == 1),
+        jnp.logical_and(col_diff == 0, jnp.abs(row_diff) == 1),
+    )
     called_done = jnp.asarray(action == DONE_ACTION)
-    return jnp.logical_and(facing_target, called_done)
+    return jnp.logical_and(adjacent, called_done)
 
 
 def on_wrong_toggle(action: Array) -> Array:

--- a/navix/grid.py
+++ b/navix/grid.py
@@ -287,6 +287,49 @@ def random_distinct_positions(
     return jnp.concatenate(positions, axis=0)
 
 
+def random_position_far_from(
+    key: Array,
+    grid: Array,
+    reference: Array,
+    min_distance: int = 2,
+    exclude: Array = jnp.asarray((-1, -1)),
+) -> Array:
+    """Generates one random position at Chebyshev distance `>=
+    min_distance` from `reference`, also excluding `exclude`.
+
+    For `PutNear`-style tasks: quantified directly (500 seeds each),
+    `random_distinct_positions` alone let 36% of `Navix-PutNear-6x6-N2-v0`
+    episodes spawn with the "move" object already within Chebyshev
+    distance 1 of the "drop near" target - trivially "solved" with no
+    real navigation needed, unlike real MiniGrid's `PutNearEnv`, which
+    explicitly rejects that via `reject_fn=near_obj` (see PR #191
+    review's "New risks" section).
+
+    Args:
+        key (Array): A random key.
+        grid (Array): A 2D grid of shape (height, width).
+        reference (Array): The `(row, col)` position to stay away from.
+        min_distance (int, optional): Minimum Chebyshev distance from
+            `reference`. Defaults to 2 (i.e. not orthogonally/
+            diagonally adjacent, and not the same cell).
+        exclude (Array, optional): Position(s) to also exclude, shape
+            `(2,)` or `(k, 2)`. Defaults to `jnp.asarray((-1, -1))`.
+
+    Returns:
+        Array: A position of shape `i32[2]`."""
+    mesh_row, mesh_col = jnp.mgrid[0 : grid.shape[0], 0 : grid.shape[1]]
+    chebyshev = jnp.maximum(jnp.abs(mesh_row - reference[0]), jnp.abs(mesh_col - reference[1]))
+    too_close = (chebyshev < min_distance).reshape(-1)
+
+    probs = grid.reshape(-1)
+    exclude = jnp.atleast_2d(exclude)
+    exclude_idx = idx_from_coordinates(grid, exclude)
+    probs = probs.at[exclude_idx].set(-1)
+    probs = jnp.where(too_close, -1, probs) + 1.0
+    idx = jax.random.categorical(key, jnp.log(probs), shape=(1,))
+    return coordinates_from_idx(grid, idx).squeeze()
+
+
 def random_directions(key: Array, n=1) -> Array:
     """Generates `n` random directions in the range [0, 1, 2, 3] representing the \
         cardinal directions [east, south, west, north].

--- a/navix/grid.py
+++ b/navix/grid.py
@@ -254,6 +254,39 @@ def random_positions(
     return position.squeeze()
 
 
+def random_distinct_positions(
+    key: Array, grid: Array, n: int, exclude: Array = jnp.asarray((-1, -1))
+) -> Array:
+    """Generates `n` *mutually distinct* random positions in the grid,
+    each also excluding `exclude` - unlike `random_positions(..., n=n)`,
+    whose `n` draws are i.i.d. (`jax.random.categorical` samples with
+    replacement) and so can collide with each other (see issue #172's
+    PR: GoToObject/Fetch/PutNear all need genuinely distinct object
+    positions to track a mission by position alone). Draws sequentially,
+    each excluding every position drawn so far in addition to `exclude` -
+    `n` is a small static Python int in every current caller, so the
+    unrolled loop is fine under jit (same pattern as `jax.random.split`
+    being called with a static count elsewhere in this codebase).
+
+    Args:
+        key (Array): A random key.
+        grid (Array): A 2D grid of shape (height, width).
+        n (int): The number of distinct positions to generate.
+        exclude (Array, optional): Position(s) to also exclude, shape
+            `(2,)` or `(k, 2)`. Defaults to `jnp.asarray((-1, -1))`.
+
+    Returns:
+        Array: `n` mutually distinct positions of shape `i32[n, 2]`."""
+    exclude = jnp.atleast_2d(exclude)
+    keys = jax.random.split(key, n)
+    positions = []
+    for i in range(n):
+        excluded_so_far = jnp.concatenate([exclude, *positions], axis=0)
+        pos = random_positions(keys[i], grid, n=1, exclude=excluded_so_far)
+        positions.append(jnp.reshape(pos, (1, 2)))
+    return jnp.concatenate(positions, axis=0)
+
+
 def random_directions(key: Array, n=1) -> Array:
     """Generates `n` random directions in the range [0, 1, 2, 3] representing the \
         cardinal directions [east, south, west, north].

--- a/navix/rewards.py
+++ b/navix/rewards.py
@@ -169,5 +169,68 @@ def on_box_pickup(prev_state: State, action: Array, state: State) -> Array:
     return jnp.asarray(events.on_box_pickup(state), dtype=jnp.float32)
 
 
+def on_ordered_doors_success(prev_state: State, action: Array, state: State) -> Array:
+    """`RedBlueDoors`' reward: 1 if the blue door was opened this step
+    while red was already open, 0 otherwise (including the failure case
+    of opening blue first).
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A scalar array `f32[]`."""
+    return jnp.asarray(
+        events.on_ordered_doors_success(prev_state, state), dtype=jnp.float32
+    )
+
+
+def on_target_done(prev_state: State, action: Array, state: State) -> Array:
+    """`GoToObject`'s reward: 1 if `done` was called while facing the
+    mission target, 0 otherwise.
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A scalar array `f32[]`."""
+    return jnp.asarray(events.on_target_done(action, state), dtype=jnp.float32)
+
+
+def on_target_fetched(prev_state: State, action: Array, state: State) -> Array:
+    """`Fetch`'s reward: 1 if the mission's target object was the one
+    picked up this step, 0 otherwise (including picking up the wrong
+    one, which still ends the episode via `terminations.
+    on_any_target_pickup`).
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A scalar array `f32[]`."""
+    return jnp.asarray(events.on_target_fetched(state), dtype=jnp.float32)
+
+
+def on_put_near_success(prev_state: State, action: Array, state: State) -> Array:
+    """`PutNear`'s reward: 1 if the carried object was dropped within
+    Chebyshev distance 1 of the second mission target, 0 otherwise.
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A scalar array `f32[]`."""
+    return jnp.asarray(
+        events.on_put_near_success(prev_state, action, state), dtype=jnp.float32
+    )
+
+
 DEFAULT_TASK = compose(on_goal_reached, action_cost)
 """The default task for the game, composed of the `on_goal_reached` and `action_cost` reward functions."""

--- a/navix/states.py
+++ b/navix/states.py
@@ -468,15 +468,15 @@ class State(struct.PyTreeNode):
     goal is reached, or the player is hit by a ball. Left at its default (empty)
     here - `__post_init__` populates it from `entities` via `EventsManager.create`,
     since a `struct.PyTreeNode` field's default can't see its sibling fields."""
-    mission: Event | None = None
-    """The environment's primary mission target, if any (e.g. the door to
-    open in `GoToDoor`, the object to reach in `GoToObject`, the object to
-    carry in `Fetch`/`PutNear`)."""
-    mission2: Event | None = None
-    """A second, independently-tracked mission target, if any - only
-    `PutNear` needs this today (the object to drop *near*, distinct from
-    `mission`'s "object to carry"); every other environment leaves this
-    at its default `None`."""
+    mission: Tuple[Event, ...] = ()
+    """The environment's mission target(s), if any - e.g. `(door,)` in
+    `GoToDoor`, `(target,)` in `GoToObject`/`Fetch`, `(carry, drop_near)`
+    in `PutNear` (index 0 is always the "primary"/carry target; index 1,
+    where present, is a second, independently-tracked target - only
+    `PutNear` needs two today). Empty for an environment with no mission
+    at all. A tuple, not a fixed number of separate fields, so a future
+    environment needing a third simultaneous target is just a longer
+    tuple, not another numbered field."""
 
     def __post_init__(self) -> None:
         # events.events is only ever empty right after construction with no

--- a/navix/states.py
+++ b/navix/states.py
@@ -212,6 +212,28 @@ class EventsManager(struct.PyTreeNode):
             return jnp.asarray(False)
         return jnp.any(event.happened)
 
+    def happened_at(self, key: Tuple[str, str], position: Array) -> Array:
+        """Whether `key`'s slot fired this step for the specific instance
+        that was at `position` when recorded - `Event.position` keeps the
+        firing instance's own position even after game logic later moves
+        the entity itself (e.g. to the discard pile on pickup), so this
+        can identify *which* instance fired, not just whether any did
+        (see `happened`). `False` (not a `KeyError`) if this
+        environment's `entities` never included that entity type at all.
+
+        Args:
+            key (Tuple[str, str]): The `(entity_type, event_type)` slot to
+                check.
+            position (Array): The position to match against.
+
+        Returns:
+            Array: A boolean scalar."""
+        event = self.events.get(key)
+        if event is None:
+            return jnp.asarray(False)
+        at_position = jnp.all(event.position == position, axis=-1)
+        return jnp.any(jnp.logical_and(event.happened, at_position))
+
     def merge_event(
         self, key: Tuple[str, str], hit: Array, position: Array, colour: Array
     ) -> EventsManager:
@@ -447,6 +469,14 @@ class State(struct.PyTreeNode):
     here - `__post_init__` populates it from `entities` via `EventsManager.create`,
     since a `struct.PyTreeNode` field's default can't see its sibling fields."""
     mission: Event | None = None
+    """The environment's primary mission target, if any (e.g. the door to
+    open in `GoToDoor`, the object to reach in `GoToObject`, the object to
+    carry in `Fetch`/`PutNear`)."""
+    mission2: Event | None = None
+    """A second, independently-tracked mission target, if any - only
+    `PutNear` needs this today (the object to drop *near*, distinct from
+    `mission`'s "object to carry"); every other environment leaves this
+    at its default `None`."""
 
     def __post_init__(self) -> None:
         # events.events is only ever empty right after construction with no

--- a/navix/terminations.py
+++ b/navix/terminations.py
@@ -140,4 +140,94 @@ def on_box_pickup(prev_state: State, action: Array, state: State) -> Array:
     return jnp.asarray(events.on_box_pickup(state), dtype=jnp.bool_)
 
 
+def on_ordered_doors_resolved(prev_state: State, action: Array, state: State) -> Array:
+    """`RedBlueDoors`' termination: ends the episode as soon as blue
+    opens, whether that was a success (red already open) or a failure
+    (blue opened first).
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean array."""
+    success = events.on_ordered_doors_success(prev_state, state)
+    failure = events.on_ordered_doors_failure(prev_state, state)
+    return jnp.asarray(jnp.logical_or(success, failure), dtype=jnp.bool_)
+
+
+def on_target_done(prev_state: State, action: Array, state: State) -> Array:
+    """`GoToObject`'s success termination: `done` was called while
+    facing the mission target.
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean array."""
+    return jnp.asarray(events.on_target_done(action, state), dtype=jnp.bool_)
+
+
+def on_wrong_toggle(prev_state: State, action: Array, state: State) -> Array:
+    """`GoToObject`'s failure termination: the `toggle` action was used
+    at all.
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean array."""
+    return jnp.asarray(events.on_wrong_toggle(action), dtype=jnp.bool_)
+
+
+def on_any_target_pickup(prev_state: State, action: Array, state: State) -> Array:
+    """`Fetch`'s termination: any `Key`/`Ball` pickup this step ends the
+    episode, right or wrong (see `rewards.on_target_fetched` for which
+    one determines the reward).
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean array."""
+    return jnp.asarray(events.on_any_target_pickup(state), dtype=jnp.bool_)
+
+
+def on_put_near_wrong_pickup(prev_state: State, action: Array, state: State) -> Array:
+    """`PutNear`'s failure-on-pickup termination: the wrong object was
+    picked up this step.
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean array."""
+    return jnp.asarray(events.on_put_near_wrong_pickup(state), dtype=jnp.bool_)
+
+
+def on_put_near_drop_attempted(prev_state: State, action: Array, state: State) -> Array:
+    """`PutNear`'s termination on a genuine drop attempt (success or
+    failure - see `rewards.on_put_near_success` for which one this was).
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean array."""
+    return jnp.asarray(
+        events.on_put_near_drop_attempted(prev_state, action), dtype=jnp.bool_
+    )
+
+
 DEFAULT_TERMINATION = compose(on_goal_reached, on_lava_fall, on_ball_hit)

--- a/navix/terminations.py
+++ b/navix/terminations.py
@@ -96,6 +96,24 @@ def on_ball_hit(prev_state: State, action: Array, state: State) -> Array:
     return jnp.asarray(events.on_ball_hit(state), dtype=jnp.bool_)
 
 
+def on_ball_pickup(prev_state: State, action: Array, state: State) -> Array:
+    """Check if any ball was picked up this step, using the `ball_pickup`
+    event - for environments (e.g. `DynamicObstacles`) where `Ball`
+    represents a hazard to avoid touching, not an object to carry:
+    composing this alongside `on_ball_hit` makes picking one up end the
+    episode the same way walking into it already does, rather than
+    silently removing it from play now that `Ball` is `Pickable`.
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean array indicating whether any ball was picked up."""
+    return jnp.asarray(events.on_ball_pickup(state), dtype=jnp.bool_)
+
+
 def on_door_done(prev_state: State, action: Array, state: State) -> Array:
     """Check if the action `done` has been called in front of a `Door` object with the \
         correct colour.

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,2 @@
 minigrid
+pytest-xdist

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -316,6 +316,56 @@ def test_pickup():
     ), "Expected key to be at {}, got {}".format(DISCARD_PILE_COORDS, keys.position)
 
 
+def test_pickup_with_exactly_two_instances_of_a_type():
+    # PR #191 review: pickup_entity's `jnp.where(found, DISCARD_PILE_
+    # COORDS, entity.position)` used an unreshaped `found` (shape
+    # (n_instances,)) against entity.position (shape (n_instances, 2)) -
+    # when n_instances == 2, found's shape collides with the trailing
+    # (row, col) axis, so JAX broadcasts it against the wrong axis
+    # entirely (aligning from the right: (2,) matches position's last
+    # axis, not its instance axis). Reproduced directly: with two Ball
+    # instances and only the first one in front of the player, the old
+    # code corrupted *both* balls' rows to the discard row while
+    # leaving both columns untouched, instead of moving only the first
+    # ball to DISCARD_PILE_COORDS entirely. Two Ball instances
+    # specifically (not Key/Box) since this is what actually exposed
+    # the bug - every existing Key/Box usage only ever has one instance.
+    heigh, width = 5, 5
+    grid = jnp.zeros((heigh - 2, width - 2), dtype=jnp.int32)
+    grid = jnp.pad(grid, pad_width=1, mode="constant", constant_values=1)
+    key = jax.random.PRNGKey(0)
+    player = nx.entities.Player(
+        position=jnp.asarray((1, 1)), direction=jnp.asarray(0), pocket=EMPTY_POCKET_ID
+    )
+    balls = nx.entities.Ball(
+        position=jnp.asarray([[1, 2], [3, 3]]),
+        colour=jnp.asarray([PALETTE.BLUE, PALETTE.RED]),
+        probability=jnp.asarray([1.0, 1.0]),
+        id=jnp.asarray([1, 2]),
+    )
+    cache = nx.rendering.cache.RenderingCache.init(grid)
+    entities = {Entities.PLAYER: player[None], Entities.BALL: balls}
+    state = State(key=key, grid=grid, cache=cache, entities=entities)
+
+    state = nx.actions.pickup(state)
+
+    balls = state.get_balls()
+    assert jnp.array_equal(
+        balls.position[0], DISCARD_PILE_COORDS
+    ), "Expected the picked-up ball (id=1) to be at {}, got {}".format(
+        DISCARD_PILE_COORDS, balls.position[0]
+    )
+    assert jnp.array_equal(
+        balls.position[1], jnp.asarray([3, 3])
+    ), "Expected the other ball (id=2) to stay untouched at (3, 3), got {}".format(
+        balls.position[1]
+    )
+    player = state.get_player()
+    assert jnp.array_equal(
+        player.pocket, jnp.asarray(1)
+    ), "Expected pocket to hold the picked-up ball's id (1), got {}".format(player.pocket)
+
+
 def test_drop():
     heigh, width = 5, 5
     grid = jnp.zeros((heigh - 2, width - 2), dtype=jnp.int32)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -338,19 +338,59 @@ def test_ball_hit_walk_into():
     assert bool(nx.events.on_ball_hit(state))
 
 
+def test_ball_pickup_terminates_dynamic_obstacles():
+    # PR #191 review: Ball becoming Pickable means actions.pickup no
+    # longer no-ops facing a ball in Navix-Dynamic-Obstacles-* (every
+    # registered environment includes pickup in its default action_set,
+    # and this is the only pre-existing environment that constructs
+    # Ball - confirmed via grep, no other shipped environment is
+    # affected). Rather than silently removing the ball from play, or
+    # shrinking the action space to exclude pickup (which would make
+    # this environment's action interface heterogeneous with the rest
+    # of the suite, breaking any agent meant to train across all of
+    # it), DynamicObstacles' termination_fn now also fires on
+    # ball_pickup, exactly like it already does on ball_hit - picking
+    # one up ends the episode the same way touching it always did.
+    PICKUP = 3
+    env = nx.make("Navix-Dynamic-Obstacles-5x5-v0")
+    timestep = env.reset(jax.random.PRNGKey(0))
+    state = timestep.state
+
+    player = state.get_player()
+    assert player.position.tolist() == [1, 1]
+
+    balls = state.get_balls()
+    balls = balls.replace(position=jnp.asarray([[3, 2], [2, 2]]))
+    state = state.replace(entities={**state.entities, Entities.BALL: balls})
+    state = walk_to(state, 2, 1)
+    state = face(state, EAST)
+    timestep = timestep.replace(state=state)
+
+    assert timestep.step_type == 0
+    timestep = env.step(timestep, jnp.asarray(PICKUP))
+
+    assert timestep.state.events.happened((Entities.BALL, EventType.PICKUP)), (
+        "expected a ball_pickup event"
+    )
+    assert timestep.step_type == 2, (
+        "expected termination on picking up a ball, same as walking into one"
+    )
+    assert float(timestep.reward) == 0, "expected zero reward (goal wasn't reached)"
+
+
 def test_door_unlock_and_ball_pickup_are_directly_testable():
-    # record_door_unlock and record_ball_pickup are the two record_*
-    # methods no current navix action ever calls: actions.open only ever
-    # calls record_door_opening (even when it unlocks a locked door in
-    # the same step - see test_wall_key_door_goal_sequence above, where
+    # record_door_unlock is the one record_* method no current navix
+    # action ever calls: actions.open only ever calls
+    # record_door_opening (even when it unlocks a locked door in the
+    # same step - see test_wall_key_door_goal_sequence above, where
     # DOOR/UNLOCK stays False despite the door being both unlocked and
-    # opened), and actions.pickup only ever handles Key, never Ball
-    # (confirmed via grep across navix/ before writing this test - no
-    # call site for either exists outside states.py itself). That's a
-    # pre-existing gap unrelated to issue #139 (not something this PR
-    # changes), but merge_event's own correctness for these two slots
-    # is still worth verifying directly, the same way the reachable
-    # record_* methods are verified above through real gameplay.
+    # opened). record_ball_pickup *is* reachable through real gameplay
+    # as of PR #191 (actions.pickup handles Ball, not just Key/Box - see
+    # test_ball_pickup_terminates_dynamic_obstacles below for that path
+    # exercised directly), but merge_event's own correctness for both
+    # slots is still worth verifying directly here too, the same way
+    # the other record_* methods are verified above through real
+    # gameplay.
     env = nx.make("Navix-DoorKey-5x5-v0")
     timestep = env.reset(jax.random.PRNGKey(0))
     state = timestep.state

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,210 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`Fetch` (issue #177): structural checks against the live reset
+state, plus real `env.step()` gameplay covering both picking up the
+right object (reward, terminate) and the wrong one (no reward, still
+terminates - verified against MiniGrid's actual `FetchEnv.step`, see
+navix/environments/fetch.py's module docstring)."""
+
+from __future__ import annotations
+
+from collections import deque
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import navix as nx
+from navix.entities import Entities
+
+
+EAST, SOUTH, WEST, NORTH = 0, 1, 2, 3
+ROTATE_CW, FORWARD, PICKUP = 1, 2, 3
+
+N_SEEDS = 20
+# BFS-navigation gameplay tests are slow on eager (uncompiled) CPU JAX -
+# same finding as test_unlock.py's GAMEPLAY_SEEDS.
+GAMEPLAY_SEEDS = 2
+
+
+def blocked_mask(state) -> np.ndarray:
+    blocked = np.asarray(state.grid) == -1
+    for entity_enum, entity in state.entities.items():
+        if entity_enum == Entities.PLAYER:
+            continue
+        positions = np.asarray(entity.position)
+        if positions.ndim == 1:
+            positions = positions[None]
+        for row, col in positions:
+            blocked[row, col] = True
+    return blocked
+
+
+def bfs_path(blocked: np.ndarray, start: tuple, goal: tuple):
+    height, width = blocked.shape
+    prev = {start: None}
+    queue = deque([start])
+    while queue:
+        current = queue.popleft()
+        if current == goal:
+            break
+        row, col = current
+        for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+            nxt = (row + dr, col + dc)
+            if (
+                0 <= nxt[0] < height
+                and 0 <= nxt[1] < width
+                and not blocked[nxt]
+                and nxt not in prev
+            ):
+                prev[nxt] = current
+                queue.append(nxt)
+    if goal not in prev:
+        return None
+    path = [goal]
+    while path[-1] != start:
+        path.append(prev[path[-1]])
+    path.reverse()
+    return path
+
+
+def direction_between(a: tuple, b: tuple) -> int:
+    dr, dc = b[0] - a[0], b[1] - a[1]
+    if dr == 1:
+        return SOUTH
+    if dr == -1:
+        return NORTH
+    if dc == 1:
+        return EAST
+    if dc == -1:
+        return WEST
+    raise AssertionError(f"{a} -> {b} is not a single orthogonal step")
+
+
+def face(env, timestep, direction: int):
+    for _ in range(4):
+        if int(timestep.state.get_player().direction) == direction:
+            return timestep
+        timestep = env.step(timestep, jnp.asarray(ROTATE_CW))
+    raise AssertionError(f"could not face direction {direction}")
+
+
+def walk_path(env, timestep, path):
+    for a, b in zip(path[:-1], path[1:]):
+        timestep = face(env, timestep, direction_between(a, b))
+        timestep = env.step(timestep, jnp.asarray(FORWARD))
+    return timestep
+
+
+def navigate_adjacent_and_face(env, timestep, target_row: int, target_col: int):
+    """Paths the player to an orthogonal neighbour of `(target_row,
+    target_col)` and faces it."""
+    state = timestep.state
+    blocked = blocked_mask(state)
+    start = (int(state.get_player().position[0]), int(state.get_player().position[1]))
+    target = (target_row, target_col)
+
+    for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+        candidate = (target[0] + dr, target[1] + dc)
+        if not (0 <= candidate[0] < blocked.shape[0] and 0 <= candidate[1] < blocked.shape[1]):
+            continue
+        if blocked[candidate]:
+            continue
+        if candidate == start:
+            return face(env, timestep, direction_between(candidate, target))
+        path = bfs_path(blocked, start, candidate)
+        if path is not None:
+            timestep = walk_path(env, timestep, path)
+            return face(env, timestep, direction_between(candidate, target))
+    raise AssertionError(f"no reachable approach cell for target {target}")
+
+
+def all_object_positions(state):
+    positions = []
+    if Entities.KEY in state.entities:
+        positions.append(state.get_keys().position)
+    if Entities.BALL in state.entities:
+        positions.append(state.get_balls().position)
+    return jnp.concatenate(positions, axis=0)
+
+
+def test_fetch_structure():
+    for env_id in ("Navix-Fetch-5x5-N2-v0", "Navix-Fetch-6x6-N2-v0", "Navix-Fetch-8x8-N3-v0"):
+        env = nx.make(env_id)
+        for seed in range(N_SEEDS):
+            state = env.reset(jax.random.PRNGKey(seed)).state
+            assert state.mission is not None, f"{env_id} seed={seed}: expected a mission"
+            positions = all_object_positions(state)
+            matches = jnp.all(positions == state.mission.position, axis=-1)
+            assert int(jnp.sum(matches)) == 1, (
+                f"{env_id} seed={seed}: mission.position must match exactly one object"
+            )
+
+
+def test_fetch_correct_pickup_succeeds():
+    # one representative size - see test_go_to_object.py's equivalent
+    # comment for why.
+    for env_id in ("Navix-Fetch-6x6-N2-v0",):
+        for seed in range(GAMEPLAY_SEEDS):
+            env = nx.make(env_id)
+            timestep = env.reset(jax.random.PRNGKey(seed))
+            target_row, target_col = (
+                int(timestep.state.mission.position[0]),
+                int(timestep.state.mission.position[1]),
+            )
+            timestep = navigate_adjacent_and_face(env, timestep, target_row, target_col)
+            assert timestep.step_type == 0, f"{env_id} seed={seed}: episode ended before pickup"
+
+            timestep = env.step(timestep, jnp.asarray(PICKUP))
+            assert timestep.step_type == 2, (
+                f"{env_id} seed={seed}: expected termination on picking up the target"
+            )
+            assert float(timestep.reward) > 0, f"{env_id} seed={seed}: expected positive reward"
+
+
+def test_fetch_wrong_pickup_ends_episode_with_no_reward():
+    env = nx.make("Navix-Fetch-6x6-N2-v0")
+    for seed in range(GAMEPLAY_SEEDS):
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        state = timestep.state
+        positions = all_object_positions(state)
+        is_target = jnp.all(positions == state.mission.position, axis=-1)
+        wrong_idx = int(jnp.argmin(is_target.astype(jnp.int32)))
+        assert not bool(is_target[wrong_idx]), f"seed={seed}: expected a non-target object to exist"
+        wrong_row, wrong_col = int(positions[wrong_idx, 0]), int(positions[wrong_idx, 1])
+
+        timestep = navigate_adjacent_and_face(env, timestep, wrong_row, wrong_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert timestep.step_type == 2, (
+            f"seed={seed}: expected termination on picking up the wrong object"
+        )
+        assert float(timestep.reward) == 0, f"seed={seed}: expected zero reward"
+
+
+def test_fetch_jit_vmap_compatible():
+    for env_id in ("Navix-Fetch-5x5-N2-v0", "Navix-Fetch-6x6-N2-v0", "Navix-Fetch-8x8-N3-v0"):
+        env = nx.make(env_id)
+        keys = jax.random.split(jax.random.PRNGKey(0), 4)
+        reset = jax.jit(env.reset)
+        step = jax.jit(env.step)
+        timestep = jax.vmap(reset)(keys)
+        for action in range(len(nx.actions.DEFAULT_ACTION_SET)):
+            timestep = jax.vmap(step, in_axes=(0, None))(timestep, jnp.asarray(action))
+        jax.block_until_ready(timestep)

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -150,9 +150,9 @@ def test_fetch_structure():
         env = nx.make(env_id)
         for seed in range(N_SEEDS):
             state = env.reset(jax.random.PRNGKey(seed)).state
-            assert state.mission is not None, f"{env_id} seed={seed}: expected a mission"
+            assert len(state.mission) > 0, f"{env_id} seed={seed}: expected a mission"
             positions = all_object_positions(state)
-            matches = jnp.all(positions == state.mission.position, axis=-1)
+            matches = jnp.all(positions == state.mission[0].position, axis=-1)
             assert int(jnp.sum(matches)) == 1, (
                 f"{env_id} seed={seed}: mission.position must match exactly one object"
             )
@@ -166,8 +166,8 @@ def test_fetch_correct_pickup_succeeds():
             env = nx.make(env_id)
             timestep = env.reset(jax.random.PRNGKey(seed))
             target_row, target_col = (
-                int(timestep.state.mission.position[0]),
-                int(timestep.state.mission.position[1]),
+                int(timestep.state.mission[0].position[0]),
+                int(timestep.state.mission[0].position[1]),
             )
             timestep = navigate_adjacent_and_face(env, timestep, target_row, target_col)
             assert timestep.step_type == 0, f"{env_id} seed={seed}: episode ended before pickup"
@@ -185,7 +185,7 @@ def test_fetch_wrong_pickup_ends_episode_with_no_reward():
         timestep = env.reset(jax.random.PRNGKey(seed))
         state = timestep.state
         positions = all_object_positions(state)
-        is_target = jnp.all(positions == state.mission.position, axis=-1)
+        is_target = jnp.all(positions == state.mission[0].position, axis=-1)
         wrong_idx = int(jnp.argmin(is_target.astype(jnp.int32)))
         assert not bool(is_target[wrong_idx]), f"seed={seed}: expected a non-target object to exist"
         wrong_row, wrong_col = int(positions[wrong_idx, 0]), int(positions[wrong_idx, 1])

--- a/tests/test_go_to_object.py
+++ b/tests/test_go_to_object.py
@@ -131,7 +131,7 @@ def navigate_adjacent_and_face(env, timestep):
     target and faces it - picks whichever reachable neighbour BFS finds
     first."""
     state = timestep.state
-    target = (int(state.mission.position[0]), int(state.mission.position[1]))
+    target = (int(state.mission[0].position[0]), int(state.mission[0].position[1]))
     blocked = blocked_mask(state)
     start = (int(state.get_player().position[0]), int(state.get_player().position[1]))
 
@@ -158,7 +158,7 @@ def test_go_to_object_structure():
         env = nx.make(env_id)
         for seed in range(N_SEEDS):
             state = env.reset(jax.random.PRNGKey(seed)).state
-            assert state.mission is not None, f"{env_id} seed={seed}: expected a mission"
+            assert len(state.mission) > 0, f"{env_id} seed={seed}: expected a mission"
 
             positions = jnp.concatenate(
                 [
@@ -173,7 +173,7 @@ def test_go_to_object_structure():
                 f"{env_id} seed={seed}: expected {env.n_objects} real objects total"
             )
 
-            matches = jnp.all(positions == state.mission.position, axis=-1) & on_grid
+            matches = jnp.all(positions == state.mission[0].position, axis=-1) & on_grid
             assert int(jnp.sum(matches)) == 1, (
                 f"{env_id} seed={seed}: mission.position must match exactly one real object"
             )

--- a/tests/test_go_to_object.py
+++ b/tests/test_go_to_object.py
@@ -38,6 +38,7 @@ import jax.numpy as jnp
 import numpy as np
 
 import navix as nx
+from navix.components import DISCARD_PILE_COORDS
 from navix.entities import Entities
 
 
@@ -150,23 +151,31 @@ def navigate_adjacent_and_face(env, timestep):
 
 
 def test_go_to_object_structure():
+    # Key/Ball/Box each always have n_objects slots (see module
+    # docstring's padding-sentinel design) - only the ones not pushed to
+    # DISCARD_PILE_COORDS are "real" objects for this episode.
     for env_id in ("Navix-GoToObject-6x6-N2-v0", "Navix-GoToObject-8x8-N2-v0"):
         env = nx.make(env_id)
         for seed in range(N_SEEDS):
             state = env.reset(jax.random.PRNGKey(seed)).state
             assert state.mission is not None, f"{env_id} seed={seed}: expected a mission"
 
-            positions = []
-            if Entities.KEY in state.entities:
-                positions.append(state.get_keys().position)
-            if Entities.BALL in state.entities:
-                positions.append(state.get_balls().position)
-            positions = jnp.concatenate(positions, axis=0)
-            assert positions.shape[0] == 2, f"{env_id} seed={seed}: expected 2 objects total"
+            positions = jnp.concatenate(
+                [
+                    state.get_keys().position,
+                    state.get_balls().position,
+                    state.get_boxes().position,
+                ],
+                axis=0,
+            )
+            on_grid = jnp.any(positions != DISCARD_PILE_COORDS, axis=-1)
+            assert int(jnp.sum(on_grid)) == env.n_objects, (
+                f"{env_id} seed={seed}: expected {env.n_objects} real objects total"
+            )
 
-            matches = jnp.all(positions == state.mission.position, axis=-1)
+            matches = jnp.all(positions == state.mission.position, axis=-1) & on_grid
             assert int(jnp.sum(matches)) == 1, (
-                f"{env_id} seed={seed}: mission.position must match exactly one object"
+                f"{env_id} seed={seed}: mission.position must match exactly one real object"
             )
 
 

--- a/tests/test_go_to_object.py
+++ b/tests/test_go_to_object.py
@@ -188,6 +188,27 @@ def test_go_to_object_success_on_done():
             assert float(timestep.reward) > 0, f"{env_id} seed={seed}: expected positive reward"
 
 
+def test_go_to_object_success_without_facing():
+    # PR #191 review: on_target_done used to also require facing the
+    # target, which real MiniGrid's GoToObjectEnv.step doesn't check at
+    # all - pure orthogonal adjacency is enough. Face away from the
+    # target (still adjacent) before calling done, specifically to
+    # exercise that facing is no longer required.
+    env = nx.make("Navix-GoToObject-6x6-N2-v0")
+    for seed in range(GAMEPLAY_SEEDS):
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        timestep = navigate_adjacent_and_face(env, timestep)
+
+        away_direction = (int(timestep.state.get_player().direction) + 2) % 4
+        timestep = face(env, timestep, away_direction)
+
+        timestep = env.step(timestep, jnp.asarray(DONE))
+        assert timestep.step_type == 2, (
+            f"seed={seed}: expected termination on done while adjacent but not facing the target"
+        )
+        assert float(timestep.reward) > 0, f"seed={seed}: expected positive reward"
+
+
 def test_go_to_object_toggle_fails_immediately():
     env = nx.make("Navix-GoToObject-6x6-N2-v0")
     for seed in range(N_SEEDS):

--- a/tests/test_go_to_object.py
+++ b/tests/test_go_to_object.py
@@ -1,0 +1,209 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`GoToObject` (issue #173): structural checks against the live reset
+state, plus real `env.step()` gameplay covering both the success path
+(`done` while facing the target) and the failure path (`toggle` at
+all).
+
+Navigation here uses real BFS pathfinding over the room (all state
+values are already concrete Python ints by the time a test reads them,
+unlike navix.actions itself, which must stay jit/vmap-compatible and
+so can't use this) rather than the row-then-column heuristics
+`test_unlock.py` needed - simpler and robust to any obstacle layout
+without needing to special-case specific seeds."""
+
+from __future__ import annotations
+
+from collections import deque
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import navix as nx
+from navix.entities import Entities
+
+
+EAST, SOUTH, WEST, NORTH = 0, 1, 2, 3
+ROTATE_CW, TOGGLE, DONE = 1, 5, 6
+
+N_SEEDS = 20
+# BFS-navigation gameplay tests are slow on eager (uncompiled) CPU JAX -
+# same finding as test_unlock.py's GAMEPLAY_SEEDS.
+GAMEPLAY_SEEDS = 2
+
+
+def blocked_mask(state) -> np.ndarray:
+    """A `(height, width)` boolean array of cells the player can't step
+    onto - the wall grid, plus every non-walkable entity's own cell
+    (Key/Ball, both non-walkable; irrelevant for the player itself)."""
+    blocked = np.asarray(state.grid) == -1
+    for entity_enum, entity in state.entities.items():
+        if entity_enum == Entities.PLAYER:
+            continue
+        positions = np.asarray(entity.position)
+        if positions.ndim == 1:
+            positions = positions[None]
+        for row, col in positions:
+            blocked[row, col] = True
+    return blocked
+
+
+def bfs_path(blocked: np.ndarray, start: tuple, goal: tuple):
+    """Shortest 4-connected path from `start` to `goal` avoiding
+    `blocked` cells, as a list of `(row, col)` from `start` to `goal`
+    inclusive - `None` if unreachable."""
+    height, width = blocked.shape
+    prev = {start: None}
+    queue = deque([start])
+    while queue:
+        current = queue.popleft()
+        if current == goal:
+            break
+        row, col = current
+        for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+            nxt = (row + dr, col + dc)
+            if (
+                0 <= nxt[0] < height
+                and 0 <= nxt[1] < width
+                and not blocked[nxt]
+                and nxt not in prev
+            ):
+                prev[nxt] = current
+                queue.append(nxt)
+    if goal not in prev:
+        return None
+    path = [goal]
+    while path[-1] != start:
+        path.append(prev[path[-1]])
+    path.reverse()
+    return path
+
+
+def direction_between(a: tuple, b: tuple) -> int:
+    dr, dc = b[0] - a[0], b[1] - a[1]
+    if dr == 1:
+        return SOUTH
+    if dr == -1:
+        return NORTH
+    if dc == 1:
+        return EAST
+    if dc == -1:
+        return WEST
+    raise AssertionError(f"{a} -> {b} is not a single orthogonal step")
+
+
+def face(env, timestep, direction: int):
+    for _ in range(4):
+        if int(timestep.state.get_player().direction) == direction:
+            return timestep
+        timestep = env.step(timestep, jnp.asarray(ROTATE_CW))
+    raise AssertionError(f"could not face direction {direction}")
+
+
+def walk_path(env, timestep, path):
+    for a, b in zip(path[:-1], path[1:]):
+        timestep = face(env, timestep, direction_between(a, b))
+        timestep = env.step(timestep, jnp.asarray(2))  # forward
+    return timestep
+
+
+def navigate_adjacent_and_face(env, timestep):
+    """Paths the player to an orthogonal neighbour of `state.mission`'s
+    target and faces it - picks whichever reachable neighbour BFS finds
+    first."""
+    state = timestep.state
+    target = (int(state.mission.position[0]), int(state.mission.position[1]))
+    blocked = blocked_mask(state)
+    start = (int(state.get_player().position[0]), int(state.get_player().position[1]))
+
+    for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+        candidate = (target[0] + dr, target[1] + dc)
+        if not (0 <= candidate[0] < blocked.shape[0] and 0 <= candidate[1] < blocked.shape[1]):
+            continue
+        if blocked[candidate]:
+            continue
+        if candidate == start:
+            return face(env, timestep, direction_between(candidate, target))
+        path = bfs_path(blocked, start, candidate)
+        if path is not None:
+            timestep = walk_path(env, timestep, path)
+            return face(env, timestep, direction_between(candidate, target))
+    raise AssertionError(f"no reachable approach cell for target {target}")
+
+
+def test_go_to_object_structure():
+    for env_id in ("Navix-GoToObject-6x6-N2-v0", "Navix-GoToObject-8x8-N2-v0"):
+        env = nx.make(env_id)
+        for seed in range(N_SEEDS):
+            state = env.reset(jax.random.PRNGKey(seed)).state
+            assert state.mission is not None, f"{env_id} seed={seed}: expected a mission"
+
+            positions = []
+            if Entities.KEY in state.entities:
+                positions.append(state.get_keys().position)
+            if Entities.BALL in state.entities:
+                positions.append(state.get_balls().position)
+            positions = jnp.concatenate(positions, axis=0)
+            assert positions.shape[0] == 2, f"{env_id} seed={seed}: expected 2 objects total"
+
+            matches = jnp.all(positions == state.mission.position, axis=-1)
+            assert int(jnp.sum(matches)) == 1, (
+                f"{env_id} seed={seed}: mission.position must match exactly one object"
+            )
+
+
+def test_go_to_object_success_on_done():
+    # one representative size - structural/jit_vmap tests already cover
+    # every registered size cheaply; the *logic* under test here doesn't
+    # vary by room size.
+    for env_id in ("Navix-GoToObject-6x6-N2-v0",):
+        for seed in range(GAMEPLAY_SEEDS):
+            env = nx.make(env_id)
+            timestep = env.reset(jax.random.PRNGKey(seed))
+            timestep = navigate_adjacent_and_face(env, timestep)
+            assert timestep.step_type == 0, f"{env_id} seed={seed}: episode ended before done"
+
+            timestep = env.step(timestep, jnp.asarray(DONE))
+            assert timestep.step_type == 2, (
+                f"{env_id} seed={seed}: expected termination on done while facing the target"
+            )
+            assert float(timestep.reward) > 0, f"{env_id} seed={seed}: expected positive reward"
+
+
+def test_go_to_object_toggle_fails_immediately():
+    env = nx.make("Navix-GoToObject-6x6-N2-v0")
+    for seed in range(N_SEEDS):
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        timestep = env.step(timestep, jnp.asarray(TOGGLE))
+        assert timestep.step_type == 2, f"seed={seed}: expected termination on any toggle"
+        assert float(timestep.reward) == 0, f"seed={seed}: expected zero reward"
+
+
+def test_go_to_object_jit_vmap_compatible():
+    for env_id in ("Navix-GoToObject-6x6-N2-v0", "Navix-GoToObject-8x8-N2-v0"):
+        env = nx.make(env_id)
+        keys = jax.random.split(jax.random.PRNGKey(0), 4)
+        reset = jax.jit(env.reset)
+        step = jax.jit(env.step)
+        timestep = jax.vmap(reset)(keys)
+        for action in range(len(nx.actions.DEFAULT_ACTION_SET)):
+            timestep = jax.vmap(step, in_axes=(0, None))(timestep, jnp.asarray(action))
+        jax.block_until_ready(timestep)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -72,6 +72,7 @@ def test_91():
         position=jnp.asarray((1, 2)),
         colour=PALETTE.BLUE,
         probability=jnp.asarray(0.0),
+        id=jnp.asarray(1),
     )
     cache = RenderingCache.init(grid)
     state = State(
@@ -120,6 +121,7 @@ def test_139():
         position=jnp.asarray([[1, 2], [3, 2]]),
         colour=jnp.asarray([PALETTE.BLUE, PALETTE.RED]),
         probability=jnp.asarray([0.0, 0.0]),
+        id=jnp.asarray([1, 2]),
     )
     found_both = False
     for seed in range(200):
@@ -146,6 +148,7 @@ def test_139():
         position=jnp.asarray([[2, 3], [1, 1]]),  # ball 0 directly in front
         colour=jnp.asarray([PALETTE.BLUE, PALETTE.RED]),
         probability=jnp.asarray([0.0, 0.0]),
+        id=jnp.asarray([1, 2]),
     )
     state2 = State(
         key=jax.random.PRNGKey(0),

--- a/tests/test_put_near.py
+++ b/tests/test_put_near.py
@@ -18,7 +18,7 @@
 # under the License.
 
 """`PutNear` (issue #178): structural checks against the live reset
-state (`mission`/`mission2` distinct, each matching a real object),
+state (`mission[0]`/`mission[1]` distinct, each matching a real object),
 plus real `env.step()` gameplay covering picking up the wrong object
 (immediate failure), and picking up the right one and dropping it near
 - vs. not near - the target."""
@@ -185,15 +185,15 @@ def test_put_near_structure():
         env = nx.make(env_id)
         for seed in range(N_SEEDS):
             state = env.reset(jax.random.PRNGKey(seed)).state
-            assert state.mission is not None and state.mission2 is not None, (
+            assert len(state.mission) == 2, (
                 f"{env_id} seed={seed}: expected both mission targets"
             )
-            assert not jnp.array_equal(state.mission.position, state.mission2.position), (
+            assert not jnp.array_equal(state.mission[0].position, state.mission[1].position), (
                 f"{env_id} seed={seed}: move and target objects must be distinct"
             )
             positions = all_object_positions(state)
-            move_matches = jnp.all(positions == state.mission.position, axis=-1)
-            target_matches = jnp.all(positions == state.mission2.position, axis=-1)
+            move_matches = jnp.all(positions == state.mission[0].position, axis=-1)
+            target_matches = jnp.all(positions == state.mission[1].position, axis=-1)
             assert int(jnp.sum(move_matches)) == 1
             assert int(jnp.sum(target_matches)) == 1
 
@@ -213,7 +213,7 @@ def test_put_near_never_spawns_already_solved():
         too_close = 0
         for seed in range(n_stat_seeds):
             state = env.reset(jax.random.PRNGKey(seed)).state
-            move, target = state.mission.position, state.mission2.position
+            move, target = state.mission[0].position, state.mission[1].position
             chebyshev = jnp.maximum(jnp.abs(move[0] - target[0]), jnp.abs(move[1] - target[1]))
             if int(chebyshev) <= 1:
                 too_close += 1
@@ -229,7 +229,7 @@ def test_put_near_wrong_pickup_fails_immediately():
         timestep = env.reset(jax.random.PRNGKey(seed))
         state = timestep.state
         positions = all_object_positions(state)
-        is_move = jnp.all(positions == state.mission.position, axis=-1)
+        is_move = jnp.all(positions == state.mission[0].position, axis=-1)
         wrong_idx = int(jnp.argmin(is_move.astype(jnp.int32)))
         assert not bool(is_move[wrong_idx]), f"seed={seed}: expected a non-move object to exist"
         wrong_row, wrong_col = int(positions[wrong_idx, 0]), int(positions[wrong_idx, 1])
@@ -245,8 +245,8 @@ def test_put_near_success():
         env = nx.make("Navix-PutNear-6x6-N2-v0")
         timestep = env.reset(jax.random.PRNGKey(seed))
         state = timestep.state
-        move_row, move_col = int(state.mission.position[0]), int(state.mission.position[1])
-        target_row, target_col = int(state.mission2.position[0]), int(state.mission2.position[1])
+        move_row, move_col = int(state.mission[0].position[0]), int(state.mission[0].position[1])
+        target_row, target_col = int(state.mission[1].position[0]), int(state.mission[1].position[1])
 
         timestep = navigate_adjacent_and_face(env, timestep, move_row, move_col)
         timestep = env.step(timestep, jnp.asarray(PICKUP))
@@ -264,14 +264,14 @@ def test_put_near_drop_far_from_target_gives_no_reward():
     for seed in range(GAMEPLAY_SEEDS):
         timestep = env.reset(jax.random.PRNGKey(seed))
         state = timestep.state
-        move_row, move_col = int(state.mission.position[0]), int(state.mission.position[1])
+        move_row, move_col = int(state.mission[0].position[0]), int(state.mission[0].position[1])
 
         timestep = navigate_adjacent_and_face(env, timestep, move_row, move_col)
         timestep = env.step(timestep, jnp.asarray(PICKUP))
         assert timestep.step_type == 0
 
         # drop right where we stand (facing away from the move object's
-        # old cell), almost certainly not near mission2's target. The
+        # old cell), almost certainly not near mission[1]'s target. The
         # drop itself lands on translate(player.position, player.
         # direction) - one cell *in front of* the player, not the
         # player's own cell (PR #191 review: computing distance from
@@ -279,7 +279,7 @@ def test_put_near_drop_far_from_target_gives_no_reward():
         # bug - a layout with Chebyshev(player, target) == 2 but
         # Chebyshev(front, target) == 1 would wrongly expect reward 0).
         state = timestep.state
-        target_row, target_col = int(state.mission2.position[0]), int(state.mission2.position[1])
+        target_row, target_col = int(state.mission[1].position[0]), int(state.mission[1].position[1])
         player = state.get_player()
         drop_pos = nx.grid.translate(player.position, player.direction)
         drop_row, drop_col = int(drop_pos[0]), int(drop_pos[1])

--- a/tests/test_put_near.py
+++ b/tests/test_put_near.py
@@ -192,6 +192,31 @@ def test_put_near_structure():
             assert int(jnp.sum(target_matches)) == 1
 
 
+def test_put_near_never_spawns_already_solved():
+    # PR #191 review "New risks": random_distinct_positions alone lets
+    # the move/target pair spawn already within "near" (Chebyshev <= 1)
+    # of each other, trivially solvable with no navigation - quantified
+    # directly at 36% of seeds for the 6x6 size before this was fixed.
+    # A larger seed count than the other structural tests specifically
+    # because this is a statistical claim ("never"), not a per-seed
+    # structural invariant - passing on N_SEEDS wouldn't rule out a
+    # residual few-percent chance the earlier bug allowed.
+    n_stat_seeds = 500
+    for env_id in ("Navix-PutNear-6x6-N2-v0", "Navix-PutNear-8x8-N3-v0"):
+        env = nx.make(env_id)
+        too_close = 0
+        for seed in range(n_stat_seeds):
+            state = env.reset(jax.random.PRNGKey(seed)).state
+            move, target = state.mission.position, state.mission2.position
+            chebyshev = jnp.maximum(jnp.abs(move[0] - target[0]), jnp.abs(move[1] - target[1]))
+            if int(chebyshev) <= 1:
+                too_close += 1
+        assert too_close == 0, (
+            f"{env_id}: {too_close}/{n_stat_seeds} seeds spawned with the move "
+            f"object already within Chebyshev-1 of the target (already \"solved\")"
+        )
+
+
 def test_put_near_wrong_pickup_fails_immediately():
     env = nx.make("Navix-PutNear-6x6-N2-v0")
     for seed in range(GAMEPLAY_SEEDS):

--- a/tests/test_put_near.py
+++ b/tests/test_put_near.py
@@ -32,6 +32,7 @@ import jax.numpy as jnp
 import numpy as np
 
 import navix as nx
+from navix.components import DISCARD_PILE_COORDS
 from navix.entities import Entities
 
 
@@ -166,12 +167,17 @@ def navigate_to_drop_near(env, timestep, target_row: int, target_col: int):
 
 
 def all_object_positions(state):
-    positions = []
-    if Entities.KEY in state.entities:
-        positions.append(state.get_keys().position)
-    if Entities.BALL in state.entities:
-        positions.append(state.get_balls().position)
-    return jnp.concatenate(positions, axis=0)
+    # Key/Ball/Box each always have n_objects slots (see
+    # navix/environments/go_to_object.py's module docstring for the
+    # padding-sentinel design put_near.py shares) - filtered down to
+    # just the n_objects real ones, matching this helper's pre-Box
+    # contract exactly so every caller keeps working unchanged.
+    positions = jnp.concatenate(
+        [state.get_keys().position, state.get_balls().position, state.get_boxes().position],
+        axis=0,
+    )
+    on_grid = jnp.any(positions != DISCARD_PILE_COORDS, axis=-1)
+    return positions[on_grid]
 
 
 def test_put_near_structure():

--- a/tests/test_put_near.py
+++ b/tests/test_put_near.py
@@ -1,0 +1,266 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`PutNear` (issue #178): structural checks against the live reset
+state (`mission`/`mission2` distinct, each matching a real object),
+plus real `env.step()` gameplay covering picking up the wrong object
+(immediate failure), and picking up the right one and dropping it near
+- vs. not near - the target."""
+
+from __future__ import annotations
+
+from collections import deque
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import navix as nx
+from navix.entities import Entities
+
+
+EAST, SOUTH, WEST, NORTH = 0, 1, 2, 3
+ROTATE_CW, FORWARD, PICKUP, DROP = 1, 2, 3, 4
+
+N_SEEDS = 20
+# BFS-navigation gameplay tests are slow on eager (uncompiled) CPU JAX -
+# same finding as test_unlock.py's GAMEPLAY_SEEDS.
+GAMEPLAY_SEEDS = 2
+
+
+def blocked_mask(state) -> np.ndarray:
+    blocked = np.asarray(state.grid) == -1
+    for entity_enum, entity in state.entities.items():
+        if entity_enum == Entities.PLAYER:
+            continue
+        positions = np.asarray(entity.position)
+        if positions.ndim == 1:
+            positions = positions[None]
+        for row, col in positions:
+            blocked[row, col] = True
+    return blocked
+
+
+def bfs_path(blocked: np.ndarray, start: tuple, goal: tuple):
+    height, width = blocked.shape
+    prev = {start: None}
+    queue = deque([start])
+    while queue:
+        current = queue.popleft()
+        if current == goal:
+            break
+        row, col = current
+        for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+            nxt = (row + dr, col + dc)
+            if (
+                0 <= nxt[0] < height
+                and 0 <= nxt[1] < width
+                and not blocked[nxt]
+                and nxt not in prev
+            ):
+                prev[nxt] = current
+                queue.append(nxt)
+    if goal not in prev:
+        return None
+    path = [goal]
+    while path[-1] != start:
+        path.append(prev[path[-1]])
+    path.reverse()
+    return path
+
+
+def direction_between(a: tuple, b: tuple) -> int:
+    dr, dc = b[0] - a[0], b[1] - a[1]
+    if dr == 1:
+        return SOUTH
+    if dr == -1:
+        return NORTH
+    if dc == 1:
+        return EAST
+    if dc == -1:
+        return WEST
+    raise AssertionError(f"{a} -> {b} is not a single orthogonal step")
+
+
+def face(env, timestep, direction: int):
+    for _ in range(4):
+        if int(timestep.state.get_player().direction) == direction:
+            return timestep
+        timestep = env.step(timestep, jnp.asarray(ROTATE_CW))
+    raise AssertionError(f"could not face direction {direction}")
+
+
+def walk_path(env, timestep, path):
+    for a, b in zip(path[:-1], path[1:]):
+        timestep = face(env, timestep, direction_between(a, b))
+        timestep = env.step(timestep, jnp.asarray(FORWARD))
+    return timestep
+
+
+def navigate_adjacent_and_face(env, timestep, target_row: int, target_col: int):
+    state = timestep.state
+    blocked = blocked_mask(state)
+    start = (int(state.get_player().position[0]), int(state.get_player().position[1]))
+    target = (target_row, target_col)
+
+    for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+        candidate = (target[0] + dr, target[1] + dc)
+        if not (0 <= candidate[0] < blocked.shape[0] and 0 <= candidate[1] < blocked.shape[1]):
+            continue
+        if blocked[candidate]:
+            continue
+        if candidate == start:
+            return face(env, timestep, direction_between(candidate, target))
+        path = bfs_path(blocked, start, candidate)
+        if path is not None:
+            timestep = walk_path(env, timestep, path)
+            return face(env, timestep, direction_between(candidate, target))
+    raise AssertionError(f"no reachable approach cell for target {target}")
+
+
+def navigate_to_drop_near(env, timestep, target_row: int, target_col: int):
+    """Faces the player towards some empty cell within Chebyshev
+    distance 1 of `(target_row, target_col)` - i.e. wherever `drop`
+    would land the carried object close enough to count."""
+    state = timestep.state
+    blocked = blocked_mask(state)
+    start = (int(state.get_player().position[0]), int(state.get_player().position[1]))
+    height, width = blocked.shape
+
+    drop_candidates = [
+        (target_row + dr, target_col + dc)
+        for dr in (-1, 0, 1)
+        for dc in (-1, 0, 1)
+        if not (dr == 0 and dc == 0)
+    ]
+    for drop in drop_candidates:
+        if not (0 <= drop[0] < height and 0 <= drop[1] < width) or blocked[drop]:
+            continue
+        for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+            approach = (drop[0] + dr, drop[1] + dc)
+            if not (0 <= approach[0] < height and 0 <= approach[1] < width) or blocked[approach]:
+                continue
+            if approach == start:
+                return face(env, timestep, direction_between(approach, drop))
+            path = bfs_path(blocked, start, approach)
+            if path is not None:
+                timestep = walk_path(env, timestep, path)
+                return face(env, timestep, direction_between(approach, drop))
+    raise AssertionError(f"no reachable drop cell near target {(target_row, target_col)}")
+
+
+def all_object_positions(state):
+    positions = []
+    if Entities.KEY in state.entities:
+        positions.append(state.get_keys().position)
+    if Entities.BALL in state.entities:
+        positions.append(state.get_balls().position)
+    return jnp.concatenate(positions, axis=0)
+
+
+def test_put_near_structure():
+    for env_id in ("Navix-PutNear-6x6-N2-v0", "Navix-PutNear-8x8-N3-v0"):
+        env = nx.make(env_id)
+        for seed in range(N_SEEDS):
+            state = env.reset(jax.random.PRNGKey(seed)).state
+            assert state.mission is not None and state.mission2 is not None, (
+                f"{env_id} seed={seed}: expected both mission targets"
+            )
+            assert not jnp.array_equal(state.mission.position, state.mission2.position), (
+                f"{env_id} seed={seed}: move and target objects must be distinct"
+            )
+            positions = all_object_positions(state)
+            move_matches = jnp.all(positions == state.mission.position, axis=-1)
+            target_matches = jnp.all(positions == state.mission2.position, axis=-1)
+            assert int(jnp.sum(move_matches)) == 1
+            assert int(jnp.sum(target_matches)) == 1
+
+
+def test_put_near_wrong_pickup_fails_immediately():
+    env = nx.make("Navix-PutNear-6x6-N2-v0")
+    for seed in range(GAMEPLAY_SEEDS):
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        state = timestep.state
+        positions = all_object_positions(state)
+        is_move = jnp.all(positions == state.mission.position, axis=-1)
+        wrong_idx = int(jnp.argmin(is_move.astype(jnp.int32)))
+        assert not bool(is_move[wrong_idx]), f"seed={seed}: expected a non-move object to exist"
+        wrong_row, wrong_col = int(positions[wrong_idx, 0]), int(positions[wrong_idx, 1])
+
+        timestep = navigate_adjacent_and_face(env, timestep, wrong_row, wrong_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert timestep.step_type == 2, f"seed={seed}: expected termination on wrong pickup"
+        assert float(timestep.reward) == 0, f"seed={seed}: expected zero reward"
+
+
+def test_put_near_success():
+    for seed in range(GAMEPLAY_SEEDS):
+        env = nx.make("Navix-PutNear-6x6-N2-v0")
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        state = timestep.state
+        move_row, move_col = int(state.mission.position[0]), int(state.mission.position[1])
+        target_row, target_col = int(state.mission2.position[0]), int(state.mission2.position[1])
+
+        timestep = navigate_adjacent_and_face(env, timestep, move_row, move_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert timestep.step_type == 0, f"seed={seed}: episode ended on the correct pickup"
+        assert int(timestep.state.get_player().pocket) != -1, f"seed={seed}: item not picked up"
+
+        timestep = navigate_to_drop_near(env, timestep, target_row, target_col)
+        timestep = env.step(timestep, jnp.asarray(DROP))
+        assert timestep.step_type == 2, f"seed={seed}: expected termination on the drop"
+        assert float(timestep.reward) > 0, f"seed={seed}: expected positive reward for dropping near the target"
+
+
+def test_put_near_drop_far_from_target_gives_no_reward():
+    env = nx.make("Navix-PutNear-6x6-N2-v0")
+    for seed in range(GAMEPLAY_SEEDS):
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        state = timestep.state
+        move_row, move_col = int(state.mission.position[0]), int(state.mission.position[1])
+
+        timestep = navigate_adjacent_and_face(env, timestep, move_row, move_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert timestep.step_type == 0
+
+        # drop right where we stand (facing away from the move object's
+        # old cell), almost certainly not near mission2's target
+        state = timestep.state
+        target_row, target_col = int(state.mission2.position[0]), int(state.mission2.position[1])
+        player = state.get_player()
+        drop_row, drop_col = int(player.position[0]), int(player.position[1])
+        far_from_target = max(abs(drop_row - target_row), abs(drop_col - target_col)) > 1
+        if not far_from_target:
+            continue  # rare layouts where the player already ended up near the target
+
+        timestep = env.step(timestep, jnp.asarray(DROP))
+        assert timestep.step_type == 2, f"seed={seed}: expected termination on any genuine drop"
+        assert float(timestep.reward) == 0, f"seed={seed}: expected zero reward, dropped far from target"
+
+
+def test_put_near_jit_vmap_compatible():
+    for env_id in ("Navix-PutNear-6x6-N2-v0", "Navix-PutNear-8x8-N3-v0"):
+        env = nx.make(env_id)
+        keys = jax.random.split(jax.random.PRNGKey(0), 4)
+        reset = jax.jit(env.reset)
+        step = jax.jit(env.step)
+        timestep = jax.vmap(reset)(keys)
+        for action in range(len(nx.actions.DEFAULT_ACTION_SET)):
+            timestep = jax.vmap(step, in_axes=(0, None))(timestep, jnp.asarray(action))
+        jax.block_until_ready(timestep)

--- a/tests/test_put_near.py
+++ b/tests/test_put_near.py
@@ -240,11 +240,18 @@ def test_put_near_drop_far_from_target_gives_no_reward():
         assert timestep.step_type == 0
 
         # drop right where we stand (facing away from the move object's
-        # old cell), almost certainly not near mission2's target
+        # old cell), almost certainly not near mission2's target. The
+        # drop itself lands on translate(player.position, player.
+        # direction) - one cell *in front of* the player, not the
+        # player's own cell (PR #191 review: computing distance from
+        # the player's own position instead was a latent flaky-test
+        # bug - a layout with Chebyshev(player, target) == 2 but
+        # Chebyshev(front, target) == 1 would wrongly expect reward 0).
         state = timestep.state
         target_row, target_col = int(state.mission2.position[0]), int(state.mission2.position[1])
         player = state.get_player()
-        drop_row, drop_col = int(player.position[0]), int(player.position[1])
+        drop_pos = nx.grid.translate(player.position, player.direction)
+        drop_row, drop_col = int(drop_pos[0]), int(drop_pos[1])
         far_from_target = max(abs(drop_row - target_row), abs(drop_col - target_col)) > 1
         if not far_from_target:
             continue  # rare layouts where the player already ended up near the target

--- a/tests/test_red_blue_doors.py
+++ b/tests/test_red_blue_doors.py
@@ -1,0 +1,151 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`RedBlueDoors` (issue #172): structural checks against the live reset
+state, plus real `env.step()` gameplay covering both the success path
+(red before blue) and the failure path (blue first)."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+import navix as nx
+from navix.rendering.registry import PALETTE
+
+
+EAST, SOUTH, WEST, NORTH = 0, 1, 2, 3
+ROTATE_CW, FORWARD, TOGGLE = 1, 2, 5
+
+N_SEEDS = 20
+
+
+def face(env, timestep, direction: int):
+    for _ in range(4):
+        if int(timestep.state.get_player().direction) == direction:
+            return timestep
+        timestep = env.step(timestep, jnp.asarray(ROTATE_CW))
+    raise AssertionError(f"could not face direction {direction}")
+
+
+def walk_to(env, timestep, row: int, col: int):
+    player = timestep.state.get_player()
+    dr = row - int(player.position[0])
+    if dr > 0:
+        timestep = face(env, timestep, SOUTH)
+        for _ in range(dr):
+            timestep = env.step(timestep, jnp.asarray(FORWARD))
+    elif dr < 0:
+        timestep = face(env, timestep, NORTH)
+        for _ in range(-dr):
+            timestep = env.step(timestep, jnp.asarray(FORWARD))
+    player = timestep.state.get_player()
+    dc = col - int(player.position[1])
+    if dc > 0:
+        timestep = face(env, timestep, EAST)
+        for _ in range(dc):
+            timestep = env.step(timestep, jnp.asarray(FORWARD))
+    elif dc < 0:
+        timestep = face(env, timestep, WEST)
+        for _ in range(-dc):
+            timestep = env.step(timestep, jnp.asarray(FORWARD))
+    return timestep
+
+
+def test_red_blue_doors_structure():
+    for env_id in ("Navix-RedBlueDoors-6x6-v0", "Navix-RedBlueDoors-8x8-v0"):
+        env = nx.make(env_id)
+        for seed in range(N_SEEDS):
+            state = env.reset(jax.random.PRNGKey(seed)).state
+            doors = state.get_doors()
+            player = state.get_player()
+
+            assert doors.position.shape[0] == 2, f"{env_id} seed={seed}: expected 2 doors"
+            # fixed construction order: index 0 = red, index 1 = blue -
+            # events.on_ordered_doors_* rely on this.
+            assert int(doors.colour[0]) == int(PALETTE.RED)
+            assert int(doors.colour[1]) == int(PALETTE.BLUE)
+            assert int(doors.position[0, 1]) == int(doors.position[1, 1]), (
+                f"{env_id} seed={seed}: both doors must sit in the same dividing wall"
+            )
+            assert int(doors.position[0, 0]) != int(doors.position[1, 0]), (
+                f"{env_id} seed={seed}: doors must be at distinct rows"
+            )
+            assert not bool(doors.open[0]) and not bool(doors.open[1]), (
+                f"{env_id} seed={seed}: doors should start closed"
+            )
+            assert int(doors.requires[0]) == -1 and int(doors.requires[1]) == -1, (
+                f"{env_id} seed={seed}: doors should start unlocked"
+            )
+            wall_col = int(doors.position[0, 1])
+            assert int(player.position[1]) < wall_col, (
+                f"{env_id} seed={seed}: player must start in the left chamber"
+            )
+
+
+def test_red_blue_doors_success_red_then_blue():
+    for seed in range(N_SEEDS):
+        env = nx.make("Navix-RedBlueDoors-6x6-v0")
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        doors = timestep.state.get_doors()
+        red_row, wall_col = int(doors.position[0, 0]), int(doors.position[0, 1])
+        blue_row = int(doors.position[1, 0])
+
+        # approach each door from the left chamber (one cell west of it)
+        timestep = walk_to(env, timestep, red_row, wall_col - 1)
+        timestep = face(env, timestep, EAST)
+        timestep = env.step(timestep, jnp.asarray(TOGGLE))
+        assert bool(timestep.state.get_doors().open[0]), f"seed={seed}: red door did not open"
+        assert timestep.step_type == 0, f"seed={seed}: episode ended after opening only red"
+
+        timestep = walk_to(env, timestep, blue_row, wall_col - 1)
+        timestep = face(env, timestep, EAST)
+        timestep = env.step(timestep, jnp.asarray(TOGGLE))
+        assert bool(timestep.state.get_doors().open[1]), f"seed={seed}: blue door did not open"
+        assert timestep.step_type == 2, (
+            f"seed={seed}: expected termination once blue opens with red already open"
+        )
+        assert float(timestep.reward) > 0, f"seed={seed}: expected positive reward"
+
+
+def test_red_blue_doors_failure_blue_first():
+    for seed in range(N_SEEDS):
+        env = nx.make("Navix-RedBlueDoors-6x6-v0")
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        doors = timestep.state.get_doors()
+        blue_row, wall_col = int(doors.position[1, 0]), int(doors.position[1, 1])
+
+        timestep = walk_to(env, timestep, blue_row, wall_col - 1)
+        timestep = face(env, timestep, EAST)
+        timestep = env.step(timestep, jnp.asarray(TOGGLE))
+        assert bool(timestep.state.get_doors().open[1]), f"seed={seed}: blue door did not open"
+        assert timestep.step_type == 2, f"seed={seed}: expected termination on opening blue first"
+        assert float(timestep.reward) == 0, f"seed={seed}: expected zero reward for opening blue first"
+
+
+def test_red_blue_doors_jit_vmap_compatible():
+    for env_id in ("Navix-RedBlueDoors-6x6-v0", "Navix-RedBlueDoors-8x8-v0"):
+        env = nx.make(env_id)
+        keys = jax.random.split(jax.random.PRNGKey(0), 4)
+        reset = jax.jit(env.reset)
+        step = jax.jit(env.step)
+        timestep = jax.vmap(reset)(keys)
+        for action in range(len(nx.actions.DEFAULT_ACTION_SET)):
+            timestep = jax.vmap(step, in_axes=(0, None))(timestep, jnp.asarray(action))
+        jax.block_until_ready(timestep)

--- a/tests/test_unlock.py
+++ b/tests/test_unlock.py
@@ -45,8 +45,11 @@ layout has two real obstacles a naive walk can collide with:
 
 from __future__ import annotations
 
+from collections import deque
+
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 import navix as nx
 from navix.components import EMPTY_POCKET_ID
@@ -57,7 +60,7 @@ from navix.states import EventType
 EAST, SOUTH, WEST, NORTH = 0, 1, 2, 3
 
 # navix.actions.DEFAULT_ACTION_SET = (rotate_ccw, rotate_cw, forward, pickup, drop, toggle, done)
-ROTATE_CW, FORWARD, PICKUP, TOGGLE = 1, 2, 3, 5
+ROTATE_CW, FORWARD, PICKUP, DROP, TOGGLE = 1, 2, 3, 4, 5
 
 N_SEEDS = 10
 
@@ -385,3 +388,201 @@ def test_unlock_and_unlockpickup_jit_vmap_compatible():
         for action in range(len(nx.actions.DEFAULT_ACTION_SET)):
             timestep = jax.vmap(step, in_axes=(0, None))(timestep, jnp.asarray(action))
         jax.block_until_ready(timestep)
+
+
+def test_blocked_unlock_pickup_structure():
+    env = nx.make("Navix-BlockedUnlockPickup-v0")
+    for seed in range(N_SEEDS):
+        state = env.reset(jax.random.PRNGKey(seed)).state
+        assert Entities.BALL in state.entities
+        assert Entities.BOX in state.entities
+
+        balls = state.get_balls()
+        doors = state.get_doors()
+        door_row, door_col = int(doors.position[0, 0]), int(doors.position[0, 1])
+        assert int(balls.position[0, 0]) == door_row, "ball must be on the door's row"
+        assert int(balls.position[0, 1]) == door_col - 1, (
+            "ball must be directly in front of the door, on the first room's side"
+        )
+
+        player = state.get_player()
+        keys = state.get_keys()
+        assert not jnp.array_equal(player.position, balls.position[0]), (
+            f"seed={seed}: player overlaps the blocking ball"
+        )
+        assert not jnp.array_equal(keys.position[0], balls.position[0]), (
+            f"seed={seed}: key overlaps the blocking ball"
+        )
+
+
+def bfs_blocked_mask(state) -> np.ndarray:
+    """Like the BFS helpers in test_go_to_object.py/test_fetch.py/
+    test_put_near.py (a `(height, width)` boolean array of cells the
+    player can't step onto) - separate from this file's own `walk_to`/
+    `navigate_adjacent_and_face` heuristics, which were tuned for
+    Unlock/UnlockPickup's exact 2-obstacle (Key, Box) layout and don't
+    know about BlockedUnlockPickup's extra, position-varying `Ball`.
+    Recomputed fresh whenever the door might have opened, since `Door.
+    walkable` depends on its own `open` state, unlike Key/Box/Ball."""
+    blocked = np.asarray(state.grid) == -1
+    for entity_enum, entity in state.entities.items():
+        if entity_enum == Entities.PLAYER:
+            continue
+        walkable = np.asarray(entity.walkable)
+        positions = np.asarray(entity.position)
+        if positions.ndim == 1:
+            positions = positions[None]
+            walkable = walkable.reshape(1)
+        for (row, col), w in zip(positions, walkable):
+            if not w:
+                blocked[row, col] = True
+    return blocked
+
+
+def bfs_path(blocked: np.ndarray, start: tuple, goal: tuple):
+    height, width = blocked.shape
+    prev = {start: None}
+    queue = deque([start])
+    while queue:
+        current = queue.popleft()
+        if current == goal:
+            break
+        row, col = current
+        for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+            nxt = (row + dr, col + dc)
+            if (
+                0 <= nxt[0] < height
+                and 0 <= nxt[1] < width
+                and not blocked[nxt]
+                and nxt not in prev
+            ):
+                prev[nxt] = current
+                queue.append(nxt)
+    if goal not in prev:
+        return None
+    path = [goal]
+    while path[-1] != start:
+        path.append(prev[path[-1]])
+    path.reverse()
+    return path
+
+
+def bfs_direction_between(a: tuple, b: tuple) -> int:
+    dr, dc = b[0] - a[0], b[1] - a[1]
+    if dr == 1:
+        return SOUTH
+    if dr == -1:
+        return NORTH
+    if dc == 1:
+        return EAST
+    if dc == -1:
+        return WEST
+    raise AssertionError(f"{a} -> {b} is not a single orthogonal step")
+
+
+def bfs_walk_path_via_step(env, timestep, path):
+    for a, b in zip(path[:-1], path[1:]):
+        timestep = face_via_step(env, timestep, bfs_direction_between(a, b))
+        timestep = env.step(timestep, jnp.asarray(FORWARD))
+    return timestep
+
+
+def bfs_navigate_adjacent_and_face_via_step(env, timestep, target_row: int, target_col: int):
+    state = timestep.state
+    blocked = bfs_blocked_mask(state)
+    start = (int(state.get_player().position[0]), int(state.get_player().position[1]))
+    target = (target_row, target_col)
+
+    for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+        candidate = (target[0] + dr, target[1] + dc)
+        if not (0 <= candidate[0] < blocked.shape[0] and 0 <= candidate[1] < blocked.shape[1]):
+            continue
+        if blocked[candidate]:
+            continue
+        if candidate == start:
+            return face_via_step(env, timestep, bfs_direction_between(candidate, target))
+        path = bfs_path(blocked, start, candidate)
+        if path is not None:
+            timestep = bfs_walk_path_via_step(env, timestep, path)
+            return face_via_step(env, timestep, bfs_direction_between(candidate, target))
+    raise AssertionError(f"no reachable approach cell for target {target}")
+
+
+def test_blocked_unlock_pickup_gameplay_and_reward_termination():
+    # real env.step() cycle throughout, matching test_unlock_gameplay_
+    # and_reward_termination's convention. Uses the BFS helpers above,
+    # not this file's walk_to/navigate_adjacent_and_face heuristics -
+    # those were tuned for exactly two static obstacles (Key, Box) and
+    # don't know about the extra Ball, which (once dropped somewhere
+    # after clearing it) could sit anywhere and confuse a blind
+    # row-then-column walk (confirmed directly: seed 0 failed this way
+    # with the heuristic navigation).
+    #
+    # Solve order matters: pickup() overwrites whatever's already in
+    # the player's pocket, so the ball must be cleared *and dropped*
+    # (freeing the pocket again) before the key can be picked up -
+    # picking up the key first, then the ball, would silently lose the
+    # key (still at the discard pile, but no longer referenced by
+    # player.pocket).
+    for seed in GAMEPLAY_SEEDS:
+        env = nx.make("Navix-BlockedUnlockPickup-v0")
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        state = timestep.state
+        doors = state.get_doors()
+        door_row, door_col = int(doors.position[0, 0]), int(doors.position[0, 1])
+        keys = state.get_keys()
+        key_row, key_col = int(keys.position[0, 0]), int(keys.position[0, 1])
+        balls = state.get_balls()
+        ball_row, ball_col = int(balls.position[0, 0]), int(balls.position[0, 1])
+        boxes = state.get_boxes()
+        box_row, box_col = int(boxes.position[0, 0]), int(boxes.position[0, 1])
+
+        # clear the blocking ball: pick it up (moves it straight to the
+        # discard pile - the cell is clear immediately)...
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, ball_row, ball_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert int(timestep.state.get_player().pocket) != int(EMPTY_POCKET_ID), (
+            f"seed={seed}: ball not picked up"
+        )
+        # ...then step into the now-vacated cell and drop facing further
+        # into the room (not back at the door's own interaction cell,
+        # which dropping in place would immediately re-block).
+        timestep = env.step(timestep, jnp.asarray(FORWARD))
+        timestep = face_via_step(env, timestep, WEST)
+        timestep = env.step(timestep, jnp.asarray(DROP))
+        assert int(timestep.state.get_player().pocket) == int(EMPTY_POCKET_ID), (
+            f"seed={seed}: pocket not freed after dropping the ball"
+        )
+
+        # now proceed like UnlockPickup: key -> unlock -> cross -> box
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, key_row, key_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert int(timestep.state.get_player().pocket) != int(EMPTY_POCKET_ID), (
+            f"seed={seed}: key not picked up"
+        )
+
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, door_row, door_col)
+        timestep = env.step(timestep, jnp.asarray(TOGGLE))
+        assert bool(timestep.state.get_doors().open[0]), f"seed={seed}: door not opened"
+        assert timestep.step_type == 0, f"seed={seed}: episode ended before picking up the box"
+
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, box_row, box_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert int(timestep.state.get_player().pocket) == int(boxes.id[0]), (
+            f"seed={seed}: box not picked up"
+        )
+        assert timestep.step_type == 2, (
+            f"seed={seed}: expected termination on picking up the box"
+        )
+        assert float(timestep.reward) > 0, f"seed={seed}: expected positive reward"
+
+
+def test_blocked_unlock_pickup_jit_vmap_compatible():
+    env = nx.make("Navix-BlockedUnlockPickup-v0")
+    keys = jax.random.split(jax.random.PRNGKey(0), 4)
+    reset = jax.jit(env.reset)
+    step = jax.jit(env.step)
+    timestep = jax.vmap(reset)(keys)
+    for action in range(len(nx.actions.DEFAULT_ACTION_SET)):
+        timestep = jax.vmap(step, in_axes=(0, None))(timestep, jnp.asarray(action))
+    jax.block_until_ready(timestep)


### PR DESCRIPTION
Closes #172, #173, #177, #178, #181.

## Summary

Five new environment families, all single-room (no `RoomGrid`/#174 needed - `BlockedUnlockPickup` reuses `Unlock`/`UnlockPickup`'s existing `two_equal_rooms_with_door` instead), sharing new infrastructure:

- **`Ball` is now `Pickable`** (gained an `id` field, matching `Key`/`Box`) and wired into `actions.pickup()` - `record_ball_pickup`/its event slot already existed as dead code. `pickup()`'s shared closure now dispatches via the already-generic `state.events.record_pickup(entity, position)` instead of a manual per-type branch.
- **`EventsManager.happened_at(key, position)`**: like `happened()`, but identifies *which* instance fired (needed by Fetch/PutNear to tell a correct pickup from an incorrect one).
- **`State.mission2`**: a second, independently-tracked mission target (only `PutNear` needs two simultaneously - the object to carry vs. the object to drop near).
- **`grid.random_distinct_positions`**: a real bug fix - `random_positions(key, grid, n=n)` samples *with replacement*, so two objects could land on the same cell. Found via actual test failures, not inspection.
- Both this and a second bug (the default `stochastic_transition` unconditionally wanders every `Ball` entity a random step each turn, meant for `DynamicObstacles`) were caught only by running real gameplay on berlin - structural/jit-vmap smoke tests alone missed both.

## Per-environment notes

- **RedBlueDoors** (#172): verified against MiniGrid's actual `RedBlueDoorEnv` source (both doors sit in one dividing wall; order, not position, determines success) - not assumed.
- **GoToObject** (#173) and **Fetch** (#177): both had originally-guessed semantics in their own issue text that turned out wrong once checked against real MiniGrid source (`GoToObject` requires the `done` action, not just proximity, and `toggle` fails immediately; `Fetch`'s wrong-pickup ends the episode, it's not a no-op).
- **PutNear** (#178): the most involved - two independently-tracked targets, wrong-pickup failure, and a Chebyshev-distance drop-near success check, all verified against MiniGrid's actual `PutNearEnv.step`.
- **BlockedUnlockPickup** (#181): lives in `unlock.py` alongside `Unlock`/`UnlockPickup` (not its own file), reusing `two_equal_rooms_with_door` via a new `block_door: bool` parameter.

## Testing

Structural + real `env.step()` gameplay + jit/vmap tests per environment, all verified on berlin (real JAX/GPU execution). Gameplay tests use real BFS pathfinding for test navigation (not the row-then-column heuristics `test_unlock.py`'s existing tests use) - simpler and robust to any obstacle layout. Seed counts and per-test env-id coverage are deliberately trimmed (structural/jit-vmap tests already cover every registered size cheaply; gameplay tests use 2 seeds against one representative size) to keep full-suite CI time reasonable now that this adds five more environment families' worth of tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
