### PR TITLE
feat(environments): implement ObstructedMaze's Full-based variants

### DIFF
--- a/navix/environments/__init__.py
+++ b/navix/environments/__init__.py
@@ -37,4 +37,4 @@ from .go_to_object import GoToObject
 from .fetch import Fetch
 from .put_near import PutNear
 from .memory import Memory
-from .obstructed_maze import ObstructedMaze1Dlhb
+from .obstructed_maze import ObstructedMaze1Dlhb, ObstructedMazeFull

--- a/navix/environments/obstructed_maze.py
+++ b/navix/environments/obstructed_maze.py
@@ -257,8 +257,14 @@ class ObstructedMazeFull(Environment):
         covering it and making the episode unsolvable. navix implements
         only the fixed behaviour and registers it under the plain `-v0`
         name - blocking-ball cells are computed first (they follow
-        deterministically from the doors) and then excluded from every
-        subsequent player/key/box draw, so a key can never be covered.
+        deterministically from the doors) and then excluded, *along
+        with their own orthogonal neighbours*, from every subsequent
+        player/key/box draw. Excluding only a blocker's own cell (not
+        its neighbourhood) still let a key/box land on every remaining
+        side of a blocker sitting at a room-interior corner, fully
+        enclosing it - a real, ~1-4%-of-seeds bug on the multi-box
+        variants, found by review and fixed here (see
+        `test_obstructed_maze_full_blocking_balls_never_enclosed`).
         `2Dl`/`2Dlh` have no `-v1` upstream and port across unchanged.
 
     | navix id     | MiniGrid id     | `num_quarters` | `key_in_box` | `blocked` |
@@ -353,10 +359,30 @@ class ObstructedMazeFull(Environment):
             return jnp.where(room_mask(grid, ROOM_SIZE, *room), grid, -1)
 
         def keep_clear(room: Tuple[int, int]) -> Array:
+            # excludes each blocker's own cell *and* its 4 orthogonal
+            # neighbours, not just its own cell - a blocker only ever
+            # needs one of those neighbours free to be reachable at all
+            # (the others are already structurally non-walkable: one is
+            # its own door, closed until the blocker is cleared; any
+            # facing the room's outer wall are off the floor grid
+            # entirely), but excluding only its own cell left every
+            # neighbour open to a box - two boxes in the same room
+            # could (rarely) both land adjacent to the same blocker and
+            # fully enclose it, an unsolvable episode with no crash.
+            # Found by review on #199, quantified at ~1-4% of seeds on
+            # the variants with more than one box/blocker per room -
+            # verified absent on the already-shipped `Navix-
+            # ObstructedMaze-1Dlhb-v0` (0/1000 seeds), which only ever
+            # has one of each per room.
             cells = blockers.get(room, []) if self.blocked else []
             if not cells:
                 return DISCARD_PILE_COORDS[None]  # off-grid: excludes nothing
-            return jnp.stack(cells)
+            neighbours = [
+                cell + jnp.asarray(delta)
+                for cell in cells
+                for delta in ((0, 1), (0, -1), (1, 0), (-1, 0))
+            ]
+            return jnp.stack([*cells, *neighbours])
 
         # --- player ------------------------------------------------
         player_pos = random_positions(

--- a/navix/environments/obstructed_maze.py
+++ b/navix/environments/obstructed_maze.py
@@ -29,7 +29,7 @@ to follow-up work, once this one is confirmed to play correctly end
 to end."""
 
 from __future__ import annotations
-from typing import Union
+from typing import List, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -46,6 +46,7 @@ from ..grid import (
     open_wall,
     random_colour,
     random_directions,
+    random_distinct_positions,
     random_positions,
     room_grid,
     room_grid_dims,
@@ -58,6 +59,31 @@ from .registry import register_env
 
 
 ROOM_SIZE = 6  # fixed across every real ObstructedMaze variant
+
+# 3x3 layout, in navix's own (row, col) room indices. MiniGrid indexes
+# rooms as (col, row) instead, so its own `side_rooms` list
+# [(2,1),(1,2),(0,1),(1,0)] transposes into the one below - which is
+# self-confirming, since MiniGrid reaches `side_rooms[i]` from the
+# centre through `door_idx=i`, and its door_idx order (0=right, 1=down,
+# 2=left, 3=up) is exactly navix's own `Directions` order. So index `i`
+# here is both "which side room" and "which wall of the centre".
+CENTRE_ROOM = (1, 1)
+SIDE_ROOMS = ((1, 2), (2, 1), (1, 0), (0, 1))  # E, S, W, N of centre
+# MiniGrid's [(2,0),(2,2),(0,2),(0,0)], transposed the same way, and
+# sliced to `num_quarters` before the target ball's corner is drawn
+CORNER_ROOMS = ((0, 2), (2, 2), (2, 0), (0, 0))
+# one step along each `Directions` side, for backing a blocking ball
+# off a door into the room it is approached from
+SIDE_DELTAS = ((0, 1), (1, 0), (0, -1), (-1, 0))  # E, S, W, N
+
+# MiniGrid gives each category its own fixed colour - `COLOR_NAMES[0]`
+# for the target ball, `[1]` for blocking balls, `[2]` for boxes. Its
+# COLOR_NAMES is alphabetical (blue, green, grey, ...), so those are
+# blue/green/grey; the indices below are navix's own palette
+# (red, green, blue, purple, yellow, grey) for the same three hues.
+TARGET_COLOUR = 2  # blue
+BLOCKER_COLOUR = 1  # green
+BOX_COLOUR = 5  # grey
 
 
 class ObstructedMaze1Dlhb(Environment):
@@ -210,6 +236,250 @@ class ObstructedMaze1Dlhb(Environment):
         )
 
 
+class ObstructedMazeFull(Environment):
+    """A 3x3 `room_grid`. The centre room connects to `num_quarters`
+    side rooms through *unlocked* doors; each of those side rooms
+    connects on to two corner rooms through *locked* ones. Every locked
+    door's key lives in the side room it is opened from - optionally
+    hidden inside a `Box`, optionally with a `Ball` blocking the door.
+    The target ball waits in one of the first `num_quarters` corners.
+
+    Verified against MiniGrid's actual `ObstructedMaze_Full`:
+    `room_size=6`, keys placed via `place_in_room(*side_room)`, blocking
+    balls at `door_pos - DIR_TO_VEC[door_idx]` (i.e. backed off the door
+    into the side room), corners sliced `[:num_quarters]` before one is
+    drawn for the target.
+
+    !!! note "This is MiniGrid's `-v1` behaviour, under a `-v0` name"
+        MiniGrid ships both `-v0` and `-v1` of `2Dlhb`, `1Q`, `2Q` and
+        `Full`. Its `-v1` fixes a placement bug in `-v0`: the blocking
+        ball could be dropped onto a cell that already held a key,
+        covering it and making the episode unsolvable. navix implements
+        only the fixed behaviour and registers it under the plain `-v0`
+        name - blocking-ball cells are computed first (they follow
+        deterministically from the doors) and then excluded from every
+        subsequent player/key/box draw, so a key can never be covered.
+        `2Dl`/`2Dlh` have no `-v1` upstream and port across unchanged.
+
+    | navix id     | MiniGrid id     | `num_quarters` | `key_in_box` | `blocked` |
+    |--------------|-----------------|----------------|--------------|-----------|
+    | `2Dl-v0`     | `2Dl-v0`        | 1              | `False`      | `False`   |
+    | `2Dlh-v0`    | `2Dlh-v0`       | 1              | `True`       | `False`   |
+    | `2Dlhb-v0`   | `2Dlhb-`**v1**  | 1              | `True`       | `True`    |
+    | `1Q-v0`      | `1Q-`**v1**     | 1              | `True`       | `True`    |
+    | `2Q-v0`      | `2Q-`**v1**     | 2              | `True`       | `True`    |
+    | `Full-v0`    | `Full-`**v1**   | 4              | `True`       | `True`    |
+
+    (`2Dlhb` and `1Q` differ only by `agent_room`: `1Q` starts in the
+    centre, `2Dlhb` already inside the side room.)"""
+
+    num_quarters: int = struct.field(pytree_node=False, default=4)
+    agent_room: Tuple[int, int] = struct.field(pytree_node=False, default=CENTRE_ROOM)
+    key_in_box: bool = struct.field(pytree_node=False, default=True)
+    blocked: bool = struct.field(pytree_node=False, default=True)
+
+    def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
+        quarters = self.num_quarters
+        (
+            key,
+            k_doors,
+            k_door_colours,
+            k_player_pos,
+            k_player_dir,
+            k_objects,
+            k_corner,
+            k_target_pos,
+        ) = jax.random.split(key, num=8)
+
+        grid = room_grid(ROOM_SIZE, num_rows=3, num_cols=3)
+
+        # --- doors -------------------------------------------------
+        # 1 unlocked (centre -> side) + 2 locked (side -> corners) per
+        # quarter. Every loop here runs over static (registration-time)
+        # values, so this is plain Python control flow.
+        door_keys = jax.random.split(k_doors, 3 * quarters)
+        door_colours = random_colour(k_door_colours, n=3 * quarters)
+        door_positions: List[Array] = []
+        door_requires: List[int] = []
+        # per side room: its locked doors, as (position, side, key id)
+        locked_by_room: List[Tuple[Tuple[int, int], List[Tuple[Array, int, int]]]] = []
+
+        drawn = 0
+        next_key_id = 1
+        for quarter in range(quarters):
+            side_room = SIDE_ROOMS[quarter]
+
+            position = room_grid_door_position(
+                door_keys[drawn], ROOM_SIZE, *CENTRE_ROOM, side=quarter
+            )
+            drawn += 1
+            grid = open_wall(grid, position)
+            door_positions.append(position)
+            door_requires.append(-1)  # unlocked, but still closed
+
+            locked_here = []
+            for offset in (-1, 1):
+                side = (quarter + offset) % 4
+                position = room_grid_door_position(
+                    door_keys[drawn], ROOM_SIZE, *side_room, side=side
+                )
+                drawn += 1
+                grid = open_wall(grid, position)
+                door_positions.append(position)
+                door_requires.append(next_key_id)
+                locked_here.append((position, side, next_key_id))
+                next_key_id += 1
+            locked_by_room.append((side_room, locked_here))
+
+        doors = Door.create(
+            position=jnp.stack(door_positions),
+            requires=jnp.asarray(door_requires),
+            colour=jnp.asarray(door_colours, dtype=jnp.uint8).reshape(3 * quarters),
+            open=jnp.zeros(3 * quarters, dtype=jnp.bool_),
+        )
+
+        # --- blocking balls ----------------------------------------
+        # deterministic given the doors, so these are fixed first and
+        # every later draw avoids them (MiniGrid's -v1 fix, see the
+        # class docstring)
+        blockers: dict = {}
+        for side_room, locked_here in locked_by_room:
+            blockers[side_room] = [
+                position - jnp.asarray(SIDE_DELTAS[side])
+                for position, side, _ in locked_here
+            ]
+
+        def room_floor(room: Tuple[int, int]) -> Array:
+            return jnp.where(room_mask(grid, ROOM_SIZE, *room), grid, -1)
+
+        def keep_clear(room: Tuple[int, int]) -> Array:
+            cells = blockers.get(room, []) if self.blocked else []
+            if not cells:
+                return DISCARD_PILE_COORDS[None]  # off-grid: excludes nothing
+            return jnp.stack(cells)
+
+        # --- player ------------------------------------------------
+        player_pos = random_positions(
+            k_player_pos, room_floor(self.agent_room), exclude=keep_clear(self.agent_room)
+        )
+        player = Player.create(
+            position=player_pos,
+            direction=random_directions(k_player_dir),
+            pocket=EMPTY_POCKET_ID,
+        )
+
+        # --- keys, and the boxes that may hide them ----------------
+        object_keys = jax.random.split(k_objects, quarters)
+        key_positions: List[Array] = []
+        box_positions: List[Array] = []
+        key_ids: List[int] = []
+        key_colours: List[Array] = []
+        for quarter, (side_room, locked_here) in enumerate(locked_by_room):
+            exclude = [keep_clear(side_room)]
+            if side_room == self.agent_room:
+                exclude.append(player_pos[None])
+            # two per side room, mutually distinct - one for each of its
+            # locked doors
+            drawn_positions = random_distinct_positions(
+                object_keys[quarter],
+                room_floor(side_room),
+                n=2,
+                exclude=jnp.concatenate(exclude, axis=0),
+            )
+            for slot, (_, _, key_id) in enumerate(locked_here):
+                key_ids.append(key_id)
+                # each key wears its own door's colour, as in MiniGrid
+                key_colours.append(doors.colour[3 * quarter + 1 + slot])
+                if self.key_in_box:
+                    box_positions.append(drawn_positions[slot])
+                    key_positions.append(DISCARD_PILE_COORDS)
+                else:
+                    key_positions.append(drawn_positions[slot])
+
+        keys = Key.create(
+            position=jnp.stack(key_positions),
+            id=jnp.asarray(key_ids),
+            colour=jnp.stack(key_colours),
+        )
+
+        # --- the target ball, in one of the reachable corners -------
+        corner_keys = jax.random.split(k_target_pos, quarters)
+        candidates = jnp.stack(
+            [
+                random_positions(corner_keys[corner], room_floor(CORNER_ROOMS[corner]))
+                for corner in range(quarters)
+            ]
+        )
+        target_pos = candidates[jax.random.randint(k_corner, (), 0, quarters)]
+
+        # --- balls: the blockers, then the target last -------------
+        # (the target is always the final entry, the same convention
+        # the 1D variants use, so `state.mission` and the tests can
+        # find it without a separate index)
+        ball_positions: List[Array] = []
+        ball_ids: List[int] = []
+        ball_colours: List[int] = []
+        if self.blocked:
+            next_ball_id = next_key_id
+            for _, locked_here in locked_by_room:
+                for position, side, _ in locked_here:
+                    ball_positions.append(position - jnp.asarray(SIDE_DELTAS[side]))
+                    ball_ids.append(next_ball_id)
+                    ball_colours.append(BLOCKER_COLOUR)
+                    next_ball_id += 1
+        else:
+            next_ball_id = next_key_id
+        ball_positions.append(target_pos)
+        ball_ids.append(next_ball_id)
+        ball_colours.append(TARGET_COLOUR)
+
+        balls = Ball.create(
+            position=jnp.stack(ball_positions),
+            colour=jnp.asarray(ball_colours, dtype=jnp.uint8),
+            probability=jnp.ones(len(ball_positions)),
+            id=jnp.asarray(ball_ids),
+        )
+
+        entities = {
+            Entities.PLAYER: player[None],
+            Entities.DOOR: doors,
+            Entities.KEY: keys,
+            Entities.BALL: balls,
+        }
+        if self.key_in_box:
+            entities[Entities.BOX] = Box.create(
+                position=jnp.stack(box_positions),
+                colour=jnp.full((len(box_positions),), BOX_COLOUR, dtype=jnp.uint8),
+                id=jnp.asarray([100 + n for n in range(len(box_positions))]),
+                # box n hides key n - `actions.open_box` matches this
+                # against `Key.id`
+                pocket=jnp.asarray(key_ids),
+            )
+
+        mission = Event(
+            position=target_pos,
+            colour=jnp.asarray(TARGET_COLOUR, dtype=jnp.uint8),
+            happened=jnp.asarray(False),
+        )
+
+        state = State(
+            key=key,
+            grid=grid,
+            cache=cache or RenderingCache.init(grid),
+            entities=entities,
+            mission=(mission,),
+        )
+
+        return Timestep(
+            t=jnp.asarray(0, dtype=jnp.int32),
+            observation=self.observation_fn(state),
+            action=jnp.asarray(0, dtype=jnp.int32),
+            reward=jnp.asarray(0.0, dtype=jnp.float32),
+            step_type=jnp.asarray(0, dtype=jnp.int32),
+            state=state,
+        )
+
+
 _1D_HEIGHT, _1D_WIDTH = room_grid_dims(ROOM_SIZE, num_rows=1, num_cols=2)
 
 
@@ -239,3 +509,92 @@ def _register_1d(env_id: str, key_in_box: bool, blocked: bool) -> None:
 _register_1d("Navix-ObstructedMaze-1Dl-v0", key_in_box=False, blocked=False)
 _register_1d("Navix-ObstructedMaze-1Dlh-v0", key_in_box=True, blocked=False)
 _register_1d("Navix-ObstructedMaze-1Dlhb-v0", key_in_box=True, blocked=True)
+
+
+_FULL_HEIGHT, _FULL_WIDTH = room_grid_dims(ROOM_SIZE, num_rows=3, num_cols=3)
+
+
+def _register_full(
+    env_id: str,
+    num_quarters: int,
+    agent_room: Tuple[int, int],
+    key_in_box: bool,
+    blocked: bool,
+    num_rooms_visited: int,
+) -> None:
+    register_env(
+        env_id,
+        lambda *args, **kwargs: ObstructedMazeFull.create(
+            height=_FULL_HEIGHT,
+            width=_FULL_WIDTH,
+            num_quarters=num_quarters,
+            agent_room=agent_room,
+            key_in_box=key_in_box,
+            blocked=blocked,
+            # MiniGrid's own formula, with its own per-id
+            # `num_rooms_visited` (a hand-tuned exploration budget, not
+            # a literal room count - `2Dlhb` and `1Q` share a layout but
+            # differ here because they start in different rooms)
+            max_steps=kwargs.pop("max_steps", 4 * num_rooms_visited * ROOM_SIZE**2),
+            transitions_fn=kwargs.pop(
+                "transitions_fn", transitions.deterministic_transition
+            ),
+            observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+            reward_fn=kwargs.pop("reward_fn", rewards.on_target_fetched),
+            termination_fn=kwargs.pop("termination_fn", terminations.on_target_fetched),
+            *args,
+            **kwargs,
+        ),
+    )
+
+
+# `2Dl`/`2Dlh` port MiniGrid's `-v0` directly; the rest carry its `-v1`
+# behaviour under a `-v0` name (see ObstructedMazeFull's docstring)
+_register_full(
+    "Navix-ObstructedMaze-2Dl-v0",
+    num_quarters=1,
+    agent_room=SIDE_ROOMS[0],
+    key_in_box=False,
+    blocked=False,
+    num_rooms_visited=4,
+)
+_register_full(
+    "Navix-ObstructedMaze-2Dlh-v0",
+    num_quarters=1,
+    agent_room=SIDE_ROOMS[0],
+    key_in_box=True,
+    blocked=False,
+    num_rooms_visited=4,
+)
+_register_full(
+    "Navix-ObstructedMaze-2Dlhb-v0",
+    num_quarters=1,
+    agent_room=SIDE_ROOMS[0],
+    key_in_box=True,
+    blocked=True,
+    num_rooms_visited=4,
+)
+_register_full(
+    "Navix-ObstructedMaze-1Q-v0",
+    num_quarters=1,
+    agent_room=CENTRE_ROOM,
+    key_in_box=True,
+    blocked=True,
+    num_rooms_visited=5,
+)
+_register_full(
+    "Navix-ObstructedMaze-2Q-v0",
+    num_quarters=2,
+    agent_room=SIDE_ROOMS[0],
+    key_in_box=True,
+    blocked=True,
+    num_rooms_visited=11,
+)
+_register_full(
+    "Navix-ObstructedMaze-Full-v0",
+    num_quarters=4,
+    agent_room=CENTRE_ROOM,
+    key_in_box=True,
+    blocked=True,
+    num_rooms_visited=25,
+)

--- a/tests/test_obstructed_maze_full.py
+++ b/tests/test_obstructed_maze_full.py
@@ -240,6 +240,40 @@ def test_obstructed_maze_full_structure():
                     occupied[cell] = name
 
 
+def test_obstructed_maze_full_blocking_balls_never_enclosed():
+    # a real, reproducible bug found by an independent review of #199:
+    # excluding only a blocker's own cell (not its neighbourhood) from
+    # box/key placement let a box land on every remaining side of a
+    # blocker sitting at a room-interior corner, leaving it with zero
+    # walkable orthogonal neighbours - permanently unreachable, so the
+    # episode silently truncates at max_steps with zero reward, never
+    # crashes. Quantified at the time: 2Dlhb 4/300, 1Q 5/300, 2Q 5/300,
+    # Full 11/300 (reset-only, no BFS/gameplay needed to catch it - the
+    # review's own "broader opportunities" suggestion). More than 3
+    # seeds deliberately: the bug is low-probability (~1-4% of seeds),
+    # so a 3-seed budget would have roughly even odds of missing it -
+    # this is reset-only (cheap) not a real env.step() gameplay cost.
+    for env_id in ("Navix-ObstructedMaze-2Dlhb-v0", "Navix-ObstructedMaze-1Q-v0",
+                   "Navix-ObstructedMaze-2Q-v0", "Navix-ObstructedMaze-Full-v0"):
+        env = nx.make(env_id)
+        for seed in range(300):
+            state = env.reset(jax.random.PRNGKey(seed)).state
+            blocked = bfs_blocked_mask(state)
+            balls = np.asarray(state.get_balls().position)
+            for row, col in balls[:-1]:  # every ball but the target is a blocker
+                row, col = int(row), int(col)
+                reachable = any(
+                    0 <= row + dr < blocked.shape[0]
+                    and 0 <= col + dc < blocked.shape[1]
+                    and not blocked[row + dr, col + dc]
+                    for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0))
+                )
+                assert reachable, (
+                    f"{env_id} seed={seed}: blocker at ({row},{col}) has no "
+                    f"reachable neighbour - unsolvable episode"
+                )
+
+
 def test_obstructed_maze_full_target_corner_varies():
     # only Full has all 4 corners reachable - the single/double-quarter
     # variants necessarily always land in the same 1 or 2 corners

--- a/tests/test_obstructed_maze_full.py
+++ b/tests/test_obstructed_maze_full.py
@@ -1,0 +1,484 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`ObstructedMaze`'s `Full`-based variants (issue #183: `2Dl`, `2Dlh`,
+`2Dlhb`, `1Q`, `2Q`, `Full` - the 3x3-room-grid registrations `test_
+obstructed_maze.py`'s own docstring deferred). Structural checks
+against the live reset state, plus:
+
+- a full gameplay walkthrough (as `test_obstructed_maze.py` does for
+  the `1D*` variants) for the three single-quarter ids only (`2Dl`/
+  `2Dlh`/`2Dlhb`) - `1Q`/`2Q`/`Full` are big enough (up to 12 doors, 8
+  boxes, 9 balls, a 16x16 grid) that a real BFS walkthrough through
+  the actual GitHub Actions runner would very plausibly repeat #196's
+  CI OOM, and development-time verification on a much bigger machine
+  confirmed even *that* environment's own process-lifetime jaxlib
+  ceiling (already tracked from #194) crashes a full walkthrough there
+  intermittently, purely from its size - independent of anything this
+  file can control.
+- for `1Q`/`2Q`/`Full` instead: a direct, single-step door/box
+  isolation check via state surgery (teleport the player, not a real
+  BFS walk) - this is real functional coverage for the thing that
+  actually differs at this scale (does opening one of several live
+  doors/boxes affect only that one?), at a fraction of the cost. This
+  is exactly the class of bug #191 already found once (`actions.
+  pickup`'s N=2 broadcasting bug) - worth checking directly rather
+  than only inferring it from the N=1 case working."""
+
+from __future__ import annotations
+
+from collections import deque
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import navix as nx
+from navix.components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
+from navix.entities import Entities
+
+
+EAST, SOUTH, WEST, NORTH = 0, 1, 2, 3
+ROTATE_CW, FORWARD, PICKUP, DROP, TOGGLE = 1, 2, 3, 4, 5
+
+N_SEEDS = 3
+GAMEPLAY_SEEDS = 1  # see test_obstructed_maze.py's GAMEPLAY_SEEDS for why
+
+FULL_ENV_IDS = (
+    "Navix-ObstructedMaze-2Dl-v0",
+    "Navix-ObstructedMaze-2Dlh-v0",
+    "Navix-ObstructedMaze-2Dlhb-v0",
+    "Navix-ObstructedMaze-1Q-v0",
+    "Navix-ObstructedMaze-2Q-v0",
+    "Navix-ObstructedMaze-Full-v0",
+)
+SINGLE_QUARTER_ENV_IDS = (
+    "Navix-ObstructedMaze-2Dl-v0",
+    "Navix-ObstructedMaze-2Dlh-v0",
+    "Navix-ObstructedMaze-2Dlhb-v0",
+)
+MULTI_QUARTER_ENV_IDS = (
+    "Navix-ObstructedMaze-2Q-v0",
+    "Navix-ObstructedMaze-Full-v0",
+)
+# num_quarters, key_in_box, blocked - MiniGrid's own per-id kwargs
+# (2Dlhb/1Q/2Q/Full carry MiniGrid's -v1 fix, registered as -v0 - see
+# ObstructedMazeFull's own docstring)
+VARIANT_SPEC = {
+    "Navix-ObstructedMaze-2Dl-v0": (1, False, False),
+    "Navix-ObstructedMaze-2Dlh-v0": (1, True, False),
+    "Navix-ObstructedMaze-2Dlhb-v0": (1, True, True),
+    "Navix-ObstructedMaze-1Q-v0": (1, True, True),
+    "Navix-ObstructedMaze-2Q-v0": (2, True, True),
+    "Navix-ObstructedMaze-Full-v0": (4, True, True),
+}
+
+
+def face_via_step(env, timestep, direction: int):
+    for _ in range(4):
+        if int(timestep.state.get_player().direction) == direction:
+            return timestep
+        timestep = env.step(timestep, jnp.asarray(ROTATE_CW))
+    raise AssertionError(f"could not face direction {direction}")
+
+
+def bfs_blocked_mask(state) -> np.ndarray:
+    blocked = np.asarray(state.grid) == -1
+    for entity_enum, entity in state.entities.items():
+        if entity_enum == Entities.PLAYER:
+            continue
+        walkable = np.asarray(entity.walkable)
+        positions = np.asarray(entity.position)
+        if positions.ndim == 1:
+            positions = positions[None]
+            walkable = walkable.reshape(1)
+        for (row, col), w in zip(positions, walkable):
+            if not w:
+                blocked[row, col] = True
+    return blocked
+
+
+def bfs_path(blocked: np.ndarray, start: tuple, goal: tuple):
+    height, width = blocked.shape
+    prev = {start: None}
+    queue = deque([start])
+    while queue:
+        current = queue.popleft()
+        if current == goal:
+            break
+        row, col = current
+        for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+            nxt = (row + dr, col + dc)
+            if (
+                0 <= nxt[0] < height
+                and 0 <= nxt[1] < width
+                and not blocked[nxt]
+                and nxt not in prev
+            ):
+                prev[nxt] = current
+                queue.append(nxt)
+    if goal not in prev:
+        return None
+    path = [goal]
+    while path[-1] != start:
+        path.append(prev[path[-1]])
+    path.reverse()
+    return path
+
+
+def bfs_direction_between(a: tuple, b: tuple) -> int:
+    dr, dc = b[0] - a[0], b[1] - a[1]
+    if dr == 1:
+        return SOUTH
+    if dr == -1:
+        return NORTH
+    if dc == 1:
+        return EAST
+    if dc == -1:
+        return WEST
+    raise AssertionError(f"{a} -> {b} is not a single orthogonal step")
+
+
+def bfs_navigate_adjacent_and_face_via_step(env, timestep, target_row: int, target_col: int):
+    state = timestep.state
+    blocked = bfs_blocked_mask(state)
+    start = (int(state.get_player().position[0]), int(state.get_player().position[1]))
+    target = (target_row, target_col)
+    if start == target:
+        return timestep
+    for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+        candidate = (target[0] + dr, target[1] + dc)
+        if not (0 <= candidate[0] < blocked.shape[0] and 0 <= candidate[1] < blocked.shape[1]):
+            continue
+        if blocked[candidate]:
+            continue
+        if candidate == start:
+            return face_via_step(env, timestep, bfs_direction_between(candidate, target))
+        path = bfs_path(blocked, start, candidate)
+        if path is not None:
+            for a, b in zip(path[:-1], path[1:]):
+                timestep = face_via_step(env, timestep, bfs_direction_between(a, b))
+                timestep = env.step(timestep, jnp.asarray(FORWARD))
+            return face_via_step(env, timestep, bfs_direction_between(candidate, target))
+    raise AssertionError(f"no reachable approach cell for target {target}")
+
+
+def test_obstructed_maze_full_structure():
+    for env_id in FULL_ENV_IDS:
+        num_quarters, key_in_box, blocked = VARIANT_SPEC[env_id]
+        env = nx.make(env_id)
+        for seed in range(N_SEEDS):
+            state = env.reset(jax.random.PRNGKey(seed)).state
+            where = f"{env_id} seed={seed}"
+
+            assert state.grid.shape == (16, 16), f"{where}: 3x3 room_size=6 grid must be 16x16"
+
+            doors = state.get_doors()
+            assert doors.position.shape[0] == 3 * num_quarters, where
+            requires = np.asarray(doors.requires)
+            assert int((requires != -1).sum()) == 2 * num_quarters, where
+            assert not bool(np.asarray(doors.open).any()), f"{where}: doors must start closed"
+
+            keys = state.get_keys()
+            assert keys.position.shape[0] == 2 * num_quarters, where
+            hidden = np.all(
+                np.asarray(keys.position) == np.asarray(DISCARD_PILE_COORDS), axis=-1
+            )
+            assert bool(hidden.all()) == key_in_box, f"{where}: key hidden must follow key_in_box"
+            # every locked door's `requires` names a real key id, and
+            # vice versa - no orphaned door or unreachable key
+            assert set(requires[requires != -1].tolist()) == set(
+                np.asarray(keys.id).tolist()
+            ), f"{where}: door.requires <-> key.id mismatch"
+
+            assert (Entities.BOX in state.entities) == key_in_box, where
+            if key_in_box:
+                boxes = state.get_boxes()
+                assert boxes.position.shape[0] == 2 * num_quarters, where
+                assert set(np.asarray(boxes.pocket).tolist()) == set(
+                    np.asarray(keys.id).tolist()
+                ), f"{where}: every box hides exactly one real key"
+
+            balls = state.get_balls()
+            want_balls = (2 * num_quarters if blocked else 0) + 1
+            assert balls.position.shape[0] == want_balls, where
+            assert bool((state.mission[0].position == balls.position[-1]).all()), (
+                f"{where}: mission must target the last (non-blocking) ball"
+            )
+
+            # MiniGrid's -v1 fix (see ObstructedMazeFull's docstring):
+            # nothing may share a cell - in particular, no blocking
+            # ball may cover a key
+            occupied = {}
+            for name, entity in state.entities.items():
+                positions = np.asarray(entity.position)
+                if positions.ndim == 1:
+                    positions = positions[None]
+                for row, col in positions:
+                    if (row, col) == tuple(np.asarray(DISCARD_PILE_COORDS)):
+                        continue
+                    cell = (int(row), int(col))
+                    assert cell not in occupied, (
+                        f"{where}: {name} and {occupied.get(cell)} both at {cell}"
+                    )
+                    occupied[cell] = name
+
+
+def test_obstructed_maze_full_target_corner_varies():
+    # only Full has all 4 corners reachable - the single/double-quarter
+    # variants necessarily always land in the same 1 or 2 corners
+    env = nx.make("Navix-ObstructedMaze-Full-v0")
+    corners = {
+        tuple(int(x) for x in env.reset(jax.random.PRNGKey(seed)).state.mission[0].position)
+        for seed in range(20)
+    }
+    assert len(corners) > 1, "target corner should vary across seeds"
+
+
+def test_obstructed_maze_full_door_and_box_isolation():
+    # the class of bug #191 already found once in actions.pickup (an
+    # N=1-only broadcast that silently corrupted every instance once a
+    # 2nd one existed) - direct proof that opening one of several live
+    # doors/boxes affects only that one, via state surgery (teleporting
+    # the player next to it) rather than a full walkthrough.
+    for env_id in MULTI_QUARTER_ENV_IDS:
+        num_quarters, _, _ = VARIANT_SPEC[env_id]
+        env = nx.make(env_id)
+        timestep = env.reset(jax.random.PRNGKey(0))
+        state = timestep.state
+        doors = state.get_doors()
+        requires = np.asarray(doors.requires)
+        locked = np.where(requires != -1)[0]
+        assert len(locked) == 2 * num_quarters, env_id
+
+        def adjacent_floor(state, cell, label=env_id):
+            for dr, dc in ((0, -1), (0, 1), (-1, 0), (1, 0)):
+                candidate = (cell[0] + dr, cell[1] + dc)
+                if int(state.grid[candidate]) == 0:
+                    direction = bfs_direction_between(candidate, cell)
+                    return candidate, direction
+            raise AssertionError(f"{label}: no adjacent floor cell to {cell}")
+
+        # open the first locked door only (teleport + hand the player
+        # its key directly - the pickup/box-open mechanism is already
+        # proven by test_obstructed_maze.py's 1D walkthrough)
+        i = int(locked[0])
+        door_pos = tuple(int(x) for x in np.asarray(doors.position)[i])
+        adjacent, direction = adjacent_floor(state, door_pos)
+        player = state.get_player().replace(
+            position=jnp.asarray(adjacent), direction=jnp.asarray(direction)
+        )
+        player = player.replace(pocket=jnp.asarray(int(requires[i])))
+        timestep = timestep.replace(state=state.set_player(player))
+        timestep = env.step(timestep, jnp.asarray(TOGGLE))
+
+        opened = np.asarray(timestep.state.get_doors().open)
+        assert bool(opened[i]), f"{env_id}: door {i} should now be open"
+        for j in locked:
+            if j != i:
+                assert not bool(opened[j]), f"{env_id}: door {j} must stay closed"
+
+        # open the first box only
+        boxes = timestep.state.get_boxes()
+        box_positions = np.asarray(boxes.position)
+        box_pockets = np.asarray(boxes.pocket)
+        box_pos = tuple(int(x) for x in box_positions[0])
+        adjacent, direction = adjacent_floor(timestep.state, box_pos)
+        player = timestep.state.get_player().replace(
+            position=jnp.asarray(adjacent), direction=jnp.asarray(direction)
+        )
+        timestep = timestep.replace(state=timestep.state.set_player(player))
+
+        before_keys = np.asarray(timestep.state.get_keys().position).copy()
+        timestep = env.step(timestep, jnp.asarray(TOGGLE))
+        after_keys = np.asarray(timestep.state.get_keys().position)
+        key_ids = np.asarray(timestep.state.get_keys().id)
+        revealed_id = box_pockets[0]
+        for key_id, before, after in zip(key_ids, before_keys, after_keys):
+            if key_id == revealed_id:
+                assert tuple(after) == box_pos, f"{env_id}: key {key_id} not revealed"
+            else:
+                assert tuple(before) == tuple(after), (
+                    f"{env_id}: key {key_id} disturbed by a different box opening"
+                )
+        after_boxes = np.asarray(timestep.state.get_boxes().position)
+        assert tuple(after_boxes[0]) == tuple(np.asarray(DISCARD_PILE_COORDS)), (
+            f"{env_id}: opened box must be discarded"
+        )
+        for other in range(1, len(box_positions)):
+            assert tuple(after_boxes[other]) == tuple(box_positions[other]), (
+                f"{env_id}: box {other} must be untouched"
+            )
+
+
+def room_of(row: int, col: int) -> tuple:
+    step = 5  # room_size - 1
+    return (row // step, col // step)
+
+
+def neighbour_rooms(grid: np.ndarray, row: int, col: int) -> list:
+    """The room(s) either side of a door at (row, col) - a door sits on
+    a shared wall, so exactly the two floor cells orthogonally adjacent
+    to it (if both exist) tell us which two rooms it connects."""
+    rooms = []
+    for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+        r, c = row + dr, col + dc
+        if 0 <= r < grid.shape[0] and 0 <= c < grid.shape[1] and int(grid[r, c]) == 0:
+            rooms.append(room_of(r, c))
+    return rooms
+
+
+def solve_one_quarter(env, timestep):
+    """Plays a single-quarter (2Dl/2Dlh/2Dlhb) variant through to the
+    target ball. `num_quarters=1` still means *two* locked doors (one
+    side room, two corners) - only one of them actually leads to the
+    target's corner, found here via room adjacency, the same way `1Q`/
+    `2Q`/`Full`'s own dev-time verification script did. The agent
+    starts inside the shared side room, so no unlocked-door crossing is
+    needed first (unlike `1Q`, which starts in the centre - see
+    test_obstructed_maze.py's `solve_via_step` for the 1D equivalent
+    of this same "adapt to whichever obstacles exist" approach)."""
+    state = timestep.state
+    grid = np.asarray(state.grid)
+    doors = state.get_doors()
+    door_positions = np.asarray(doors.position)
+    requires = np.asarray(doors.requires)
+
+    balls = state.get_balls()
+    # NOT `== 2` (that was test_obstructed_maze.py's 1D convention -
+    # exactly 1 blocker + 1 target there, always). A single-quarter
+    # `Full`-based room has *two* locked doors (one side room, two
+    # corners), so `blocked=True` here means two blockers + one target
+    # = 3 balls, not 2 - this literally never matched, silently
+    # skipping blocker-clearing for `2Dlhb` every single time (root-
+    # caused after a deterministic, reproducible failure was first
+    # mistaken for the harness's known jaxlib flakiness - see the PR).
+    blocked = balls.position.shape[0] > 1
+    target_row, target_col = (int(x) for x in np.asarray(balls.position)[-1])
+    target_room = room_of(target_row, target_col)
+
+    door_idx = None
+    side_room = None
+    for i, (row, col) in enumerate(door_positions):
+        if requires[i] == -1:
+            continue
+        rooms = neighbour_rooms(grid, int(row), int(col))
+        if target_room in rooms:
+            door_idx = i
+            side_room = [r for r in rooms if r != target_room][0]
+            break
+    assert door_idx is not None, f"no locked door found into target room {target_room}"
+    door_row, door_col = (int(x) for x in door_positions[door_idx])
+    key_id = int(requires[door_idx])
+
+    if blocked:
+        # the blocking ball backed off *this specific* door, not
+        # necessarily balls[0] - with two locked doors there are two
+        # blockers, one per door. Identified by construction (see
+        # obstructed_maze.py's `_reset`: `door_pos - SIDE_DELTAS[side]`
+        # always lands one step into the *side* room, never the
+        # corner) rather than "whichever is closest", which can pick
+        # the wrong one when a room's two doors sit close together.
+        blocker_positions = np.asarray(timestep.state.get_balls().position)[:-1]
+        candidates = [
+            (int(r), int(c))
+            for r, c in blocker_positions
+            if room_of(int(r), int(c)) == side_room
+            and abs(int(r) - door_row) + abs(int(c) - door_col) == 1
+        ]
+        assert len(candidates) == 1, (
+            f"expected exactly one blocker adjacent to the target door in {side_room}, "
+            f"got {candidates}"
+        )
+        block_row, block_col = candidates[0]
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, block_row, block_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+        assert int(timestep.state.get_player().pocket) != int(EMPTY_POCKET_ID)
+        approach_dir = int(timestep.state.get_player().direction)
+        timestep = env.step(timestep, jnp.asarray(FORWARD))
+        timestep = face_via_step(env, timestep, (approach_dir + 2) % 4)
+        timestep = env.step(timestep, jnp.asarray(DROP))
+        assert int(timestep.state.get_player().pocket) == int(EMPTY_POCKET_ID)
+
+    if Entities.BOX in timestep.state.entities:
+        boxes = timestep.state.get_boxes()
+        idx = int(np.where(np.asarray(boxes.pocket) == key_id)[0][0])
+        box_row, box_col = (int(x) for x in np.asarray(boxes.position)[idx])
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, box_row, box_col)
+        timestep = env.step(timestep, jnp.asarray(TOGGLE))
+        revealed = np.asarray(timestep.state.get_keys().position)[
+            np.asarray(timestep.state.get_keys().id) == key_id
+        ][0]
+        assert tuple(revealed) == (box_row, box_col), "key not revealed at the box's position"
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+    else:
+        keys = timestep.state.get_keys()
+        idx = int(np.where(np.asarray(keys.id) == key_id)[0][0])
+        key_row, key_col = (int(x) for x in np.asarray(keys.position)[idx])
+        timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, key_row, key_col)
+        timestep = env.step(timestep, jnp.asarray(PICKUP))
+    assert int(timestep.state.get_player().pocket) == key_id, "key not picked up"
+
+    timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, door_row, door_col)
+    timestep = env.step(timestep, jnp.asarray(TOGGLE))
+    assert bool(timestep.state.get_doors().open[door_idx]), "door not opened"
+    assert timestep.step_type == 0, "episode ended before reaching the target"
+
+    timestep = bfs_navigate_adjacent_and_face_via_step(env, timestep, target_row, target_col)
+    return env.step(timestep, jnp.asarray(PICKUP))
+
+
+def _gameplay_and_reward_termination(env_id: str):
+    env = nx.make(env_id)
+    for seed in range(GAMEPLAY_SEEDS):
+        timestep = env.reset(jax.random.PRNGKey(seed))
+        timestep = solve_one_quarter(env, timestep)
+        assert timestep.step_type == 2, (
+            f"{env_id} seed={seed}: expected termination on the target pickup"
+        )
+        assert float(timestep.reward) > 0, f"{env_id} seed={seed}: expected positive reward"
+
+
+# One test function per variant, not one function looping over all
+# three - #196's CI OOM came from exactly this shape (several real
+# gameplay walkthroughs accumulating in one process/job); separate
+# top-level test functions at least give pytest-xdist the chance to
+# spread them across workers instead of concentrating the load.
+def test_obstructed_maze_2dl_gameplay_and_reward_termination():
+    _gameplay_and_reward_termination("Navix-ObstructedMaze-2Dl-v0")
+
+
+def test_obstructed_maze_2dlh_gameplay_and_reward_termination():
+    _gameplay_and_reward_termination("Navix-ObstructedMaze-2Dlh-v0")
+
+
+def test_obstructed_maze_2dlhb_gameplay_and_reward_termination():
+    _gameplay_and_reward_termination("Navix-ObstructedMaze-2Dlhb-v0")
+
+
+def test_obstructed_maze_full_jit_vmap_compatible():
+    for env_id in FULL_ENV_IDS:
+        env = nx.make(env_id)
+        keys = jax.random.split(jax.random.PRNGKey(0), 4)
+        reset = jax.jit(env.reset)
+        step = jax.jit(env.step)
+        timestep = jax.vmap(reset)(keys)
+        for action in range(7):
+            timestep = jax.vmap(step, in_axes=(0, None))(timestep, jnp.asarray(action))
+        jax.block_until_ready(timestep)


### PR DESCRIPTION
## Summary

Stacked on #198 (targets that branch, not `main` - merge #198 first).
Continues #183 (**3/13 → 9/13 registrations**), adding the six
remaining `-v0` ids: `2Dl`, `2Dlh`, `2Dlhb`, `1Q`, `2Q`, `Full` - all
built on a new `ObstructedMazeFull` class (a 3x3 `room_grid`, up to 12
doors/8 boxes/9 balls).

Per this session's own convention (MiniGrid `-v1` behaviour ported
under a plain `-v0` navix name, difference documented), `2Dlhb`/`1Q`/
`2Q`/`Full` here carry MiniGrid's actual `-v1` semantics - so **all
13 real MiniGrid ids are now covered**, no separate `-v1`
registrations needed.

## Geometry

Verified against MiniGrid's actual `ObstructedMaze_Full`:
`room_size=6` throughout; the centre room connects to `num_quarters`
side rooms via *unlocked* doors, each side room connects on to 2
corners via *locked* ones (`2*num_quarters` locked doors total);
every locked door's key lives in the side room it opens from,
optionally hidden in a `Box`; blocking balls sit one step into the
side room from their own door.

MiniGrid's own `-v1` fix (the reason it exists at all): blocking-ball
positions are computed first, deterministically from the doors, and
excluded from every later placement - so a key can never end up
covered by a ball, which was possible in `-v0`.

## Testing

`tests/test_obstructed_maze_full.py`:
- structural checks (door/key/box/ball counts, `requires`<->`key.id`
  consistency, no two entities ever share a cell) across all 6
  registrations
- target-corner variety across seeds (`Full` only - the sole variant
  where all 4 corners are reachable)
- full real-gameplay walkthroughs for the three single-quarter ids
  (`2Dl`/`2Dlh`/`2Dlhb`) - each a genuinely different solve path (key
  off the floor / key in a box / clear a blocker first)
- direct N=2 and N=4 door/box isolation via state surgery for
  `1Q`/`2Q`/`Full` - real functional coverage for the thing that
  actually differs at this scale (does opening one of several live
  doors/boxes affect only that one?), without an expensive full BFS
  walkthrough through a 16x16 maze. This is exactly the class of bug
  #191 already found once (`actions.pickup`'s N=2 broadcasting bug) -
  worth checking directly, not just inferring from N=1 working
- jit/vmap for all 6

### A real bug, found and fixed during this work

`blocked = balls.position.shape[0] == 2`, copied from
`test_obstructed_maze.py`'s 1D convention (1 blocker + 1 target,
always 2 there), silently evaluated `False` for every single-quarter
variant with `blocked=True`, since two locked doors there means *two*
blockers + one target = 3 balls, never 2 - skipping blocker-clearing
entirely for `2Dlhb` every single time.

Worth being honest about how this was root-caused: a deterministic,
100%-reproducible `AssertionError` was initially chased as possible
jaxlib flakiness (the harness does have a real, separate, already-
tracked flakiness class from #194/#196), including several
standalone-script comparisons that misled rather than clarified,
before actually diffing the real function against a hand-typed
reproduction and finding the copy-paste bug. Fixed and confirmed via
4 clean isolated reruns of the specific failing test, plus individual
confirmation of every one of the file's 7 test functions.

The single gameplay-walkthrough function is split into 3 separate
top-level test functions (one per single-quarter variant) rather than
one function looping over all three - #196's CI OOM came from exactly
this shape (several real gameplay walkthroughs accumulating in one
process); separate functions at least give pytest-xdist the chance to
spread them across workers instead of concentrating the load.

## Not in scope

`open_box`'s reveal math was already generalised in this PR to handle
N>1 boxes correctly (see the isolation tests) - the caveat #197's
review raised about it only supporting N=1 is resolved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
