### PR TITLE
ci: add workflow_dispatch job to regenerate .test_durations on a real runner

### DIFF
--- a/.github/workflows/refresh-test-durations.yml
+++ b/.github/workflows/refresh-test-durations.yml
@@ -1,0 +1,39 @@
+name: Refresh test durations
+
+# Manually-triggered: regenerates .test_durations on an actual GitHub
+# Actions runner (matching the Test job's exact setup - same
+# ubuntu-latest, same Python version, same install steps), so
+# pytest-split's group-balancing reflects the real CI runner's
+# characteristics (2 dedicated cores, no contention) rather than
+# whatever machine happened to be used to (re)generate the file.
+# Run this after adding/changing enough tests that the committed
+# .test_durations has drifted, then commit the downloaded artifact.
+on:
+  workflow_dispatch:
+
+jobs:
+  durations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            requirements*.txt
+            pyproject.toml
+      - name: Setup navix
+        run: |
+          uv pip install --system . -v
+          uv pip install --system -r requirements_test.txt
+      - name: Store test durations
+        run: |
+          wandb offline
+          pytest -n auto --store-durations -q
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-durations
+          path: .test_durations


### PR DESCRIPTION
## Summary

Standalone infra addition, split out of #194 since GitHub only
discovers `workflow_dispatch` workflows once they exist on the
default branch (a workflow file living only on a feature branch can't
be dispatched at all, even against that same branch as the `ref`).

Adds a manually-triggered workflow that regenerates `.test_durations`
on an actual GitHub Actions runner - mirroring the `Test` job's exact
setup (same `ubuntu-latest`, same Python version, same install steps)
minus `--splits`/`--group`. This matters because `.test_durations`
(added in #194, for `pytest-split`'s group-balancing) had been
generated on a shared 192-core GPU box, a poor proxy for the real
2-core dedicated CI runner - contention and core-count differences
there don't just add noise, they can shift which tests look
relatively slow/fast, skewing which tests land in which of the 4
split groups relative to how they'd actually behave in CI.

Once merged, this can be dispatched (`gh workflow run
refresh-test-durations.yml --ref <branch>`) to regenerate an accurate
`.test_durations` for #194 itself, and again in the future whenever
the test suite has grown/changed enough to be worth refreshing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
