### PR TITLE
feat(environments): implement ObstructedMaze1Dlhb + RoomGrid + Box-opening

### DIFF
--- a/navix/actions.py
+++ b/navix/actions.py
@@ -305,22 +305,62 @@ def toggle(state: State) -> State:
     return open(state)
 
 
-def open(state: State) -> State:
-    """Unlocks and opens an openable object (like a door) if possible.
-    
+def open_box(state: State, position_in_front: Array) -> State:
+    """Opens the `Box` in front of the player, if any (verified against
+    MiniGrid's actual `Box.toggle`: `env.grid.set(pos, self.contains)`
+    - the box is removed and, if it held something, that object takes
+    its place at the same position). Currently only `Key` boxes are
+    supported (`Box.pocket` stores the id of a `Key` instance, the same
+    way `player.pocket` does) - `ObstructedMaze`'s only real user of
+    this, keys hidden inside boxes.
+
     Args:
         state (State): The current state.
-    
+        position_in_front (Array): The position directly in front of
+            the player.
+
+    Returns:
+        State: The new state, with any opened box removed and its
+        contents (if any) revealed at its former position."""
+    boxes = state.get_boxes()
+    opened = positions_equal(position_in_front, boxes.position)
+
+    if Entities.KEY in state.entities:
+        keys = state.get_keys()
+        has_key = boxes.pocket != EMPTY_POCKET_ID
+        revealing = opened & has_key
+        revealed_key_id = jnp.sum(jnp.where(revealing, boxes.pocket, 0))
+        reveal = jnp.any(revealing) & (keys.id == revealed_key_id)
+        keys = keys.replace(
+            position=jnp.where(reveal[:, None], position_in_front, keys.position)
+        )
+        state = state.set_keys(keys)
+
+    boxes = boxes.replace(
+        position=jnp.where(opened[:, None], DISCARD_PILE_COORDS, boxes.position)
+    )
+    return state.set_boxes(boxes)
+
+
+def open(state: State) -> State:
+    """Unlocks and opens an openable object (like a door), or opens a
+    box to reveal what it contains, if possible.
+
+    Args:
+        state (State): The current state.
+
     Returns:
         State: The new state with the openable object opened."""
+    player = state.get_player(idx=0)
+    position_in_front = translate(player.position, player.direction)
+
+    if Entities.BOX in state.entities:
+        state = open_box(state, position_in_front)
+
     if Entities.DOOR not in state.entities:
         return state
 
-    # get the tile in front of the player
-    player = state.get_player(idx=0)
     doors = state.get_doors()
-
-    position_in_front = translate(player.position, player.direction)
 
     # check if there is a door in front of the player
     door_found = positions_equal(position_in_front, doors.position)

--- a/navix/entities.py
+++ b/navix/entities.py
@@ -434,7 +434,19 @@ class Box(Entity, Pickable, HasColour, Holder):
     instance the same way `Key.id` does, for `actions.pickup` to match
     against `player.pocket`; `pocket` (from `Holder`) is a *different*
     field, for whatever item is hidden inside the box (e.g. a `Key`'s
-    id), unrelated to the box's own pickup-identity."""
+    id), unrelated to the box's own pickup-identity.
+
+    BREAKING CHANGE: `actions.open` (the `toggle` action) now also
+    handles `Box` - toggling one removes it from play and, if its
+    `pocket` held a `Key`'s id, reveals that `Key` at the box's former
+    position (verified against MiniGrid's actual `Box.toggle`: `env.
+    grid.set(pos, self.contains)`). Previously boxes were inert to
+    `toggle` in every environment. This changes the dynamics of any
+    existing environment whose `action_set` includes `toggle` and
+    which places a `Box` (`GoToObject`, `PutNear`, `Unlock`/
+    `UnlockPickup`/`BlockedUnlockPickup`'s decoy box) - the box can now
+    be made to disappear by toggling it, where it previously could
+    not."""
 
     @classmethod
     def create(

--- a/navix/environments/__init__.py
+++ b/navix/environments/__init__.py
@@ -37,3 +37,4 @@ from .go_to_object import GoToObject
 from .fetch import Fetch
 from .put_near import PutNear
 from .memory import Memory
+from .obstructed_maze import ObstructedMaze1Dlhb

--- a/navix/environments/obstructed_maze.py
+++ b/navix/environments/obstructed_maze.py
@@ -1,0 +1,188 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`ObstructedMaze` (issue #183): the outlier of the remaining
+families, per that issue's own scoping - it needs a real `RoomGrid`
+(#174, now built generically in `grid.py`'s `room_grid`/`room_mask`/
+`room_grid_door_position`/etc, reusable by `MultiRoom`/#182 too) plus
+a wholly new mechanic (`actions.open_box`, opening a `Box` to reveal a
+hidden `Key`). Per the issue's staged-rollout recommendation, this
+file starts with only the smallest variant, `ObstructedMaze1Dlhb` (a
+1x2 room grid) - the other 12 registrations are deliberately deferred
+to follow-up work, once this one is confirmed to play correctly end
+to end."""
+
+from __future__ import annotations
+from typing import Union
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from navix import observations
+
+from .. import rewards, terminations, transitions
+from ..components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
+from ..entities import Ball, Box, Door, Entities, Key, Player
+from ..states import State, Event
+from ..grid import (
+    open_wall,
+    random_colour,
+    random_directions,
+    random_positions,
+    room_grid,
+    room_grid_dims,
+    room_grid_door_position,
+    room_mask,
+)
+from ..rendering.cache import RenderingCache
+from .environment import Environment, Timestep
+from .registry import register_env
+
+
+ROOM_SIZE = 6  # fixed across every real ObstructedMaze variant
+
+
+class ObstructedMaze1Dlhb(Environment):
+    """A 1x2 `room_grid`: the agent starts in the left room, a target
+    `Ball` sits in the right room, behind a locked `Door`. The door's
+    key is hidden inside a `Box` in the left room (must be opened with
+    `toggle` to reveal it), and a second `Ball` blocks the door on the
+    player's own side (verified against MiniGrid's actual
+    `ObstructedMaze_1Dlhb`: `room_size=6`, `key_in_box=True`,
+    `blocked=True`). Reward + termination only on picking up the
+    *target* ball - the blocking ball can be picked up too (nothing in
+    `actions.pickup` prevents it, matching real MiniGrid) without
+    ending the episode, since `terminations`/`rewards.on_target_fetched`
+    key off `state.mission`'s specific tracked position."""
+
+    def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
+        (
+            key,
+            k_door_pos,
+            k_door_colour,
+            k_box_colour,
+            k_block_colour,
+            k_target_colour,
+            k_player_pos,
+            k_player_dir,
+            k_box_pos,
+            k_target_pos,
+        ) = jax.random.split(key, num=10)
+
+        grid = room_grid(ROOM_SIZE, num_rows=1, num_cols=2)
+        door_pos = room_grid_door_position(k_door_pos, ROOM_SIZE, 0, 0, side=0)  # east
+        grid = open_wall(grid, door_pos)
+
+        door_colour = random_colour(k_door_colour)
+        doors = Door.create(
+            position=door_pos,
+            requires=jnp.asarray(1),
+            colour=door_colour,
+            open=jnp.asarray(False),
+        )
+
+        start_room = jnp.where(room_mask(grid, ROOM_SIZE, 0, 0), grid, -1)
+        target_room = jnp.where(room_mask(grid, ROOM_SIZE, 0, 1), grid, -1)
+
+        # the blocking ball sits one cell into the start room, adjacent
+        # to the door (verified: MiniGrid places it at `door_pos -
+        # DIR_TO_VEC[door_idx]` - one step back the way the door faces)
+        block_pos = door_pos - jnp.asarray([0, 1])
+
+        player_pos = random_positions(k_player_pos, start_room, exclude=block_pos)
+        player_dir = random_directions(k_player_dir)
+        player = Player.create(
+            position=player_pos, direction=player_dir, pocket=EMPTY_POCKET_ID
+        )
+
+        box_pos = random_positions(
+            k_box_pos, start_room, exclude=jnp.stack([player_pos, block_pos])
+        )
+        boxes = Box.create(
+            position=box_pos,
+            colour=random_colour(k_box_colour),
+            id=jnp.asarray(2),
+            pocket=jnp.asarray(1),  # references the key's id below
+        )
+        # the key exists only conceptually "inside" the box until
+        # opened (verified against MiniGrid's actual Box.toggle: the
+        # key is not a separate grid object until then) - starts at the
+        # discard pile, `actions.open_box` moves it to the box's former
+        # position once revealed.
+        keys = Key.create(
+            position=DISCARD_PILE_COORDS, id=jnp.asarray(1), colour=door_colour
+        )
+
+        target_pos = random_positions(k_target_pos, target_room)
+        balls = Ball.create(
+            position=jnp.stack([block_pos, target_pos]),
+            colour=jnp.stack([random_colour(k_block_colour), random_colour(k_target_colour)]),
+            probability=jnp.ones(2),
+            id=jnp.asarray([3, 4]),
+        )
+
+        mission = Event(
+            position=target_pos,
+            colour=balls.colour[1],
+            happened=jnp.asarray(False),
+        )
+
+        entities = {
+            Entities.PLAYER: player[None],
+            Entities.DOOR: doors[None],
+            Entities.KEY: keys[None],
+            Entities.BOX: boxes[None],
+            Entities.BALL: balls,
+        }
+
+        state = State(
+            key=key,
+            grid=grid,
+            cache=cache or RenderingCache.init(grid),
+            entities=entities,
+            mission=(mission,),
+        )
+
+        return Timestep(
+            t=jnp.asarray(0, dtype=jnp.int32),
+            observation=self.observation_fn(state),
+            action=jnp.asarray(0, dtype=jnp.int32),
+            reward=jnp.asarray(0.0, dtype=jnp.float32),
+            step_type=jnp.asarray(0, dtype=jnp.int32),
+            state=state,
+        )
+
+
+_1DLHB_HEIGHT, _1DLHB_WIDTH = room_grid_dims(ROOM_SIZE, num_rows=1, num_cols=2)
+
+register_env(
+    "Navix-ObstructedMaze-1Dlhb-v0",
+    lambda *args, **kwargs: ObstructedMaze1Dlhb.create(
+        height=_1DLHB_HEIGHT,
+        width=_1DLHB_WIDTH,
+        max_steps=kwargs.pop("max_steps", 4 * 2 * ROOM_SIZE**2),
+        transitions_fn=kwargs.pop("transitions_fn", transitions.deterministic_transition),
+        observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+        reward_fn=kwargs.pop("reward_fn", rewards.on_target_fetched),
+        termination_fn=kwargs.pop("termination_fn", terminations.on_target_fetched),
+        *args,
+        **kwargs,
+    ),
+)

--- a/navix/grid.py
+++ b/navix/grid.py
@@ -461,6 +461,155 @@ def horizontal_wall(
     return positions
 
 
+def room_grid_dims(room_size: int, num_rows: int, num_cols: int) -> Tuple[int, int]:
+    """The `(height, width)` of a `room_grid` layout - adjacent rooms
+    share a single-cell-thick dividing wall (verified against
+    MiniGrid's actual `RoomGrid.__init__`), so the grid is smaller than
+    `num_rows * room_size` naively.
+
+    Args:
+        room_size (int): The size (both height and width) of one room,
+            including its own walls. Must be >= 3 (at least a 1-cell
+            interior).
+        num_rows (int): Number of rooms stacked vertically.
+        num_cols (int): Number of rooms stacked horizontally.
+
+    Returns:
+        Tuple[int, int]: The `(height, width)` of the full grid."""
+    height = (room_size - 1) * num_rows + 1
+    width = (room_size - 1) * num_cols + 1
+    return height, width
+
+
+def room_grid(room_size: int, num_rows: int, num_cols: int) -> Array:
+    """Creates the base occupancy grid for a `num_rows` x `num_cols`
+    layout of `room_size` x `room_size` rooms: the outer border plus
+    every internal room-dividing wall, with no doors punched through
+    yet (every room is fully sealed off from its neighbours) - callers
+    open specific cells with `open_wall` to place doors. `room_size`,
+    `num_rows`, `num_cols` are always static (environment-registration-
+    time) values, never per-episode traced ones, so this is plain
+    Python control flow, not vectorised.
+
+    Args:
+        room_size (int): The size of one room, including its own walls.
+        num_rows (int): Number of rooms stacked vertically.
+        num_cols (int): Number of rooms stacked horizontally.
+
+    Returns:
+        Array: A 2D grid of shape `(height, width)`."""
+    height, width = room_grid_dims(room_size, num_rows, num_cols)
+    grid = jnp.zeros((height, width), dtype=jnp.int32)
+    grid = grid.at[jnp.asarray([0, height - 1])].set(-1)
+    grid = grid.at[:, jnp.asarray([0, width - 1])].set(-1)
+    for i in range(1, num_rows):
+        grid = grid.at[i * (room_size - 1)].set(-1)
+    for j in range(1, num_cols):
+        grid = grid.at[:, j * (room_size - 1)].set(-1)
+    return grid
+
+
+def room_top_left(room_size: int, i: int, j: int) -> Tuple[int, int]:
+    """The `(row, col)` of room `(i, j)`'s top-left corner (its own
+    wall, not its interior) in a `room_grid` layout.
+
+    Args:
+        room_size (int): The size of one room, including its own walls.
+        i (int): The room's row index.
+        j (int): The room's column index.
+
+    Returns:
+        Tuple[int, int]: The `(row, col)` of the room's top-left corner."""
+    return i * (room_size - 1), j * (room_size - 1)
+
+
+def room_interior_bounds(room_size: int, i: int, j: int) -> Tuple[int, int, int, int]:
+    """The inclusive `(row_min, col_min, row_max, col_max)` interior
+    bounds of room `(i, j)` in a `room_grid` layout - excludes the
+    room's own walls, the range a position can be sampled from.
+
+    Args:
+        room_size (int): The size of one room, including its own walls.
+        i (int): The room's row index.
+        j (int): The room's column index.
+
+    Returns:
+        Tuple[int, int, int, int]: The inclusive interior bounds."""
+    top_row, top_col = room_top_left(room_size, i, j)
+    return top_row + 1, top_col + 1, top_row + room_size - 2, top_col + room_size - 2
+
+
+def room_grid_door_position(
+    key: Array, room_size: int, i: int, j: int, side: int
+) -> Array:
+    """A random position along room `(i, j)`'s shared wall on the given
+    `side` - where `add_door` would place a door in MiniGrid's actual
+    `RoomGrid`. Verified against MiniGrid's own door placement: a
+    uniform random offset along the wall, excluding the corners.
+
+    Args:
+        key (Array): A random key.
+        room_size (int): The size of one room, including its own walls.
+        i (int): The room's row index.
+        j (int): The room's column index.
+        side (int): The wall side, using navix's own direction
+            convention (`entities.Directions`): 0=east, 1=south,
+            2=west, 3=north. Always a static (registration-time) value,
+            never a per-episode traced one, so this is a plain `if`,
+            not `jax.lax.switch`.
+
+    Returns:
+        Array: An `i32[2]` `(row, col)` position on the wall."""
+    top_row, top_col = room_top_left(room_size, i, j)
+    offset = jax.random.randint(key, (), minval=1, maxval=room_size - 1)
+    if side == 0:  # east
+        return jnp.asarray([top_row + offset, top_col + room_size - 1])
+    elif side == 1:  # south
+        return jnp.asarray([top_row + room_size - 1, top_col + offset])
+    elif side == 2:  # west
+        return jnp.asarray([top_row + offset, top_col])
+    else:  # north
+        return jnp.asarray([top_row, top_col + offset])
+
+
+def room_mask(grid: Array, room_size: int, i: int, j: int) -> Array:
+    """A boolean mask of `grid`'s shape, `True` only within room `(i,
+    j)`'s interior (its own walls excluded) - unlike `unlock.py`'s
+    `mask_by_coordinates` (which only tests "before a single row/col",
+    fine for a 1-row-of-rooms layout corner-anchored at the origin),
+    rooms in a general `room_grid` need all four bounds, since they
+    aren't corner-anchored. Useful for scoping `random_positions`'
+    sampling to one room.
+
+    Args:
+        grid (Array): A 2D grid of shape `(height, width)`.
+        room_size (int): The size of one room, including its own walls.
+        i (int): The room's row index.
+        j (int): The room's column index.
+
+    Returns:
+        Array: A boolean mask of shape `(height, width)`."""
+    row_min, col_min, row_max, col_max = room_interior_bounds(room_size, i, j)
+    rows, cols = coordinates(grid)
+    return (
+        (rows >= row_min) & (rows <= row_max) & (cols >= col_min) & (cols <= col_max)
+    )
+
+
+def open_wall(grid: Array, position: Array) -> Array:
+    """Removes a single wall cell (e.g. to place a door through it) by
+    setting it to floor (`0`) - the door's own entity (not the grid)
+    then controls whether the player can actually pass through.
+
+    Args:
+        grid (Array): A 2D grid of shape `(height, width)`.
+        position (Array): The `(row, col)` position to open.
+
+    Returns:
+        Array: The updated grid."""
+    return grid.at[position[0], position[1]].set(0)
+
+
 def crop(
     grid: Array, origin: Array, direction: Array, radius: int, padding_value: int = 100
 ) -> Array:

--- a/navix/terminations.py
+++ b/navix/terminations.py
@@ -218,6 +218,23 @@ def on_any_target_pickup(prev_state: State, action: Array, state: State) -> Arra
     return jnp.asarray(events.on_any_target_pickup(state), dtype=jnp.bool_)
 
 
+def on_target_fetched(prev_state: State, action: Array, state: State) -> Array:
+    """`ObstructedMaze`'s termination: only picking up the *specific*
+    mission-target `Key`/`Ball` ends the episode - unlike `Fetch`'s
+    `on_any_target_pickup`, a wrong pickup (the blocking `Ball`, say)
+    does not end it here, matching MiniGrid's actual `ObstructedMazeEnv`
+    (reward + termination only on picking up the target).
+
+    Args:
+        prev_state (State): The previous state of the game.
+        action (Array): The action taken by the player.
+        state (State): The current state of the game.
+
+    Returns:
+        Array: A boolean array."""
+    return jnp.asarray(events.on_target_fetched(state), dtype=jnp.bool_)
+
+
 def on_put_near_wrong_pickup(prev_state: State, action: Array, state: State) -> Array:
     """`PutNear`'s failure-on-pickup termination: the wrong object was
     picked up this step.

--- a/tests/test_obstructed_maze.py
+++ b/tests/test_obstructed_maze.py
@@ -1,0 +1,248 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`ObstructedMaze1Dlhb` (issue #183, smallest variant only - see that
+issue's own staged-rollout recommendation): structural checks against
+the live reset state, plus a full hand-crafted gameplay walkthrough
+via real `env.step()` calls - clear the blocking ball, open the box to
+reveal the key, unlock and open the door, cross into the second room,
+pick up the target ball. Uses BFS pathfinding (not a row-then-column
+heuristic) since the blocking ball can end up dropped anywhere,
+matching test_unlock.py's own `BlockedUnlockPickup` precedent."""
+
+from __future__ import annotations
+
+from collections import deque
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import navix as nx
+from navix.components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
+from navix.entities import Entities
+
+
+EAST, SOUTH, WEST, NORTH = 0, 1, 2, 3
+ROTATE_CW, FORWARD, PICKUP, DROP, TOGGLE = 1, 2, 3, 4, 5
+
+N_SEEDS = 3
+GAMEPLAY_SEEDS = 2
+
+
+def face_via_step(env, timestep, direction: int):
+    for _ in range(4):
+        if int(timestep.state.get_player().direction) == direction:
+            return timestep
+        timestep = env.step(timestep, jnp.asarray(ROTATE_CW))
+    raise AssertionError(f"could not face direction {direction}")
+
+
+def bfs_blocked_mask(state) -> np.ndarray:
+    blocked = np.asarray(state.grid) == -1
+    for entity_enum, entity in state.entities.items():
+        if entity_enum == Entities.PLAYER:
+            continue
+        walkable = np.asarray(entity.walkable)
+        positions = np.asarray(entity.position)
+        if positions.ndim == 1:
+            positions = positions[None]
+            walkable = walkable.reshape(1)
+        for (row, col), w in zip(positions, walkable):
+            if not w:
+                blocked[row, col] = True
+    return blocked
+
+
+def bfs_path(blocked: np.ndarray, start: tuple, goal: tuple):
+    height, width = blocked.shape
+    prev = {start: None}
+    queue = deque([start])
+    while queue:
+        current = queue.popleft()
+        if current == goal:
+            break
+        row, col = current
+        for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+            nxt = (row + dr, col + dc)
+            if (
+                0 <= nxt[0] < height
+                and 0 <= nxt[1] < width
+                and not blocked[nxt]
+                and nxt not in prev
+            ):
+                prev[nxt] = current
+                queue.append(nxt)
+    if goal not in prev:
+        return None
+    path = [goal]
+    while path[-1] != start:
+        path.append(prev[path[-1]])
+    path.reverse()
+    return path
+
+
+def bfs_direction_between(a: tuple, b: tuple) -> int:
+    dr, dc = b[0] - a[0], b[1] - a[1]
+    if dr == 1:
+        return SOUTH
+    if dr == -1:
+        return NORTH
+    if dc == 1:
+        return EAST
+    if dc == -1:
+        return WEST
+    raise AssertionError(f"{a} -> {b} is not a single orthogonal step")
+
+
+def bfs_walk_path_via_step(env, timestep, path):
+    for a, b in zip(path[:-1], path[1:]):
+        timestep = face_via_step(env, timestep, bfs_direction_between(a, b))
+        timestep = env.step(timestep, jnp.asarray(FORWARD))
+    return timestep
+
+
+def bfs_navigate_adjacent_and_face_via_step(env, timestep, target_row: int, target_col: int):
+    state = timestep.state
+    blocked = bfs_blocked_mask(state)
+    start = (int(state.get_player().position[0]), int(state.get_player().position[1]))
+    target = (target_row, target_col)
+
+    if start == target:
+        return timestep
+
+    for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+        candidate = (target[0] + dr, target[1] + dc)
+        if not (0 <= candidate[0] < blocked.shape[0] and 0 <= candidate[1] < blocked.shape[1]):
+            continue
+        if blocked[candidate]:
+            continue
+        if candidate == start:
+            return face_via_step(env, timestep, bfs_direction_between(candidate, target))
+        path = bfs_path(blocked, start, candidate)
+        if path is not None:
+            timestep = bfs_walk_path_via_step(env, timestep, path)
+            return face_via_step(env, timestep, bfs_direction_between(candidate, target))
+    raise AssertionError(f"no reachable approach cell for target {target}")
+
+
+def test_obstructed_maze_1dlhb_structure():
+    env = nx.make("Navix-ObstructedMaze-1Dlhb-v0")
+    for seed in range(N_SEEDS):
+        state = env.reset(jax.random.PRNGKey(seed)).state
+
+        doors = state.get_doors()
+        assert bool(doors.requires[0] == 1), f"seed={seed}: door must require key id 1"
+        assert not bool(doors.open[0]), f"seed={seed}: door must start closed"
+
+        keys = state.get_keys()
+        assert (keys.position[0] == DISCARD_PILE_COORDS).all(), (
+            f"seed={seed}: key must start hidden (discard pile) until the box is opened"
+        )
+
+        boxes = state.get_boxes()
+        assert int(boxes.pocket[0]) == 1, f"seed={seed}: box must hold key id 1"
+
+        balls = state.get_balls()
+        assert balls.position.shape[0] == 2, f"seed={seed}: expected 2 balls (blocker + target)"
+
+        mission_row, mission_col = (int(x) for x in state.mission[0].position)
+        assert (mission_row, mission_col) == (
+            int(balls.position[1, 0]),
+            int(balls.position[1, 1]),
+        ), f"seed={seed}: mission must target the second (non-blocking) ball"
+
+
+def test_obstructed_maze_1dlhb_gameplay_and_reward_termination():
+    for seed in range(GAMEPLAY_SEEDS):
+        env = nx.make("Navix-ObstructedMaze-1Dlhb-v0")
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        state = timestep.state
+        doors = state.get_doors()
+        door_row, door_col = int(doors.position[0]), int(doors.position[1])
+        boxes = state.get_boxes()
+        box_row, box_col = int(boxes.position[0, 0]), int(boxes.position[0, 1])
+        balls = state.get_balls()
+        block_row, block_col = int(balls.position[0, 0]), int(balls.position[0, 1])
+        target_row, target_col = int(balls.position[1, 0]), int(balls.position[1, 1])
+
+        # clear the blocking ball out of the door's only approach cell
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, block_row, block_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert int(timestep.state.get_player().pocket) != int(EMPTY_POCKET_ID), (
+            f"seed={seed}: blocking ball not picked up"
+        )
+        timestep = env.step(timestep, jnp.asarray(FORWARD))
+        timestep = face_via_step(env, timestep, WEST)
+        timestep = env.step(timestep, jnp.asarray(DROP))
+        assert int(timestep.state.get_player().pocket) == int(EMPTY_POCKET_ID), (
+            f"seed={seed}: pocket not freed after dropping the ball"
+        )
+
+        # open the box, revealing the key at the same position
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, box_row, box_col)
+        timestep = env.step(timestep, jnp.asarray(TOGGLE))
+        assert (timestep.state.get_boxes().position[0] == DISCARD_PILE_COORDS).all(), (
+            f"seed={seed}: box not removed after opening"
+        )
+        assert (timestep.state.get_keys().position[0] == jnp.asarray([box_row, box_col])).all(), (
+            f"seed={seed}: key not revealed at the box's former position"
+        )
+
+        # still facing that same cell - pick up the now-revealed key
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert int(timestep.state.get_player().pocket) == 1, f"seed={seed}: key not picked up"
+
+        # unlock and open the door
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, door_row, door_col)
+        timestep = env.step(timestep, jnp.asarray(TOGGLE))
+        assert bool(timestep.state.get_doors().open[0]), f"seed={seed}: door not opened"
+        assert timestep.step_type == 0, f"seed={seed}: episode ended before reaching the target"
+
+        # cross through and pick up the target ball
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, target_row, target_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert timestep.step_type == 2, f"seed={seed}: expected termination on the target pickup"
+        assert float(timestep.reward) > 0, f"seed={seed}: expected positive reward"
+
+
+def test_obstructed_maze_1dlhb_wrong_pickup_does_not_terminate():
+    # picking up the blocking ball (the "wrong" pickup) must not end
+    # the episode - only terminations.on_target_fetched, keyed to the
+    # specific mission-target ball, does.
+    env = nx.make("Navix-ObstructedMaze-1Dlhb-v0")
+    timestep = env.reset(jax.random.PRNGKey(0))
+    balls = timestep.state.get_balls()
+    block_row, block_col = int(balls.position[0, 0]), int(balls.position[0, 1])
+    timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, block_row, block_col)
+    timestep = env.step(timestep, jnp.asarray(PICKUP))
+    assert int(timestep.state.get_player().pocket) != int(EMPTY_POCKET_ID)
+    assert timestep.step_type == 0, "picking up the blocking ball must not terminate the episode"
+    assert float(timestep.reward) == 0
+
+
+def test_obstructed_maze_1dlhb_jit_vmap_compatible():
+    env = nx.make("Navix-ObstructedMaze-1Dlhb-v0")
+    keys = jax.random.split(jax.random.PRNGKey(0), 4)
+    reset = jax.jit(env.reset)
+    step = jax.jit(env.step)
+    timestep = jax.vmap(reset)(keys)
+    for action in range(7):
+        timestep = jax.vmap(step, in_axes=(0, None))(timestep, jnp.asarray(action))
+    jax.block_until_ready(timestep)

--- a/tests/test_obstructed_maze.py
+++ b/tests/test_obstructed_maze.py
@@ -175,7 +175,7 @@ def test_obstructed_maze_1dlhb_gameplay_and_reward_termination():
         timestep = env.reset(jax.random.PRNGKey(seed))
         state = timestep.state
         doors = state.get_doors()
-        door_row, door_col = int(doors.position[0]), int(doors.position[1])
+        door_row, door_col = int(doors.position[0, 0]), int(doors.position[0, 1])
         boxes = state.get_boxes()
         box_row, box_col = int(boxes.position[0, 0]), int(boxes.position[0, 1])
         balls = state.get_balls()


### PR DESCRIPTION
## Summary

First step of #183 - per that issue's own scoping recommendation
(ObstructedMaze is the outlier of the remaining families, needing a
real `RoomGrid`, #174, plus a wholly new Box-opening mechanic), this
PR builds both, then lands only the smallest variant,
`Navix-ObstructedMaze-1Dlhb-v0`. The other 12 registrations (2Dl/2Dlh/
2Dlhb, 1Q/2Q, Full - all needing a full 3x3 room grid) are
deliberately deferred to follow-up work now that this foundation is
confirmed to play correctly end to end.

## New infrastructure

- **`grid.py`: generic `RoomGrid` primitives** (#174) -
  `room_grid`/`room_grid_dims`/`room_top_left`/`room_interior_bounds`/
  `room_mask`/`room_grid_door_position`/`open_wall`. A functional/
  array-style equivalent of MiniGrid's actual stateful `Room`/
  `RoomGrid` classes (verified against the real source: adjacent rooms
  share a single-cell-thick wall). Doesn't port `connect_all`/
  `add_distractors`/`place_agent` - callers hand-place doors/objects
  directly, matching every other navix environment. Also unblocks
  `MultiRoom` (#182) later.
- **`actions.open_box`**: `actions.open` (the `toggle` action)
  previously only handled `Door` - extended to open a `Box`, verified
  against MiniGrid's actual `Box.toggle`: toggling removes the box
  and, if its `pocket` held a `Key`'s id, reveals that `Key` at the
  box's former position. `Box.pocket` already existed but was never
  wired to any interaction before.
  **BREAKING CHANGE**: any environment with a `Box` (`GoToObject`,
  `PutNear`, `Unlock`/`UnlockPickup`/`BlockedUnlockPickup`'s decoy
  box) previously could not have that box toggled at all - now it
  can, and toggling removes it. Every existing box has always had
  `pocket=-1` (empty), so this doesn't change what any of them
  *contain*, only that they're now toggle-able. Verified no
  regression: the 19 existing tests touching `Box` across those three
  files still pass.
- **`terminations.on_target_fetched`**: unlike `Fetch`'s `on_any_
  target_pickup` (any pickup ends the episode), `ObstructedMaze` only
  ends on picking up the *specific* mission-target object - a wrong
  pickup shouldn't terminate. `rewards.on_target_fetched` already
  existed for the reward side; this adds the matching termination.

## `ObstructedMaze1Dlhb`

A 1x2 `room_grid`: agent starts in the left room, a target `Ball`
sits in the right room behind a locked `Door`, the door's key is
hidden inside a `Box` in the left room, and a second `Ball` blocks
the door on the player's own side - confirmed directly that this is
the door's *only* interior-adjacent cell (`room_size=6`, the door
sits on the shared wall). All verified against MiniGrid's actual
`ObstructedMaze_1Dlhb`: `room_size=6`, `key_in_box=True`,
`blocked=True`, `max_steps=4*num_rooms*room_size**2=288`.

`transitions_fn=deterministic_transition` is required, not just
convention: both balls' positions are matched positionally later
(blocking-ball-clears-the-path, `on_target_fetched`'s position check)
- the default `stochastic_transition` would move them and break both.

## Testing

Structural + a full hand-crafted gameplay walkthrough (clear the
blocking ball, open the box, pick up the revealed key, unlock and
cross the door, pick up the target ball) + wrong-pickup-doesn't-
terminate + jit/vmap. All independently verified via real JAX
execution with small standalone scripts - the pytest harness itself
intermittently hit the same jaxlib process-lifetime flakiness already
tracked from #194/#196, but every underlying behaviour checked out
clean, including a direct regression check against the three existing
`Box`-touching test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
