### PR TITLE
ci(test): parallelize pytest with xdist to fix CI OOM

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run unit tests with pytest
         run: |
           wandb offline
-          pytest
+          pytest -n auto
       - name: Run examples
         run: |
           for example in examples/*.py; do

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,2 @@
 minigrid
+pytest-xdist


### PR DESCRIPTION
PR #191's CI run took 20 minutes for 162 tests and OOM'd on the last two (`jax.errors.JaxRuntimeError: Failed to materialize symbols`, with repeated `LLVM compilation error: Cannot allocate memory` right before the failure). JAX/XLA never releases compiled-code memory within a process, so a long single-process `pytest` run accumulates it monotonically for the whole run - the failure landing on the very last two tests in the suite is consistent with that (both passed cleanly in isolation on berlin), not a bug in those tests specifically.

`pytest-xdist` (`-n auto`) splits the suite across worker processes (auto-detects available cores), capping each worker's own cumulative compiled-code footprint to roughly its share of the suite instead of the full total. Bonus: independently cuts total wall-clock time too.

Real uncertainty this doesn't resolve on paper: N workers compiling concurrently could raise peak memory at any single instant, even if each worker's own total is lower - only actually running it will confirm which effect wins. Applying this to PR #191's own branch too, to validate directly against the failure that motivated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
