### PR TITLE
feat(environments): implement MultiRoom (#182)

### DIFF
--- a/navix/environments/__init__.py
+++ b/navix/environments/__init__.py
@@ -38,3 +38,4 @@ from .fetch import Fetch
 from .put_near import PutNear
 from .memory import Memory
 from .obstructed_maze import ObstructedMaze1Dlhb, ObstructedMazeFull
+from .multi_room import MultiRoom

--- a/navix/environments/multi_room.py
+++ b/navix/environments/multi_room.py
@@ -46,7 +46,21 @@ set - so `N6` is genuinely, permanently more expensive to run than any
 other navix environment, not just slower to compile. Kept anyway,
 deliberately, for fidelity - see this session's own discussion on
 issue #182 for the (rejected) cheaper alternative (a straight room
-chain) and the actual cost numbers."""
+chain) and the actual cost numbers.
+
+One consequence worth calling out explicitly: `Environment.step`
+embeds a full `Environment.reset` call as its `jax.lax.cond` autoreset
+branch, so calling `env.step(...)` *un-jitted* in a Python loop
+retraces and recompiles that whole branch - reset included - on every
+single call, since eager `lax.cond` doesn't cache across separate
+top-level calls the way `jax.jit` does. For most navix environments
+that's an unnoticeable cost, because their `reset` is cheap. For
+`MultiRoom`, and especially `N6`, `reset` is exactly the heavy nested-
+retry search described above, so this pattern is a real footgun: it
+was measured to balloon to minutes of compile time and multiple GB of
+memory before crashing outright. Always `jax.jit` (or `jax.vmap` over
+a jitted function) `env.step`/`env.reset` before calling either in a
+loop against any `MultiRoom` variant."""
 
 from __future__ import annotations
 from typing import List, Tuple, Union
@@ -69,7 +83,7 @@ from .registry import register_env
 
 GRID_SIZE = 25  # fixed for every registration, matching MiniGrid's own
 MIN_ROOM_SIZE = 4  # matches MiniGrid's hardcoded minSz
-BOUNDARY_MARGIN = MIN_ROOM_SIZE - 1  # see _place_room's docstring
+BOUNDARY_MARGIN = MIN_ROOM_SIZE - 1  # see place_room's docstring
 MAX_PLACEMENT_TRIES = 64  # MiniGrid itself retries only 8 times per room,
 # but a JAX retry (one more jax.lax.while_loop iteration, already-compiled)
 # has essentially none of the real cost a Python-level retry does - bumped
@@ -79,7 +93,7 @@ MAX_PLACEMENT_TRIES = 64  # MiniGrid itself retries only 8 times per room,
 MAX_LAYOUT_RESTARTS = 32  # a single room's own retry (MAX_PLACEMENT_TRIES,
 # BOUNDARY_MARGIN) still can't always salvage a bad *earlier* room's
 # choice - MiniGrid's true backtracking can reconsider previous rooms,
-# a single room's retry loop structurally can't (see _place_room's
+# a single room's retry loop structurally can't (see place_room's
 # docstring). Confirmed necessary directly: even with the above two,
 # Navix-MultiRoom-N6-v0 PRNGKey(2) still exhausted every retry (room
 # 3's door only 4 cells from an edge - no legal room 4 size fits).
@@ -93,14 +107,14 @@ MAX_LAYOUT_RESTARTS = 32  # a single room's own retry (MAX_PLACEMENT_TRIES,
 # exhausted every restart) - good, not perfect, so a guaranteed-valid
 # deterministic fallback (see _reset) covers the remainder instead of
 # chasing a higher ceiling that's already shown real compile cost.
-# _generate_layout reports failure honestly instead of silently
+# generate_layout reports failure honestly instead of silently
 # returning an invalid layout (which previously manifested as e.g. the
 # goal defaulting to a wall corner, position (0,0)), and _reset
 # restarts the *entire* room chain from scratch with a fresh key,
 # rather than trying to locally patch just the one room that failed.
 
 
-def _room_top_left_east(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
+def room_top_left_east(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
     # entered via the new room's own EAST wall -> room extends west
     top_col = entry_col - size_w + 1
     # MiniGrid samples the perpendicular offset from a half-open range
@@ -117,31 +131,31 @@ def _room_top_left_east(key: Array, entry_row: Array, entry_col: Array, size_h: 
     return jnp.asarray([top_row, top_col])
 
 
-def _room_top_left_south(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
+def room_top_left_south(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
     # entered via the new room's own SOUTH wall -> room extends north
     top_row = entry_row - size_h + 1
-    # see _room_top_left_east's comment: `high` must exclude entry_col
+    # see room_top_left_east's comment: `high` must exclude entry_col
     top_col = jax.random.randint(key, (), entry_col - size_w + 2, entry_col)
     return jnp.asarray([top_row, top_col])
 
 
-def _room_top_left_west(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
+def room_top_left_west(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
     # entered via the new room's own WEST wall -> room extends east
     top_col = entry_col
-    # see _room_top_left_east's comment: `high` must exclude entry_row
+    # see room_top_left_east's comment: `high` must exclude entry_row
     top_row = jax.random.randint(key, (), entry_row - size_h + 2, entry_row)
     return jnp.asarray([top_row, top_col])
 
 
-def _room_top_left_north(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
+def room_top_left_north(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
     # entered via the new room's own NORTH wall -> room extends south
     top_row = entry_row
-    # see _room_top_left_east's comment: `high` must exclude entry_col
+    # see room_top_left_east's comment: `high` must exclude entry_col
     top_col = jax.random.randint(key, (), entry_col - size_w + 2, entry_col)
     return jnp.asarray([top_row, top_col])
 
 
-def _room_top_left(wall: Array, key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
+def room_top_left(wall: Array, key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
     """The new room's top-left corner, positioned so its `wall` side
     touches `(entry_row, entry_col)` and it extends away from there -
     verified against MiniGrid's actual `_placeRoom`'s 4 wall-relative
@@ -150,45 +164,45 @@ def _room_top_left(wall: Array, key: Array, entry_row: Array, entry_col: Array, 
     switch` rather than a plain Python `if`."""
     return jax.lax.switch(
         wall,
-        [_room_top_left_east, _room_top_left_south, _room_top_left_west, _room_top_left_north],
+        [room_top_left_east, room_top_left_south, room_top_left_west, room_top_left_north],
         key, entry_row, entry_col, size_h, size_w,
     )
 
 
-def _exit_door_position_east(key: Array, top: Array, size: Array) -> Array:
+def exit_door_position_east(key: Array, top: Array, size: Array) -> Array:
     offset = jax.random.randint(key, (), 1, size[0] - 1)
     return jnp.asarray([top[0] + offset, top[1] + size[1] - 1])
 
 
-def _exit_door_position_south(key: Array, top: Array, size: Array) -> Array:
+def exit_door_position_south(key: Array, top: Array, size: Array) -> Array:
     offset = jax.random.randint(key, (), 1, size[1] - 1)
     return jnp.asarray([top[0] + size[0] - 1, top[1] + offset])
 
 
-def _exit_door_position_west(key: Array, top: Array, size: Array) -> Array:
+def exit_door_position_west(key: Array, top: Array, size: Array) -> Array:
     offset = jax.random.randint(key, (), 1, size[0] - 1)
     return jnp.asarray([top[0] + offset, top[1]])
 
 
-def _exit_door_position_north(key: Array, top: Array, size: Array) -> Array:
+def exit_door_position_north(key: Array, top: Array, size: Array) -> Array:
     offset = jax.random.randint(key, (), 1, size[1] - 1)
     return jnp.asarray([top[0], top[1] + offset])
 
 
-def _exit_door_position(wall: Array, key: Array, top: Array, size: Array) -> Array:
+def exit_door_position(wall: Array, key: Array, top: Array, size: Array) -> Array:
     """A random position on room `top`/`size`'s `wall` side, excluding
     the two corners (matching `grid.room_grid_door_position`'s own
     corner-excluding convention - the same reason: a door needs a real
     interior cell on both sides, not the room's own corner)."""
     return jax.lax.switch(
         wall,
-        [_exit_door_position_east, _exit_door_position_south,
-         _exit_door_position_west, _exit_door_position_north],
+        [exit_door_position_east, exit_door_position_south,
+         exit_door_position_west, exit_door_position_north],
         key, top, size,
     )
 
 
-def _interiors_overlap(top_a: Array, size_a: Array, top_b: Array, size_b: Array) -> Array:
+def interiors_overlap(top_a: Array, size_a: Array, top_b: Array, size_b: Array) -> Array:
     """Whether two rooms' *interiors* (each room's own 1-cell wall
     border excluded) overlap. Interiors, not full bounds: two rooms
     connected by a door are deliberately placed edge-to-edge, sharing
@@ -204,7 +218,7 @@ def _interiors_overlap(top_a: Array, size_a: Array, top_b: Array, size_b: Array)
     return row_overlap & col_overlap
 
 
-def _place_room(
+def place_room(
     key: Array,
     entry_wall: Array,
     entry_pos: Array,
@@ -219,7 +233,7 @@ def _place_room(
     the first that's in-bounds *with a margin* (see below) and doesn't
     overlap any already-placed room). `existing_tops`/`existing_sizes`
     are plain Python lists, not padded arrays - safe here because the
-    outer room-by-room loop in `_reset`/`_generate_layout` is itself a
+    outer room-by-room loop in `_reset`/`generate_layout` is itself a
     static Python `for` (room count is a registration-time constant),
     so each call site's list length is static, same as
     `ObstructedMazeFull`'s own `door_positions` accumulation.
@@ -242,7 +256,7 @@ def _place_room(
     salvaged locally, which a single room's own retry loop structurally
     can't replicate - so on total failure here, this function reports
     it honestly instead of silently returning an invalid placement,
-    and `_generate_layout`'s own outer retry restarts the *entire*
+    and `generate_layout`'s own outer retry restarts the *entire*
     chain with a fresh key instead - the closest JAX-traceable
     equivalent of "back up and reconsider an earlier choice", since
     which earlier room to blame isn't something this function can
@@ -258,7 +272,7 @@ def _place_room(
         key, k_h, k_w, k_pos = jax.random.split(key, 4)
         size_h = jax.random.randint(k_h, (), size_min, size_max + 1)
         size_w = jax.random.randint(k_w, (), size_min, size_max + 1)
-        top = _room_top_left(entry_wall, k_pos, entry_row, entry_col, size_h, size_w)
+        top = room_top_left(entry_wall, k_pos, entry_row, entry_col, size_h, size_w)
         size = jnp.asarray([size_h, size_w])
         in_bounds = (
             (top[0] >= BOUNDARY_MARGIN)
@@ -269,7 +283,7 @@ def _place_room(
         no_overlap = jnp.asarray(True)
         for other_top, other_size in zip(existing_tops, existing_sizes):
             no_overlap = no_overlap & jnp.logical_not(
-                _interiors_overlap(top, size, other_top, other_size)
+                interiors_overlap(top, size, other_top, other_size)
             )
         valid = in_bounds & no_overlap
         return key, attempt + 1, valid, top, size
@@ -285,7 +299,7 @@ def _place_room(
     return top, size, found
 
 
-def _fallback_layout(key: Array, n: int) -> Tuple[Array, Array, Array, Array]:
+def fallback_layout(key: Array, n: int) -> Tuple[Array, Array, Array, Array]:
     """A deterministic straight chain of `n` minimum-size rooms,
     centred as a whole and extending east - always valid by
     construction (`GRID_SIZE=25` comfortably fits the *chain's total
@@ -343,18 +357,18 @@ class MultiRoom(Environment):
     num_rooms: int = struct.field(pytree_node=False, default=2)
     max_room_size: int = struct.field(pytree_node=False, default=4)
 
-    def _generate_layout(
+    def generate_layout(
         self, key: Array
     ) -> Tuple[Array, Array, Array, Array, Array]:
         """One attempt at placing all `num_rooms` rooms - a pure
         function of `key`, returning fixed-shape stacked arrays (not
-        the growing Python lists `_place_room`'s own docstring
+        the growing Python lists `place_room`'s own docstring
         describes - those are fine *within* one room's placement,
         where the call site's list length is static per room index,
         but this function's *own* output must be a single fixed-shape
         value so `_reset` can retry it whole via `jax.lax.while_loop`).
         The last return value is `all_valid`: whether every room
-        actually found a legal placement (see `_place_room`'s
+        actually found a legal placement (see `place_room`'s
         docstring on why a single room's own retry can't always
         salvage a bad earlier choice) - `_reset` restarts this whole
         function with a fresh key when it's `False`, rather than ever
@@ -380,7 +394,7 @@ class MultiRoom(Environment):
             key, k_door, k_place, k_exit_offset, k_colour = jax.random.split(key, 5)
             prev_top, prev_size, prev_exit_wall = tops[-1], sizes[-1], exit_walls[-1]
 
-            door_pos = _exit_door_position(prev_exit_wall, k_door, prev_top, prev_size)
+            door_pos = exit_door_position(prev_exit_wall, k_door, prev_top, prev_size)
             door_positions.append(door_pos)
 
             if door_colours:
@@ -388,7 +402,7 @@ class MultiRoom(Environment):
                 # previous door's - matches MiniGrid's own "exclude
                 # the previous door's colour" rule. Adding a random
                 # nonzero offset mod 6 always lands on one of the
-                # other 5, uniformly - same trick `_place_room`'s
+                # other 5, uniformly - same trick `place_room`'s
                 # exit-wall selection uses for "exclude one value".
                 offset = jax.random.randint(k_colour, (), 1, 6)
                 colour = (door_colours[-1] + offset) % 6
@@ -397,7 +411,7 @@ class MultiRoom(Environment):
             door_colours.append(colour)
 
             entry_wall = (prev_exit_wall + 2) % 4
-            top, size, found = _place_room(
+            top, size, found = place_room(
                 k_place, entry_wall, door_pos, MIN_ROOM_SIZE, size_max, tops, sizes
             )
             tops.append(top)
@@ -425,12 +439,12 @@ class MultiRoom(Environment):
 
         def body_fn(carry):
             key, attempt, _, *_ = carry
-            tops, sizes, door_positions, door_colours, valid = self._generate_layout(
+            tops, sizes, door_positions, door_colours, valid = self.generate_layout(
                 jax.random.fold_in(key, attempt)
             )
             return key, attempt + 1, valid, tops, sizes, door_positions, door_colours
 
-        init_tops, init_sizes, init_doors, init_colours, init_valid = self._generate_layout(
+        init_tops, init_sizes, init_doors, init_colours, init_valid = self.generate_layout(
             jax.random.fold_in(k_layout, 0)
         )
         _, _, valid, tops, sizes, door_positions, door_colours = jax.lax.while_loop(
@@ -443,7 +457,7 @@ class MultiRoom(Environment):
         # where random search never found a valid layout - fall back to
         # a deterministic straight chain, guaranteed valid by
         # construction, rather than ever using a broken one
-        fallback_tops, fallback_sizes, fallback_doors, fallback_colours = _fallback_layout(
+        fallback_tops, fallback_sizes, fallback_doors, fallback_colours = fallback_layout(
             jax.random.fold_in(k_layout, MAX_LAYOUT_RESTARTS), n
         )
         tops = jnp.where(valid, tops, fallback_tops)
@@ -511,7 +525,7 @@ class MultiRoom(Environment):
         )
 
 
-def _register_multi_room(env_id: str, num_rooms: int, max_room_size: int) -> None:
+def register_multi_room(env_id: str, num_rooms: int, max_room_size: int) -> None:
     register_env(
         env_id,
         lambda *args, **kwargs: MultiRoom.create(
@@ -529,11 +543,11 @@ def _register_multi_room(env_id: str, num_rooms: int, max_room_size: int) -> Non
     )
 
 
-_register_multi_room("Navix-MultiRoom-N2-S4-v0", num_rooms=2, max_room_size=4)
+register_multi_room("Navix-MultiRoom-N2-S4-v0", num_rooms=2, max_room_size=4)
 # MiniGrid's own MultiRoom-N4-S5-v0 is a documented legacy bug (kept
 # "for backwards compatibility") - it actually uses 6 rooms, not 4;
 # MiniGrid's own -v1 fixes this to the 4 its name promises. Per this
 # session's v1-becomes-v0 convention, navix implements the fix
 # (4 rooms) under the plain -v0 navix id.
-_register_multi_room("Navix-MultiRoom-N4-S5-v0", num_rooms=4, max_room_size=5)
-_register_multi_room("Navix-MultiRoom-N6-v0", num_rooms=6, max_room_size=10)
+register_multi_room("Navix-MultiRoom-N4-S5-v0", num_rooms=4, max_room_size=5)
+register_multi_room("Navix-MultiRoom-N6-v0", num_rooms=6, max_room_size=10)

--- a/navix/environments/multi_room.py
+++ b/navix/environments/multi_room.py
@@ -1,0 +1,539 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`MultiRoom` (issue #182): a chain of `num_rooms` randomly-sized,
+randomly-positioned rooms, each connected to the next by an unlocked
+`Door`, winding through the grid in a genuinely random 2D path - a
+`Goal` sits in the last room.
+
+MiniGrid's own generation algorithm is retry/backtrack-based: it
+repeatedly tries a random room placement and rejects it (retrying with
+a new random size/position, up to 8 attempts) if it overlaps an
+already-placed room or falls outside the grid. That's inherently
+data-dependent, unbounded control flow - doesn't trace under JAX the
+way every other navix environment's generation does. This file keeps
+the same *algorithm* (bounded to a fixed number of retries per room,
+`jax.lax.while_loop` instead of Python recursion) rather than
+approximating it with an easier-but-different generation scheme -
+verified end to end against MiniGrid's actual `_placeRoom`/`_gen_grid`
+(the four wall-relative positioning formulas, the entry/exit wall
+bookkeeping, the retry count).
+
+Faithful to MiniGrid in one more respect worth flagging plainly:
+`Navix-MultiRoom-N6-v0` uses a 25x25 grid (matching MiniGrid's own
+fixed default, used for every registration regardless of room count/
+size - its retry logic is what keeps a random layout compact enough to
+fit that grid, not a smaller canvas). 625 cells is the biggest grid in
+navix by a wide margin (`ObstructedMaze`'s `Full` is 16x16 = 256), and
+every per-step operation in this codebase scans the whole grid/entity
+set - so `N6` is genuinely, permanently more expensive to run than any
+other navix environment, not just slower to compile. Kept anyway,
+deliberately, for fidelity - see this session's own discussion on
+issue #182 for the (rejected) cheaper alternative (a straight room
+chain) and the actual cost numbers."""
+
+from __future__ import annotations
+from typing import List, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+from flax import struct
+
+from navix import observations, rewards, terminations
+
+from ..components import EMPTY_POCKET_ID
+from ..entities import Door, Entities, Goal, Player
+from ..states import State
+from ..grid import coordinates, open_wall, random_colour, random_directions, random_positions
+from ..rendering.cache import RenderingCache
+from .environment import Environment, Timestep
+from .registry import register_env
+
+
+GRID_SIZE = 25  # fixed for every registration, matching MiniGrid's own
+MIN_ROOM_SIZE = 4  # matches MiniGrid's hardcoded minSz
+BOUNDARY_MARGIN = MIN_ROOM_SIZE - 1  # see _place_room's docstring
+MAX_PLACEMENT_TRIES = 64  # MiniGrid itself retries only 8 times per room,
+# but a JAX retry (one more jax.lax.while_loop iteration, already-compiled)
+# has essentially none of the real cost a Python-level retry does - bumped
+# well past MiniGrid's own budget since 8 measurably wasn't enough for
+# Navix-MultiRoom-N6-v0's tight packing (6 rooms up to 10x10 in a 25x25
+# grid).
+MAX_LAYOUT_RESTARTS = 32  # a single room's own retry (MAX_PLACEMENT_TRIES,
+# BOUNDARY_MARGIN) still can't always salvage a bad *earlier* room's
+# choice - MiniGrid's true backtracking can reconsider previous rooms,
+# a single room's retry loop structurally can't (see _place_room's
+# docstring). Confirmed necessary directly: even with the above two,
+# Navix-MultiRoom-N6-v0 PRNGKey(2) still exhausted every retry (room
+# 3's door only 4 cells from an edge - no legal room 4 size fits).
+#
+# 32 was chosen empirically, not just "generously rounded up": pushing
+# this much higher (96, then 256) measurably made Navix-MultiRoom-N6-v0
+# *harder to even compile* on the real (shared, heavily-loaded)
+# machines used for this environment's own development-time
+# verification - not a hypothetical concern, repeatedly reproduced.
+# At 32, N6's own real success rate is ~90% (3/28 sampled seeds still
+# exhausted every restart) - good, not perfect, so a guaranteed-valid
+# deterministic fallback (see _reset) covers the remainder instead of
+# chasing a higher ceiling that's already shown real compile cost.
+# _generate_layout reports failure honestly instead of silently
+# returning an invalid layout (which previously manifested as e.g. the
+# goal defaulting to a wall corner, position (0,0)), and _reset
+# restarts the *entire* room chain from scratch with a fresh key,
+# rather than trying to locally patch just the one room that failed.
+
+
+def _room_top_left_east(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
+    # entered via the new room's own EAST wall -> room extends west
+    top_col = entry_col - size_w + 1
+    # MiniGrid samples the perpendicular offset from a half-open range
+    # `[entry - size + 2, entry)`, deliberately EXCLUDING `entry`
+    # itself - landing there would put the door on the new room's own
+    # north/south wall too (a corner), cutting it off from the room's
+    # interior instead of sitting on a proper interior-adjacent cell
+    # of the shared wall. `jax.random.randint`'s `high` is exclusive
+    # already, so `high=entry_row` (not `entry_row + 1`) reproduces
+    # that range exactly - found via a real seed (N4-S5, PRNGKey(0))
+    # whose door connected to a room's exact corner instead of its
+    # interior, making the two rooms unreachable from each other.
+    top_row = jax.random.randint(key, (), entry_row - size_h + 2, entry_row)
+    return jnp.asarray([top_row, top_col])
+
+
+def _room_top_left_south(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
+    # entered via the new room's own SOUTH wall -> room extends north
+    top_row = entry_row - size_h + 1
+    # see _room_top_left_east's comment: `high` must exclude entry_col
+    top_col = jax.random.randint(key, (), entry_col - size_w + 2, entry_col)
+    return jnp.asarray([top_row, top_col])
+
+
+def _room_top_left_west(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
+    # entered via the new room's own WEST wall -> room extends east
+    top_col = entry_col
+    # see _room_top_left_east's comment: `high` must exclude entry_row
+    top_row = jax.random.randint(key, (), entry_row - size_h + 2, entry_row)
+    return jnp.asarray([top_row, top_col])
+
+
+def _room_top_left_north(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
+    # entered via the new room's own NORTH wall -> room extends south
+    top_row = entry_row
+    # see _room_top_left_east's comment: `high` must exclude entry_col
+    top_col = jax.random.randint(key, (), entry_col - size_w + 2, entry_col)
+    return jnp.asarray([top_row, top_col])
+
+
+def _room_top_left(wall: Array, key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
+    """The new room's top-left corner, positioned so its `wall` side
+    touches `(entry_row, entry_col)` and it extends away from there -
+    verified against MiniGrid's actual `_placeRoom`'s 4 wall-relative
+    formulas. `wall` is a per-episode traced value (unlike every other
+    navix room-placement helper's static `side`), hence `jax.lax.
+    switch` rather than a plain Python `if`."""
+    return jax.lax.switch(
+        wall,
+        [_room_top_left_east, _room_top_left_south, _room_top_left_west, _room_top_left_north],
+        key, entry_row, entry_col, size_h, size_w,
+    )
+
+
+def _exit_door_position_east(key: Array, top: Array, size: Array) -> Array:
+    offset = jax.random.randint(key, (), 1, size[0] - 1)
+    return jnp.asarray([top[0] + offset, top[1] + size[1] - 1])
+
+
+def _exit_door_position_south(key: Array, top: Array, size: Array) -> Array:
+    offset = jax.random.randint(key, (), 1, size[1] - 1)
+    return jnp.asarray([top[0] + size[0] - 1, top[1] + offset])
+
+
+def _exit_door_position_west(key: Array, top: Array, size: Array) -> Array:
+    offset = jax.random.randint(key, (), 1, size[0] - 1)
+    return jnp.asarray([top[0] + offset, top[1]])
+
+
+def _exit_door_position_north(key: Array, top: Array, size: Array) -> Array:
+    offset = jax.random.randint(key, (), 1, size[1] - 1)
+    return jnp.asarray([top[0], top[1] + offset])
+
+
+def _exit_door_position(wall: Array, key: Array, top: Array, size: Array) -> Array:
+    """A random position on room `top`/`size`'s `wall` side, excluding
+    the two corners (matching `grid.room_grid_door_position`'s own
+    corner-excluding convention - the same reason: a door needs a real
+    interior cell on both sides, not the room's own corner)."""
+    return jax.lax.switch(
+        wall,
+        [_exit_door_position_east, _exit_door_position_south,
+         _exit_door_position_west, _exit_door_position_north],
+        key, top, size,
+    )
+
+
+def _interiors_overlap(top_a: Array, size_a: Array, top_b: Array, size_b: Array) -> Array:
+    """Whether two rooms' *interiors* (each room's own 1-cell wall
+    border excluded) overlap. Interiors, not full bounds: two rooms
+    connected by a door are deliberately placed edge-to-edge, sharing
+    exactly the 1-cell wall between them - a full-bounds overlap test
+    would flag that legitimate adjacency as a collision. Interiors
+    never legitimately touch, so this only rejects real collisions."""
+    a_row_lo, a_row_hi = top_a[0] + 1, top_a[0] + size_a[0] - 2
+    a_col_lo, a_col_hi = top_a[1] + 1, top_a[1] + size_a[1] - 2
+    b_row_lo, b_row_hi = top_b[0] + 1, top_b[0] + size_b[0] - 2
+    b_col_lo, b_col_hi = top_b[1] + 1, top_b[1] + size_b[1] - 2
+    row_overlap = (a_row_lo <= b_row_hi) & (b_row_lo <= a_row_hi)
+    col_overlap = (a_col_lo <= b_col_hi) & (b_col_lo <= a_col_hi)
+    return row_overlap & col_overlap
+
+
+def _place_room(
+    key: Array,
+    entry_wall: Array,
+    entry_pos: Array,
+    size_min: int,
+    size_max: int,
+    existing_tops: List[Array],
+    existing_sizes: List[Array],
+) -> Tuple[Array, Array, Array]:
+    """Bounded-retry room placement - `jax.lax.while_loop`'s JAX-
+    traceable equivalent of MiniGrid's own recursive retry (up to
+    `MAX_PLACEMENT_TRIES` random `(size, position)` draws, accepting
+    the first that's in-bounds *with a margin* (see below) and doesn't
+    overlap any already-placed room). `existing_tops`/`existing_sizes`
+    are plain Python lists, not padded arrays - safe here because the
+    outer room-by-room loop in `_reset`/`_generate_layout` is itself a
+    static Python `for` (room count is a registration-time constant),
+    so each call site's list length is static, same as
+    `ObstructedMazeFull`'s own `door_positions` accumulation.
+
+    `BOUNDARY_MARGIN` keeps every room a few cells clear of the grid
+    edges (not just the two relevant to its own entry wall), lowering
+    the odds a room lands flush against a boundary - which would make
+    the *next* room's placement out-of-bounds by construction,
+    unfixable by any amount of retrying here (confirmed directly:
+    `Navix-MultiRoom-N6-v0` `PRNGKey(1)`, before this margin existed -
+    room 3 landed at column 0, and room 4's own entry-wall formula,
+    extend further left from a door already at the boundary, can only
+    ever produce a negative column). The margin lowers the odds, but
+    doesn't eliminate them - a genuinely tight, unluckily-drawn layout
+    can still exhaust every retry (confirmed too: `PRNGKey(2)` still
+    failed with the margin in place, room 3's door only 4 cells from
+    an edge, too tight for *any* legal room 4 size to fit). That's
+    what `found` (the third return value) is for: MiniGrid's true
+    retry backtracks across multiple rooms when a placement can't be
+    salvaged locally, which a single room's own retry loop structurally
+    can't replicate - so on total failure here, this function reports
+    it honestly instead of silently returning an invalid placement,
+    and `_generate_layout`'s own outer retry restarts the *entire*
+    chain with a fresh key instead - the closest JAX-traceable
+    equivalent of "back up and reconsider an earlier choice", since
+    which earlier room to blame isn't something this function can
+    know from inside a single room's own placement attempt."""
+    entry_row, entry_col = entry_pos[0], entry_pos[1]
+
+    def cond_fn(carry):
+        _, attempt, found, _, _ = carry
+        return jnp.logical_and(attempt < MAX_PLACEMENT_TRIES, jnp.logical_not(found))
+
+    def body_fn(carry):
+        key, attempt, _, _, _ = carry
+        key, k_h, k_w, k_pos = jax.random.split(key, 4)
+        size_h = jax.random.randint(k_h, (), size_min, size_max + 1)
+        size_w = jax.random.randint(k_w, (), size_min, size_max + 1)
+        top = _room_top_left(entry_wall, k_pos, entry_row, entry_col, size_h, size_w)
+        size = jnp.asarray([size_h, size_w])
+        in_bounds = (
+            (top[0] >= BOUNDARY_MARGIN)
+            & (top[1] >= BOUNDARY_MARGIN)
+            & (top[0] + size[0] <= GRID_SIZE - BOUNDARY_MARGIN)
+            & (top[1] + size[1] <= GRID_SIZE - BOUNDARY_MARGIN)
+        )
+        no_overlap = jnp.asarray(True)
+        for other_top, other_size in zip(existing_tops, existing_sizes):
+            no_overlap = no_overlap & jnp.logical_not(
+                _interiors_overlap(top, size, other_top, other_size)
+            )
+        valid = in_bounds & no_overlap
+        return key, attempt + 1, valid, top, size
+
+    init = (
+        key,
+        jnp.asarray(0),
+        jnp.asarray(False),
+        jnp.zeros(2, dtype=jnp.int32),
+        jnp.zeros(2, dtype=jnp.int32),
+    )
+    _, _, found, top, size = jax.lax.while_loop(cond_fn, body_fn, init)
+    return top, size, found
+
+
+def _fallback_layout(key: Array, n: int) -> Tuple[Array, Array, Array, Array]:
+    """A deterministic straight chain of `n` minimum-size rooms,
+    centred as a whole and extending east - always valid by
+    construction (`GRID_SIZE=25` comfortably fits the *chain's total
+    span*, `MIN_ROOM_SIZE + (n-1) * (MIN_ROOM_SIZE-1)` = 19 for the
+    largest real `n=6`, for every real registration), unlike the
+    random search `_reset`'s own `jax.lax.while_loop` runs, which only
+    *usually* finds a valid layout (see `MAX_LAYOUT_RESTARTS`).
+    `_reset` uses this as the guaranteed-safe fallback for the rare
+    episode where that random search doesn't resolve within its
+    budget, rather than ever using a broken layout. Room *positions*
+    are fixed (not random) here, but door colours still are, so it
+    isn't the exact same episode every time this path is taken -
+    assumes `n >= 2` (true of every real registration; a hypothetical
+    `n=1` custom instantiation would need its own, simpler no-doors
+    handling, not provided here).
+
+    Centring the *chain's total span*, not just room 0's own position,
+    matters: consecutive rooms share one wall cell each, so the chain
+    only grows by `MIN_ROOM_SIZE - 1` per additional room, not a full
+    `MIN_ROOM_SIZE` - anchoring room 0 alone at the grid centre and
+    extending purely eastward from there runs the *last* room off the
+    grid's edge for `n=6` (confirmed directly: room 0 at column 10,
+    chain reaching column 25 - already outside the valid 0-24 range,
+    before that room's own width is even added)."""
+    size = jnp.asarray([MIN_ROOM_SIZE, MIN_ROOM_SIZE])
+    row0 = GRID_SIZE // 2 - MIN_ROOM_SIZE // 2
+    chain_width = MIN_ROOM_SIZE + (n - 1) * (MIN_ROOM_SIZE - 1)
+    col0 = (GRID_SIZE - chain_width) // 2
+
+    tops: List[Array] = [jnp.asarray([row0, col0])]
+    for i in range(1, n):
+        tops.append(tops[-1] + jnp.asarray([0, MIN_ROOM_SIZE - 1]))
+
+    door_row = row0 + 1  # a valid interior row for every room (MIN_ROOM_SIZE=4)
+    door_positions = [
+        jnp.asarray([door_row, tops[i][1] + MIN_ROOM_SIZE - 1]) for i in range(n - 1)
+    ]
+    door_colours = [random_colour(k) for k in jax.random.split(key, n - 1)]
+
+    return (
+        jnp.stack(tops),
+        jnp.stack([size] * n),
+        jnp.stack(door_positions),
+        jnp.stack(door_colours),
+    )
+
+
+class MultiRoom(Environment):
+    """See this module's own docstring for the generation algorithm
+    and the `N6` grid-size/cost note. `num_rooms`/`max_room_size` are
+    static (`pytree_node=False`) - each registration gets its own
+    traced generation graph, same convention as every other navix
+    environment's structural parameters."""
+
+    num_rooms: int = struct.field(pytree_node=False, default=2)
+    max_room_size: int = struct.field(pytree_node=False, default=4)
+
+    def _generate_layout(
+        self, key: Array
+    ) -> Tuple[Array, Array, Array, Array, Array]:
+        """One attempt at placing all `num_rooms` rooms - a pure
+        function of `key`, returning fixed-shape stacked arrays (not
+        the growing Python lists `_place_room`'s own docstring
+        describes - those are fine *within* one room's placement,
+        where the call site's list length is static per room index,
+        but this function's *own* output must be a single fixed-shape
+        value so `_reset` can retry it whole via `jax.lax.while_loop`).
+        The last return value is `all_valid`: whether every room
+        actually found a legal placement (see `_place_room`'s
+        docstring on why a single room's own retry can't always
+        salvage a bad earlier choice) - `_reset` restarts this whole
+        function with a fresh key when it's `False`, rather than ever
+        using a layout that silently contains an invalid room."""
+        n = self.num_rooms
+        size_max = self.max_room_size
+
+        key, k_size_h, k_size_w, k_wall = jax.random.split(key, 4)
+        size0_h = jax.random.randint(k_size_h, (), MIN_ROOM_SIZE, size_max + 1)
+        size0_w = jax.random.randint(k_size_w, (), MIN_ROOM_SIZE, size_max + 1)
+        top0 = jnp.asarray([GRID_SIZE // 2 - size0_h // 2, GRID_SIZE // 2 - size0_w // 2])
+        size0 = jnp.asarray([size0_h, size0_w])
+        exit_wall0 = jax.random.randint(k_wall, (), 0, 4)
+
+        tops: List[Array] = [top0]
+        sizes: List[Array] = [size0]
+        exit_walls: List[Array] = [exit_wall0]
+        door_positions: List[Array] = []
+        door_colours: List[Array] = []
+        all_valid = jnp.asarray(True)
+
+        for _ in range(1, n):
+            key, k_door, k_place, k_exit_offset, k_colour = jax.random.split(key, 5)
+            prev_top, prev_size, prev_exit_wall = tops[-1], sizes[-1], exit_walls[-1]
+
+            door_pos = _exit_door_position(prev_exit_wall, k_door, prev_top, prev_size)
+            door_positions.append(door_pos)
+
+            if door_colours:
+                # a random colour distinct from the immediately
+                # previous door's - matches MiniGrid's own "exclude
+                # the previous door's colour" rule. Adding a random
+                # nonzero offset mod 6 always lands on one of the
+                # other 5, uniformly - same trick `_place_room`'s
+                # exit-wall selection uses for "exclude one value".
+                offset = jax.random.randint(k_colour, (), 1, 6)
+                colour = (door_colours[-1] + offset) % 6
+            else:
+                colour = random_colour(k_colour)
+            door_colours.append(colour)
+
+            entry_wall = (prev_exit_wall + 2) % 4
+            top, size, found = _place_room(
+                k_place, entry_wall, door_pos, MIN_ROOM_SIZE, size_max, tops, sizes
+            )
+            tops.append(top)
+            sizes.append(size)
+            all_valid = all_valid & found
+
+            exit_offset = jax.random.randint(k_exit_offset, (), 1, 4)
+            exit_walls.append((entry_wall + exit_offset) % 4)
+
+        return (
+            jnp.stack(tops),
+            jnp.stack(sizes),
+            jnp.stack(door_positions),
+            jnp.stack(door_colours),
+            all_valid,
+        )
+
+    def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
+        n = self.num_rooms
+        key, k_layout, k_player_pos, k_player_dir, k_goal = jax.random.split(key, 5)
+
+        def cond_fn(carry):
+            _, attempt, valid, *_ = carry
+            return jnp.logical_and(attempt < MAX_LAYOUT_RESTARTS, jnp.logical_not(valid))
+
+        def body_fn(carry):
+            key, attempt, _, *_ = carry
+            tops, sizes, door_positions, door_colours, valid = self._generate_layout(
+                jax.random.fold_in(key, attempt)
+            )
+            return key, attempt + 1, valid, tops, sizes, door_positions, door_colours
+
+        init_tops, init_sizes, init_doors, init_colours, init_valid = self._generate_layout(
+            jax.random.fold_in(k_layout, 0)
+        )
+        _, _, valid, tops, sizes, door_positions, door_colours = jax.lax.while_loop(
+            cond_fn,
+            body_fn,
+            (k_layout, jnp.asarray(1), init_valid, init_tops, init_sizes, init_doors, init_colours),
+        )
+
+        # the rare (~10% at this ceiling, see MAX_LAYOUT_RESTARTS) case
+        # where random search never found a valid layout - fall back to
+        # a deterministic straight chain, guaranteed valid by
+        # construction, rather than ever using a broken one
+        fallback_tops, fallback_sizes, fallback_doors, fallback_colours = _fallback_layout(
+            jax.random.fold_in(k_layout, MAX_LAYOUT_RESTARTS), n
+        )
+        tops = jnp.where(valid, tops, fallback_tops)
+        sizes = jnp.where(valid, sizes, fallback_sizes)
+        door_positions = jnp.where(valid, door_positions, fallback_doors)
+        door_colours = jnp.where(valid, door_colours, fallback_colours)
+
+        # carve every room's interior to floor (the 1-cell borders
+        # in between stay wall, punched through only at door cells)
+        rows, cols = coordinates(jnp.zeros((GRID_SIZE, GRID_SIZE), dtype=jnp.int32))
+        is_floor = jnp.zeros((GRID_SIZE, GRID_SIZE), dtype=jnp.bool_)
+        room_floor_masks: List[Array] = []
+        for top, size in zip(tops, sizes):
+            room_floor = (
+                (rows >= top[0] + 1)
+                & (rows <= top[0] + size[0] - 2)
+                & (cols >= top[1] + 1)
+                & (cols <= top[1] + size[1] - 2)
+            )
+            room_floor_masks.append(room_floor)
+            is_floor = is_floor | room_floor
+        grid = jnp.where(is_floor, 0, -1).astype(jnp.int32)
+        for door_pos in door_positions:
+            grid = open_wall(grid, door_pos)
+
+        doors = Door.create(
+            position=door_positions,
+            requires=jnp.full((n - 1,), -1),
+            colour=door_colours.astype(jnp.uint8),
+            open=jnp.zeros(n - 1, dtype=jnp.bool_),
+        )
+
+        first_room_floor = jnp.where(room_floor_masks[0], 0, -1)
+        player_pos = random_positions(k_player_pos, first_room_floor)
+        player = Player.create(
+            position=player_pos,
+            direction=random_directions(k_player_dir),
+            pocket=EMPTY_POCKET_ID,
+        )
+
+        last_room_floor = jnp.where(room_floor_masks[-1], 0, -1)
+        goal_pos = random_positions(k_goal, last_room_floor)
+        goal = Goal.create(position=goal_pos, probability=jnp.asarray(1.0))
+
+        entities = {
+            Entities.PLAYER: player[None],
+            Entities.DOOR: doors,
+            Entities.GOAL: goal[None],
+        }
+
+        state = State(
+            key=key,
+            grid=grid,
+            cache=cache or RenderingCache.init(grid),
+            entities=entities,
+        )
+
+        return Timestep(
+            t=jnp.asarray(0, dtype=jnp.int32),
+            observation=self.observation_fn(state),
+            action=jnp.asarray(0, dtype=jnp.int32),
+            reward=jnp.asarray(0.0, dtype=jnp.float32),
+            step_type=jnp.asarray(0, dtype=jnp.int32),
+            state=state,
+        )
+
+
+def _register_multi_room(env_id: str, num_rooms: int, max_room_size: int) -> None:
+    register_env(
+        env_id,
+        lambda *args, **kwargs: MultiRoom.create(
+            height=GRID_SIZE,
+            width=GRID_SIZE,
+            num_rooms=num_rooms,
+            max_room_size=max_room_size,
+            max_steps=kwargs.pop("max_steps", num_rooms * 20),
+            observation_fn=kwargs.pop("observation_fn", observations.symbolic),
+            reward_fn=kwargs.pop("reward_fn", rewards.DEFAULT_TASK),
+            termination_fn=kwargs.pop("termination_fn", terminations.DEFAULT_TERMINATION),
+            *args,
+            **kwargs,
+        ),
+    )
+
+
+_register_multi_room("Navix-MultiRoom-N2-S4-v0", num_rooms=2, max_room_size=4)
+# MiniGrid's own MultiRoom-N4-S5-v0 is a documented legacy bug (kept
+# "for backwards compatibility") - it actually uses 6 rooms, not 4;
+# MiniGrid's own -v1 fixes this to the 4 its name promises. Per this
+# session's v1-becomes-v0 convention, navix implements the fix
+# (4 rooms) under the plain -v0 navix id.
+_register_multi_room("Navix-MultiRoom-N4-S5-v0", num_rooms=4, max_room_size=5)
+_register_multi_room("Navix-MultiRoom-N6-v0", num_rooms=6, max_room_size=10)

--- a/tests/test_multi_room.py
+++ b/tests/test_multi_room.py
@@ -42,6 +42,7 @@ import numpy as np
 
 import navix as nx
 from navix.entities import Entities
+from navix.environments import multi_room
 
 
 EAST, SOUTH, WEST, NORTH = 0, 1, 2, 3
@@ -173,37 +174,121 @@ def bfs_navigate_adjacent_and_face_via_step(step_fn, timestep, target_row: int, 
     raise AssertionError(f"no reachable approach cell for target {target}")
 
 
+def assert_valid_multi_room_state(state, n: int, where: str):
+    assert state.grid.shape == (25, 25), f"{where}: grid must be 25x25"
+
+    doors = state.get_doors()
+    assert doors.position.shape[0] == n - 1, where
+    assert not bool(np.asarray(doors.open).any()), f"{where}: doors must start closed"
+    assert bool((np.asarray(doors.requires) == -1).all()), f"{where}: doors are unlocked"
+
+    player = state.get_player()
+    goal = state.get_goals()
+    grid = np.asarray(state.grid)
+    assert int(grid[player.position[0], player.position[1]]) == 0, f"{where}: player not on floor"
+    assert int(grid[goal.position[0, 0], goal.position[0, 1]]) == 0, (
+        f"{where}: goal not on floor (this exact failure mode - a degenerate room "
+        f"whose 'floor' carves to nothing - is what fallback_layout exists to "
+        f"prevent; see multi_room.py)"
+    )
+
+    # every door cell must itself be real floor (punched through
+    # the wall, not left as an orphaned -1)
+    for row, col in np.asarray(doors.position):
+        assert int(grid[row, col]) == 0, f"{where}: door at ({row},{col}) not floor"
+
+    # every door must actually be reachable from the room before it and
+    # the room after it - the exact class of bug a purely
+    # bounds/overlap-based check (the assertions above) can miss: a
+    # door landing on a room's own corner instead of its interior
+    # passes every check above but disconnects the two rooms it's
+    # supposed to join (found via direct tracing on Navix-MultiRoom-
+    # N4-S5-v0, PRNGKey(0) - see multi_room.py's _room_top_left_*
+    # docstrings).
+    blocked = np.asarray(state.grid) == -1
+    for row, col in np.asarray(doors.position):
+        neighbours = [(row + 1, col), (row - 1, col), (row, col + 1), (row, col - 1)]
+        floor_neighbours = sum(
+            1
+            for r, c in neighbours
+            if 0 <= r < grid.shape[0] and 0 <= c < grid.shape[1] and not blocked[r, c]
+        )
+        assert floor_neighbours >= 2, (
+            f"{where}: door at ({row},{col}) has only {floor_neighbours} floor "
+            f"neighbour(s) - should border a room on each side"
+        )
+
+
 def test_multi_room_structure():
     for env_id in ALL_ENV_IDS:
         n = NUM_ROOMS[env_id]
         env = nx.make(env_id)
         for seed in range(N_SEEDS):
             state = env.reset(jax.random.PRNGKey(seed)).state
-            where = f"{env_id} seed={seed}"
+            assert_valid_multi_room_state(state, n, f"{env_id} seed={seed}")
 
-            assert state.grid.shape == (25, 25), f"{where}: grid must be 25x25"
 
-            doors = state.get_doors()
-            assert doors.position.shape[0] == n - 1, where
-            assert not bool(np.asarray(doors.open).any()), f"{where}: doors must start closed"
-            assert bool((np.asarray(doors.requires) == -1).all()), f"{where}: doors are unlocked"
+def test_multi_room_fallback_layout_valid():
+    """Direct unit test of `fallback_layout` itself (the exact
+    function that shipped with a real off-grid bug for larger `n` -
+    see multi_room.py), across every real registration's room count -
+    in bounds, non-overlapping, doors on real floor once carved into a
+    grid the same way `_reset` does."""
+    for n in sorted(set(NUM_ROOMS.values())):
+        tops, sizes, door_positions, _door_colours = multi_room.fallback_layout(
+            jax.random.PRNGKey(0), n
+        )
+        tops_np, sizes_np = np.asarray(tops), np.asarray(sizes)
+        where = f"n={n}"
 
-            player = state.get_player()
-            goal = state.get_goals()
-            grid = np.asarray(state.grid)
-            assert int(grid[player.position[0], player.position[1]]) == 0, (
-                f"{where}: player not on floor"
+        for i in range(n):
+            top, size = tops_np[i], sizes_np[i]
+            assert (top >= 0).all() and (top + size <= multi_room.GRID_SIZE).all(), (
+                f"{where}: room {i} out of [0, {multi_room.GRID_SIZE}) bounds "
+                f"(top={top}, size={size})"
             )
-            assert int(grid[goal.position[0, 0], goal.position[0, 1]]) == 0, (
-                f"{where}: goal not on floor (this exact failure mode - a degenerate room "
-                f"whose 'floor' carves to nothing - is what _fallback_layout exists to "
-                f"prevent; see multi_room.py)"
+
+        grid = -np.ones((multi_room.GRID_SIZE, multi_room.GRID_SIZE), dtype=np.int32)
+        for i in range(n):
+            top, size = tops_np[i], sizes_np[i]
+            grid[top[0] + 1 : top[0] + size[0] - 1, top[1] + 1 : top[1] + size[1] - 1] = 0
+        for row, col in np.asarray(door_positions):
+            grid[row, col] = 0
+
+        n_floor = int((grid == 0).sum())
+        assert n_floor > 0, f"{where}: fallback layout carves to no floor at all"
+
+        blocked = grid == -1
+        for row, col in np.asarray(door_positions):
+            neighbours = [(row + 1, col), (row - 1, col), (row, col + 1), (row, col - 1)]
+            floor_neighbours = sum(
+                1
+                for r, c in neighbours
+                if 0 <= r < grid.shape[0] and 0 <= c < grid.shape[1] and not blocked[r, c]
+            )
+            assert floor_neighbours >= 2, (
+                f"{where}: fallback door at ({row},{col}) has only {floor_neighbours} "
+                f"floor neighbour(s)"
             )
 
-            # every door cell must itself be real floor (punched through
-            # the wall, not left as an orphaned -1)
-            for row, col in np.asarray(doors.position):
-                assert int(grid[row, col]) == 0, f"{where}: door at ({row},{col}) not floor"
+
+def test_multi_room_fallback_path_forced(monkeypatch):
+    """Forces every episode's random layout search to fail (`place_
+    room` can never succeed with 0 retries), so `_reset` always falls
+    back to `fallback_layout` - exercises the `jnp.where(valid, ...,
+    fallback...)` integration path directly through a real `env.reset`
+    call, not just `fallback_layout` in isolation, per the PR review's
+    own suggestion. Room 0 itself isn't retried (see `generate_
+    layout`), so `all_valid` is forced False by every *other* room's
+    placement failing - true for every real registration (all have
+    `n >= 2`)."""
+    monkeypatch.setattr(multi_room, "MAX_PLACEMENT_TRIES", 0)
+    for env_id in ALL_ENV_IDS:
+        n = NUM_ROOMS[env_id]
+        env = nx.make(env_id)
+        for seed in range(N_SEEDS):
+            state = env.reset(jax.random.PRNGKey(seed)).state
+            assert_valid_multi_room_state(state, n, f"{env_id} seed={seed} (forced fallback)")
 
 
 def solve_multi_room(step_fn, timestep):

--- a/tests/test_multi_room.py
+++ b/tests/test_multi_room.py
@@ -1,0 +1,263 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`MultiRoom` (issue #182): structural checks against the live reset
+state (room count, in-bounds/non-overlapping rooms, valid door/player/
+goal placement) across all 3 registrations, plus a full real-gameplay
+walkthrough for `N2`/`N4` only.
+
+`Navix-MultiRoom-N6-v0` is deliberately kept to structural + jit/vmap
+checks, no real gameplay walkthrough - see `multi_room.py`'s own
+module docstring for why it's the most expensive environment in
+navix by a wide margin (a 25x25 grid, matching MiniGrid's own fixed
+default for every registration regardless of room count/size). A full
+BFS walkthrough through that maze, on top of `N6`'s own generation
+being the heaviest compile in the whole codebase, would risk exactly
+the CI cost explosion #196's OOM and #199's review both already
+flagged for smaller environments - deliberately not repeated here."""
+
+from __future__ import annotations
+
+from collections import deque
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import navix as nx
+from navix.entities import Entities
+
+
+EAST, SOUTH, WEST, NORTH = 0, 1, 2, 3
+ROTATE_CW, FORWARD, TOGGLE = 1, 2, 5
+
+N_SEEDS = 3
+GAMEPLAY_SEEDS = 2
+
+ALL_ENV_IDS = (
+    "Navix-MultiRoom-N2-S4-v0",
+    "Navix-MultiRoom-N4-S5-v0",
+    "Navix-MultiRoom-N6-v0",
+)
+# num_rooms - matches this file's own registration kwargs (N4-S5 here
+# is MiniGrid's own -v1 fix, 4 rooms - not the misleadingly-named
+# legacy -v0, which is actually 6 - see multi_room.py's registration
+# comment)
+NUM_ROOMS = {
+    "Navix-MultiRoom-N2-S4-v0": 2,
+    "Navix-MultiRoom-N4-S5-v0": 4,
+    "Navix-MultiRoom-N6-v0": 6,
+}
+GAMEPLAY_ENV_IDS = ("Navix-MultiRoom-N2-S4-v0", "Navix-MultiRoom-N4-S5-v0")
+
+
+def face_via_step(step_fn, timestep, direction: int):
+    for _ in range(4):
+        if int(timestep.state.get_player().direction) == direction:
+            return timestep
+        timestep = step_fn(timestep, jnp.asarray(ROTATE_CW))
+    raise AssertionError(f"could not face direction {direction}")
+
+
+def bfs_blocked_mask(state) -> np.ndarray:
+    blocked = np.asarray(state.grid) == -1
+    for entity_enum, entity in state.entities.items():
+        if entity_enum == Entities.PLAYER:
+            continue
+        walkable = np.asarray(entity.walkable)
+        positions = np.asarray(entity.position)
+        if positions.ndim == 1:
+            positions = positions[None]
+            walkable = walkable.reshape(1)
+        for (row, col), w in zip(positions, walkable):
+            if not w:
+                blocked[row, col] = True
+    return blocked
+
+
+def bfs_path(blocked: np.ndarray, start: tuple, goal: tuple):
+    height, width = blocked.shape
+    prev = {start: None}
+    queue = deque([start])
+    while queue:
+        current = queue.popleft()
+        if current == goal:
+            break
+        row, col = current
+        for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+            nxt = (row + dr, col + dc)
+            if (
+                0 <= nxt[0] < height
+                and 0 <= nxt[1] < width
+                and not blocked[nxt]
+                and nxt not in prev
+            ):
+                prev[nxt] = current
+                queue.append(nxt)
+    if goal not in prev:
+        return None
+    path = [goal]
+    while path[-1] != start:
+        path.append(prev[path[-1]])
+    path.reverse()
+    return path
+
+
+def bfs_direction_between(a: tuple, b: tuple) -> int:
+    dr, dc = b[0] - a[0], b[1] - a[1]
+    if dr == 1:
+        return SOUTH
+    if dr == -1:
+        return NORTH
+    if dc == 1:
+        return EAST
+    if dc == -1:
+        return WEST
+    raise AssertionError(f"{a} -> {b} is not a single orthogonal step")
+
+
+def bfs_walk_path_via_step(step_fn, timestep, path):
+    for a, b in zip(path[:-1], path[1:]):
+        timestep = face_via_step(step_fn, timestep, bfs_direction_between(a, b))
+        timestep = step_fn(timestep, jnp.asarray(FORWARD))
+    return timestep
+
+
+def bfs_navigate_adjacent_and_face_via_step(step_fn, timestep, target_row: int, target_col: int):
+    state = timestep.state
+    blocked = bfs_blocked_mask(state)
+    start = (int(state.get_player().position[0]), int(state.get_player().position[1]))
+    target = (target_row, target_col)
+    if start == target:
+        return timestep
+    # The target itself (e.g. the goal) is ordinary walkable floor in
+    # `blocked`, so a route to some *other* approach cell past it could
+    # path straight through it - stepping onto the goal cell mid-route
+    # already terminates the episode, and a subsequent step against
+    # that terminated timestep silently autoresets (this is exactly
+    # what produced the "player back at the original start position"
+    # symptom this test was chasing). Block the target cell for
+    # path-finding purposes only, so routes go around it, never
+    # through it - it's still a valid *destination* via the
+    # `candidate == start`/direct-neighbour checks below.
+    blocked_for_path = blocked.copy()
+    blocked_for_path[target] = True
+    for dr, dc in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+        candidate = (target[0] + dr, target[1] + dc)
+        if not (0 <= candidate[0] < blocked.shape[0] and 0 <= candidate[1] < blocked.shape[1]):
+            continue
+        if blocked[candidate]:
+            continue
+        if candidate == start:
+            return face_via_step(step_fn, timestep, bfs_direction_between(candidate, target))
+        path = bfs_path(blocked_for_path, start, candidate)
+        if path is not None:
+            timestep = bfs_walk_path_via_step(step_fn, timestep, path)
+            return face_via_step(step_fn, timestep, bfs_direction_between(candidate, target))
+    raise AssertionError(f"no reachable approach cell for target {target}")
+
+
+def test_multi_room_structure():
+    for env_id in ALL_ENV_IDS:
+        n = NUM_ROOMS[env_id]
+        env = nx.make(env_id)
+        for seed in range(N_SEEDS):
+            state = env.reset(jax.random.PRNGKey(seed)).state
+            where = f"{env_id} seed={seed}"
+
+            assert state.grid.shape == (25, 25), f"{where}: grid must be 25x25"
+
+            doors = state.get_doors()
+            assert doors.position.shape[0] == n - 1, where
+            assert not bool(np.asarray(doors.open).any()), f"{where}: doors must start closed"
+            assert bool((np.asarray(doors.requires) == -1).all()), f"{where}: doors are unlocked"
+
+            player = state.get_player()
+            goal = state.get_goals()
+            grid = np.asarray(state.grid)
+            assert int(grid[player.position[0], player.position[1]]) == 0, (
+                f"{where}: player not on floor"
+            )
+            assert int(grid[goal.position[0, 0], goal.position[0, 1]]) == 0, (
+                f"{where}: goal not on floor (this exact failure mode - a degenerate room "
+                f"whose 'floor' carves to nothing - is what _fallback_layout exists to "
+                f"prevent; see multi_room.py)"
+            )
+
+            # every door cell must itself be real floor (punched through
+            # the wall, not left as an orphaned -1)
+            for row, col in np.asarray(doors.position):
+                assert int(grid[row, col]) == 0, f"{where}: door at ({row},{col}) not floor"
+
+
+def solve_multi_room(step_fn, timestep):
+    """Plays a MultiRoom variant through to the goal - walk through
+    each door in order (they connect consecutive rooms 0->1->...-
+    >n-1, so opening them in door-array order is always a valid route
+    from the start room to the goal room), then to the goal itself."""
+    for door_row, door_col in np.asarray(timestep.state.get_doors().position):
+        timestep = bfs_navigate_adjacent_and_face_via_step(
+            step_fn, timestep, int(door_row), int(door_col)
+        )
+        timestep = step_fn(timestep, jnp.asarray(TOGGLE))
+        assert timestep.step_type == 0, "episode ended before reaching the goal"
+
+    goal = timestep.state.get_goals()
+    goal_row, goal_col = int(goal.position[0, 0]), int(goal.position[0, 1])
+    timestep = bfs_navigate_adjacent_and_face_via_step(step_fn, timestep, goal_row, goal_col)
+    return step_fn(timestep, jnp.asarray(FORWARD))
+
+
+def test_multi_room_gameplay_and_reward_termination():
+    for env_id in GAMEPLAY_ENV_IDS:
+        env = nx.make(env_id)
+        # `env.step` embeds a full `env.reset` as its `jax.lax.cond`
+        # autoreset branch (see `Environment.step`) - for most navix
+        # envs that's cheap, but MultiRoom's reset is a genuinely
+        # heavy nested bounded-retry search (see multi_room.py's
+        # module docstring). Called un-jitted, each top-level
+        # `env.step(...)` call retraces and recompiles that whole
+        # thing from scratch (eager `lax.cond` doesn't cache across
+        # separate Python calls the way `jax.jit` does) - a BFS walk
+        # of dozens of steps was measured to balloon to minutes of
+        # compile time and multi-GB memory before crashing with an
+        # LLVM "Cannot allocate memory" error, reproducible even on an
+        # otherwise-idle machine. Jitting once and reusing across the
+        # whole walk (the same pattern `test_multi_room_jit_vmap_
+        # compatible` already uses) avoids the retrace entirely.
+        step_fn = jax.jit(env.step)
+        for seed in range(GAMEPLAY_SEEDS):
+            timestep = env.reset(jax.random.PRNGKey(seed))
+            timestep = solve_multi_room(step_fn, timestep)
+            assert timestep.step_type == 2, (
+                f"{env_id} seed={seed}: expected termination on reaching the goal"
+            )
+            assert float(timestep.reward) > 0, f"{env_id} seed={seed}: expected positive reward"
+
+
+def test_multi_room_jit_vmap_compatible():
+    for env_id in ALL_ENV_IDS:
+        env = nx.make(env_id)
+        keys = jax.random.split(jax.random.PRNGKey(0), 4)
+        reset = jax.jit(env.reset)
+        step = jax.jit(env.step)
+        timestep = jax.vmap(reset)(keys)
+        for action in range(7):
+            timestep = jax.vmap(step, in_axes=(0, None))(timestep, jnp.asarray(action))
+        jax.block_until_ready(timestep)


### PR DESCRIPTION
Closes #182.

## Summary

Ports MiniGrid's `MultiRoomEnv`: `n` rooms chained by unlocked doors,
start in room 0, goal in room `n-1`. Registers 3 variants matching
MiniGrid's own kwargs:

- `Navix-MultiRoom-N2-S4-v0` (2 rooms, max size 4)
- `Navix-MultiRoom-N4-S5-v0` (4 rooms, max size 5 - MiniGrid's `-v1`
  kwargs; its own `-v0` is a documented legacy bug actually configured
  for 6 rooms, kept upstream for backwards compatibility - not ported
  here, per this repo's "port `v1`, name it `v0`, document the
  difference" convention)
- `Navix-MultiRoom-N6-v0` (6 rooms, max size 10)

## Why this took real design work

MiniGrid's own generation is retry/backtrack-based (`_placeRoom`, up
to 8 retries per room, unbounded chain restarts on failure) - not
directly JAX-traceable. This is kept faithful to the real algorithm
rather than approximated: bounded retry via nested
`jax.lax.while_loop` (per-room placement retry, then whole-chain
restart on failure), with a guaranteed-valid deterministic fallback
layout selected via `jnp.where` for the rare case the random search
doesn't converge within its retry budget - so the environment is
provably 100% correct by construction, not just "usually correct".

All 3 registrations use MiniGrid's own fixed 25x25 grid - its retry
logic is what keeps a random layout compact, not an adaptively-sized
canvas.

`N6` is the heaviest environment in navix by a wide margin (documented
in `multi_room.py`'s module docstring) and is deliberately excluded
from the test suite's gameplay walkthrough - structural + jit/vmap
checks only - to keep CI time bounded.

## Bugs found and fixed during verification

Both found via direct seed-by-seed tracing against `_generate_layout`'s
raw output, not guesswork:

1. **Room-to-room connectivity**: the wall-relative room-positioning
   formulas sampled the perpendicular offset from a half-open range
   that, due to `jax.random.randint`'s exclusive `high`, accidentally
   *included* the door's own coordinate - letting a door land on the
   new room's corner instead of its interior, disconnecting the two
   rooms while still passing every overlap/bounds check (so it wasn't
   caught by those). Fixed by excluding that endpoint, matching
   MiniGrid's own `[coord-size+2, coord)` range exactly.
2. **Fallback layout off-grid**: the deterministic fallback chain
   centred only its first room instead of the chain's total span,
   running the last room off the grid edge for larger room counts.

Also fixed a latent performance trap in the test's own BFS-navigation
helpers: calling `env.step` un-jitted in a loop retraces and
recompiles the *entire* autoreset-embedded reset (`Environment.step`'s
`jax.lax.cond` branch) on every call, since eager `lax.cond` doesn't
cache across separate Python calls - harmless for envs with a cheap
reset, but for `MultiRoom`'s genuinely heavy nested-retry reset this
measurably balloons to minutes of compile time and multiple GB before
the process runs out of memory. Fixed by jitting the step function
once per env and reusing it across the whole BFS walk.

## Verification

- Real `env.reset`/`env.step` execution (not just compilation) across
  seeds for all 3 registrations.
- Full BFS-navigated gameplay walkthrough (open every door, reach the
  goal, confirm termination + positive reward) for N2/N4.
- `tests/test_multi_room.py`: `3 passed` (structure, gameplay +
  reward/termination, jit/vmap) in ~2m13s.
- `mypy`/`pylint` on the changed files clean modulo pre-existing/
  unavoidable patterns already accepted elsewhere in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)