### PR TITLE
feat(agents): transformer frame-history encoder for POMDP tasks (#169), Option 1 — stored carry

### DIFF
--- a/examples/ppo_pomdp.py
+++ b/examples/ppo_pomdp.py
@@ -1,0 +1,76 @@
+"""Same `PPO` as `examples/ppo.py`, on a first-person (`pomdp`)
+observation - the only change is the encoder. A single first-person frame
+is not a Markovian observation (issue #169); `TransformerEncoder` gives
+the policy a short window of history instead, and it manages that window
+itself (as its carry), so the agent, the environment, and the observation
+function are all identical to the fully-observable case.
+"""
+
+from dataclasses import dataclass, field
+import tyro
+import numpy as np
+import jax.numpy as jnp
+import navix as nx
+from navix import observations
+from navix.agents import PPO, PPOHparams, ActorCritic, MLPEncoder, TransformerEncoder
+from navix.environments.environment import Environment
+
+
+@dataclass
+class Args:
+    project_name = "navix-examples"
+    seeds_offset: int = 0
+    n_seeds: int = 1
+    env_id: str = "Navix-DoorKey-Random-6x6-v0"
+    discount: float = 0.99
+    context: int = 4
+    """Number of frames the encoder attends over."""
+    ppo_config: PPOHparams = field(default_factory=lambda: PPOHparams(budget=5_000))
+    """Small budget - a quick usage demo, not a convergence benchmark."""
+
+
+if __name__ == "__main__":
+    args = tyro.cli(Args)
+
+    def FlattenObsWrapper(env: Environment):
+        # per-frame flatten: the encoder attends over a window of these.
+        flatten_obs_fn = lambda x: jnp.ravel(env.observation_fn(x))
+        flatten_obs_shape = (int(np.prod(env.observation_space.shape)),)
+        return env.replace(
+            observation_fn=flatten_obs_fn,
+            observation_space=env.observation_space.replace(shape=flatten_obs_shape),
+        )
+
+    env = nx.make(
+        args.env_id,
+        observation_fn=observations.symbolic_first_person,
+        gamma=args.discount,
+    )
+    env = FlattenObsWrapper(env)
+
+    def encoder() -> TransformerEncoder:
+        return TransformerEncoder(
+            frame_encoder=MLPEncoder(hidden_size=64),
+            hidden_size=64,
+            context=args.context,
+        )
+
+    agent = PPO(
+        hparams=args.ppo_config,
+        # the ONLY difference from examples/ppo.py: the encoder.
+        network=ActorCritic(
+            action_dim=len(env.action_set),
+            actor_encoder=encoder(),
+            critic_encoder=encoder(),
+        ),
+        env=env,
+    )
+
+    experiment = nx.Experiment(
+        name=args.project_name,
+        agent=agent,
+        env=env,
+        env_id=args.env_id,
+        seeds=tuple(range(args.seeds_offset, args.seeds_offset + args.n_seeds)),
+    )
+    train_state, logs = experiment.run()

--- a/navix/agents/__init__.py
+++ b/navix/agents/__init__.py
@@ -19,7 +19,16 @@
 
 
 from .ppo import PPO, PPOHparams as PPOHparams
-from .models import MLPEncoder, ConvEncoder, ActorCritic, QNetwork, QMLPEncoder, QConvEncoder
+from .models import (
+    MLPEncoder,
+    ConvEncoder,
+    TransformerBlock,
+    TransformerEncoder,
+    ActorCritic,
+    QNetwork,
+    QMLPEncoder,
+    QConvEncoder,
+)
 from .dreamer import (
     Dreamer,
     DreamerHparams as DreamerHparams,

--- a/navix/agents/__init__.py
+++ b/navix/agents/__init__.py
@@ -20,6 +20,7 @@
 
 from .ppo import PPO, PPOHparams as PPOHparams
 from .models import (
+    Encoder,
     MLPEncoder,
     ConvEncoder,
     TransformerBlock,

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -26,7 +26,7 @@ implementation (github.com/danijar/dreamerv3, dreamerv3/rssm.py and
 embodied/jax/agent.py) rather than assumed from the paper text alone:
 
   1. Symlog inputs/reconstruction (`rlax.signed_logp1`/`signed_expm1`,
-     used by the `Encoder` and `TwoHotHead` in `.models`).
+     used by the `SymlogEncoder` and `TwoHotHead` in `.models`).
   2. Categorical latents (`num_latents` independent categoricals of
      `num_classes` each, "stoch"/"classes" in the official
      implementation) with straight-through gradients and 1% "unimix" -
@@ -94,7 +94,7 @@ from .models import (
     straight_through_sample,
     categorical_kl,
     TwoHotHead,
-    Encoder,
+    SymlogEncoder,
     Decoder,
     RSSM,
     PriorNet,
@@ -257,7 +257,7 @@ class WorldModel(nn.Module):
 
     def setup(self):
         hp = self.hparams
-        self.encoder = Encoder(hp.hidden_size, hp.embed_size)
+        self.encoder = SymlogEncoder(hp.hidden_size, hp.embed_size)
         self.rssm = RSSM(hp.recurrent_size)
         self.prior = PriorNet(hp.hidden_size, hp.num_latents, hp.num_classes)
         self.post = PostNet(hp.hidden_size, hp.num_latents, hp.num_classes)
@@ -458,7 +458,7 @@ class WorldModel(nn.Module):
     ) -> Tuple[Array, Array]:
         """One environment-collection step: advances the RSSM's belief with
         the previous action, then updates it to the posterior given the new
-        observation. Encoder/RSSM/posterior are submodules bound to this
+        observation. SymlogEncoder/RSSM/posterior are submodules bound to this
         WorldModel instance, so - unlike a bare Dense/Sequential module -
         they can only be called from inside a WorldModel.apply() trace,
         which is what this method (called via `self.world.apply(...,

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -11,13 +11,14 @@ algorithms these latter components implement.
 
 ## The encoder contract (carry-based)
 
-Every PPO encoder (`MLPEncoder`, `ConvEncoder`, `TransformerEncoder`, and
-anything a caller substitutes for them) implements the same two-method
-interface, so an agent's training loop is written once and works for both
-fully- and partially-observable settings by swapping only the encoder:
+Every PPO/PQN feature extractor subclasses `Encoder` and implements the
+same two-method interface, so an agent's training loop is written once and
+works for both fully- and partially-observable settings by swapping only
+the encoder:
 
 - `initial_carry(obs_shape) -> carry` - the encoder's hidden state at an
-  episode boundary. Stateless encoders return `()`.
+  episode boundary. `Encoder`'s default is stateless (`()`); a stateful
+  encoder overrides it.
 - `__call__(carry, obs, is_first) -> (carry, features)` - consume one
   observation, emit the next carry and a feature vector. `is_first` (a
   bool, broadcast per batch element) marks `obs` as the first frame of a
@@ -25,13 +26,15 @@ fully- and partially-observable settings by swapping only the encoder:
   rather than reading history that belongs to the episode that just
   ended.
 
-Stateless encoders (`MLPEncoder`, `ConvEncoder`) carry `()` and ignore
-`is_first`: threading a carry through an agent that uses them is inert,
-and their output is identical to the pre-carry versions. `TransformerEncoder`
-is the stateful one (issue #169): its carry is a raw window of the last
-`context` frames, so a `pomdp` observation function's single-frame stream
-becomes a history-conditioned feature without the agent, the environment,
-or the observation function changing."""
+The stateless encoders (`MLPEncoder`, `ConvEncoder`, and PQN's
+`QMLPEncoder`/`QConvEncoder`) carry `()` and ignore `is_first`: threading
+a carry through an agent that uses them is inert, and their output is
+identical to the pre-carry versions. `TransformerEncoder` is the stateful
+one (issue #169): its carry is a raw window of the last `context` frames,
+so a `pomdp` observation function's single-frame stream becomes a
+history-conditioned feature without the agent, the environment, or the
+observation function changing. (Dreamer's RSSM encoder, `SymlogEncoder`,
+is a separate thing - different `__call__` shape, no carry.)"""
 
 from functools import partial
 from typing import Any, Callable, Sequence, Tuple
@@ -44,12 +47,27 @@ import flax.linen as nn
 from flax.linen.initializers import constant, orthogonal
 
 
-class MLPEncoder(nn.Module):
-    hidden_size: int = 64
+class Encoder(nn.Module):
+    """Base for the PPO/PQN feature extractors - the carry-based encoder
+    contract (see this module's docstring). Subclasses implement
 
-    def initial_carry(self, obs_shape: Sequence[int]) -> Tuple:
-        """Stateless: no history to carry between steps."""
+        __call__(carry, obs, is_first) -> (carry, features)
+
+    and, if they hold history across steps, override `initial_carry`. The
+    default here is stateless: an empty carry, so threading it through an
+    agent is inert. Not an `nn.Module` you instantiate directly."""
+
+    def initial_carry(self, obs_shape: Sequence[int]) -> Any:
+        """The carry at an episode boundary. Stateless by default (`()`);
+        `TransformerEncoder` overrides this with a zeroed frame window."""
         return ()
+
+    def __call__(self, carry: Any, obs: Array, is_first: Array):
+        raise NotImplementedError
+
+
+class MLPEncoder(Encoder):
+    hidden_size: int = 64
 
     @nn.compact
     def __call__(self, carry, x, is_first):
@@ -67,7 +85,7 @@ class MLPEncoder(nn.Module):
         return carry, features
 
 
-class ConvEncoder(nn.Module):
+class ConvEncoder(Encoder):
     """`strides=(2, 2)` on every layer, not flax's `nn.Conv` default of
     1 (full-resolution, no downsampling) - an RL rollout batch is huge
     (`num_steps * num_envs` samples backprop'd through at once), and
@@ -82,10 +100,6 @@ class ConvEncoder(nn.Module):
     instead of constant-times-growing-channels."""
 
     hidden_size: int = 64
-
-    def initial_carry(self, obs_shape: Sequence[int]) -> Tuple:
-        """Stateless: no history to carry between steps."""
-        return ()
 
     @nn.compact
     def __call__(self, carry, x, is_first):
@@ -132,7 +146,7 @@ class TransformerBlock(nn.Module):
         return x
 
 
-class TransformerEncoder(nn.Module):
+class TransformerEncoder(Encoder):
     """Issue #169: a `pomdp`-mode observation function (`rgb_first_person`/
     `categorical_first_person`/`symbolic_first_person`) returns a single
     current-step frame - no history. A lone frame doesn't disambiguate
@@ -224,8 +238,8 @@ class TransformerEncoder(nn.Module):
 
 class ActorCritic(nn.Module):
     action_dim: int
-    actor_encoder: nn.Module = MLPEncoder()
-    critic_encoder: nn.Module = MLPEncoder()
+    actor_encoder: Encoder = MLPEncoder()
+    critic_encoder: Encoder = MLPEncoder()
 
     def initial_carry(self, obs_shape: Sequence[int]) -> Any:
         """A single carry, shared by the actor and critic encoders. This

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -52,7 +52,7 @@ class MLPEncoder(nn.Module):
         return ()
 
     @nn.compact
-    def __call__(self, carry, x, is_first=None):
+    def __call__(self, carry, x, is_first):
         # Stateless: `carry` (always `()`) passes straight through and
         # `is_first` is ignored, so this is identical to the pre-carry
         # `MLPEncoder(x)` for any agent that threads a carry.
@@ -88,7 +88,7 @@ class ConvEncoder(nn.Module):
         return ()
 
     @nn.compact
-    def __call__(self, carry, x, is_first=None):
+    def __call__(self, carry, x, is_first):
         # Stateless (see `MLPEncoder.__call__`).
         features = nn.Sequential(
             [
@@ -196,8 +196,16 @@ class TransformerEncoder(nn.Module):
         fresh = jnp.broadcast_to(obs, carry.shape)
         window = jnp.where(is_first, fresh, rolled)
 
+        # `frame_encoder` follows the same encoder contract: a stateless
+        # spatial encoder, called per frame with its own blank carry and
+        # no reset flag.
+        fe_carry = self.frame_encoder.initial_carry(window.shape[1:])
+        not_first = jnp.asarray(False)
         embed = jnp.stack(
-            [self.frame_encoder((), window[t])[1] for t in range(self.context)],
+            [
+                self.frame_encoder(fe_carry, window[t], not_first)[1]
+                for t in range(self.context)
+            ],
             axis=0,
         )  # (context, hidden_size) - shared frame_encoder, one call per frame
         pos_embedding = self.param(

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -517,7 +517,7 @@ class PostNet(nn.Module):
 # -------------------------
 
 
-class QMLPEncoder(nn.Module):
+class QMLPEncoder(Encoder):
     """`QNetwork`'s default (MDP, fully-observable/flattened) feature
     extractor: Dense/LayerNorm/ReLU stacked twice. LayerNorm after every
     hidden layer is not incidental here the way it might be in `MLPEncoder`
@@ -526,12 +526,12 @@ class QMLPEncoder(nn.Module):
     (see `navix.agents.pqn`'s module docstring) - so unlike `ActorCritic`'s
     encoders, `QNetwork`'s own encoders (this and `QConvEncoder`) always
     keep it, rather than leaving it out like the shared `MLPEncoder`/
-    `ConvEncoder` do."""
+    `ConvEncoder` do. Stateless (`Encoder`'s `()` carry)."""
 
     hidden_size: int = 64
 
     @nn.compact
-    def __call__(self, x: Array) -> Array:
+    def __call__(self, carry, x, is_first):
         # navix observations can be any shape (a (H, W) grid, (H, W, 3)
         # RGB/symbolic, ...) and this is always called on one example at
         # a time (the caller vmaps over the env/batch axis - PQN never
@@ -539,8 +539,9 @@ class QMLPEncoder(nn.Module):
         # here means PQN's own env doesn't need external wrapping (e.g.
         # `examples/ppo.py`'s FlattenObsWrapper) the way PPO's does -
         # same ergonomics as Dreamer's `_flatten_obs`.
+        # Stateless: `carry` (`()`) passes through, `is_first` is ignored.
         x = jnp.ravel(x)
-        return nn.Sequential(
+        features = nn.Sequential(
             [
                 nn.Dense(
                     self.hidden_size,
@@ -558,22 +559,25 @@ class QMLPEncoder(nn.Module):
                 nn.relu,
             ]
         )(x)
+        return carry, features
 
 
-class QConvEncoder(nn.Module):
+class QConvEncoder(Encoder):
     """`QNetwork`'s POMDP (partially-observable pixel) feature extractor:
     same strided-downsampling conv stack as `ConvEncoder` (see its
     docstring for why the stride matters), projected through a Dense/
     LayerNorm/ReLU head to match `QMLPEncoder`'s regularization - PQN's
     LayerNorm-for-stability argument applies to the features `QNetwork`
     regresses Q-values from regardless of whether they came from a Dense
-    or Conv stack, so this keeps it rather than dropping it for pixels."""
+    or Conv stack, so this keeps it rather than dropping it for pixels.
+    Stateless (`Encoder`'s `()` carry)."""
 
     hidden_size: int = 64
 
     @nn.compact
-    def __call__(self, x: Array) -> Array:
-        return nn.Sequential(
+    def __call__(self, carry, x, is_first):
+        # Stateless: `carry` (`()`) passes through, `is_first` is ignored.
+        features = nn.Sequential(
             [
                 nn.Conv(16, kernel_size=(2, 2), strides=(2, 2)),
                 nn.relu,
@@ -591,29 +595,36 @@ class QConvEncoder(nn.Module):
                 nn.relu,
             ]
         )(x)
+        return carry, features
 
 
 class QNetwork(nn.Module):
     """The Q-network PQN regresses towards Q(lambda) targets - a
-    pluggable feature extractor (`encoder`, `QMLPEncoder` by default for
+    pluggable `Encoder` feature extractor (`QMLPEncoder` by default for
     MDP/flattened observations, swappable for `QConvEncoder` for POMDP/
-    pixel observations, same `actor_encoder`/`critic_encoder` pattern
-    `ActorCritic` uses) followed by a linear head over `action_dim` raw
-    Q-values (no output activation)."""
+    pixel observations, or `TransformerEncoder` for frame history - same
+    encoder-swap pattern `ActorCritic` uses) followed by a linear head
+    over `action_dim` raw Q-values (no output activation). Threads the
+    encoder carry through like `ActorCritic`."""
 
     action_dim: int
-    encoder: nn.Module = QMLPEncoder()
+    encoder: Encoder = QMLPEncoder()
+
+    def initial_carry(self, obs_shape: Sequence[int]) -> Any:
+        """The encoder's carry (`()` for the stateless Q-encoders)."""
+        return self.encoder.initial_carry(obs_shape)
 
     @nn.compact
-    def __call__(self, x: Array) -> Array:
-        x = self.encoder(x)
+    def __call__(self, carry: Any, x: Array, is_first: Array) -> Tuple[Any, Array]:
+        carry, feat = self.encoder(carry, x, is_first)
         # Unlike PPO's actor head (small-std output init) or Dreamer's
         # zero-init heads, the reference PQN implementation uses the
         # same orthogonal(sqrt(2)) init on the output layer as every
         # hidden layer - no special small-scale treatment for the
         # Q-value outputs.
-        return nn.Dense(
+        q = nn.Dense(
             self.action_dim,
             kernel_init=orthogonal(jnp.sqrt(2.0)),
             bias_init=constant(0.0),
-        )(x)  # raw Q-values, (action_dim,)
+        )(feat)  # raw Q-values, (action_dim,)
+        return carry, q

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -1,13 +1,37 @@
 """Shared neural-network building blocks used across navix's agents.
 
 Three groups live here: PPO's encoder/actor-critic components
-(`MLPEncoder`, `ConvEncoder`, `ActorCritic`), Dreamer's world-model
-components (categorical-latent utilities, the symexp-twohot head, and
-the RSSM's encoder/decoder/prior/posterior networks) - the reusable
-pieces `navix.agents.dreamer.WorldModel` wires together into an RSSM -
-and PQN's normalized Q-network (`QNetwork`). See `navix.agents.dreamer`
-and `navix.agents.pqn`'s module docstrings for the algorithms these
-latter components implement."""
+(`MLPEncoder`, `ConvEncoder`, `TransformerEncoder`, `ActorCritic`),
+Dreamer's world-model components (categorical-latent utilities, the
+symexp-twohot head, and the RSSM's encoder/decoder/prior/posterior
+networks) - the reusable pieces `navix.agents.dreamer.WorldModel` wires
+together into an RSSM - and PQN's normalized Q-network (`QNetwork`). See
+`navix.agents.dreamer` and `navix.agents.pqn`'s module docstrings for the
+algorithms these latter components implement.
+
+## The encoder contract (carry-based)
+
+Every PPO encoder (`MLPEncoder`, `ConvEncoder`, `TransformerEncoder`, and
+anything a caller substitutes for them) implements the same two-method
+interface, so an agent's training loop is written once and works for both
+fully- and partially-observable settings by swapping only the encoder:
+
+- `initial_carry(obs_shape) -> carry` - the encoder's hidden state at an
+  episode boundary. Stateless encoders return `()`.
+- `__call__(carry, obs, is_first) -> (carry, features)` - consume one
+  observation, emit the next carry and a feature vector. `is_first` (a
+  bool, broadcast per batch element) marks `obs` as the first frame of a
+  fresh episode, so a stateful encoder re-initialises its carry there
+  rather than reading history that belongs to the episode that just
+  ended.
+
+Stateless encoders (`MLPEncoder`, `ConvEncoder`) carry `()` and ignore
+`is_first`: threading a carry through an agent that uses them is inert,
+and their output is identical to the pre-carry versions. `TransformerEncoder`
+is the stateful one (issue #169): its carry is a raw window of the last
+`context` frames, so a `pomdp` observation function's single-frame stream
+becomes a history-conditioned feature without the agent, the environment,
+or the observation function changing."""
 
 from functools import partial
 from typing import Callable, Sequence, Tuple
@@ -23,9 +47,16 @@ from flax.linen.initializers import constant, orthogonal
 class MLPEncoder(nn.Module):
     hidden_size: int = 64
 
+    def initial_carry(self, obs_shape: Sequence[int]) -> Tuple:
+        """Stateless: no history to carry between steps."""
+        return ()
+
     @nn.compact
-    def __call__(self, x):
-        return nn.Sequential(
+    def __call__(self, carry, x, is_first=None):
+        # Stateless: `carry` (always `()`) passes straight through and
+        # `is_first` is ignored, so this is identical to the pre-carry
+        # `MLPEncoder(x)` for any agent that threads a carry.
+        features = nn.Sequential(
             [
                 nn.Dense(self.hidden_size),
                 nn.tanh,
@@ -33,6 +64,7 @@ class MLPEncoder(nn.Module):
                 nn.tanh,
             ]
         )(x)
+        return carry, features
 
 
 class ConvEncoder(nn.Module):
@@ -51,9 +83,14 @@ class ConvEncoder(nn.Module):
 
     hidden_size: int = 64
 
+    def initial_carry(self, obs_shape: Sequence[int]) -> Tuple:
+        """Stateless: no history to carry between steps."""
+        return ()
+
     @nn.compact
-    def __call__(self, x):
-        return nn.Sequential(
+    def __call__(self, carry, x, is_first=None):
+        # Stateless (see `MLPEncoder.__call__`).
+        features = nn.Sequential(
             [
                 nn.Conv(16, kernel_size=(2, 2), strides=(2, 2)),
                 nn.relu,
@@ -66,6 +103,115 @@ class ConvEncoder(nn.Module):
                 nn.relu,
             ]
         )(x)
+        return carry, features
+
+
+class TransformerBlock(nn.Module):
+    """One pre-LN transformer encoder block (self-attention + MLP, each
+    with a residual connection and `LayerNorm` applied *before* the
+    sub-layer, not after) - the standard modern choice (GPT-2 onwards)
+    over the original "Attention Is All You Need" post-LN block, which
+    needs a learning-rate warmup schedule to train stably; none of
+    navix's other components add one, so pre-LN avoids relying on it."""
+
+    hidden_size: int
+    num_heads: int = 4
+    mlp_ratio: int = 4
+
+    @nn.compact
+    def __call__(self, x: Array) -> Array:
+        y = nn.LayerNorm()(x)
+        y = nn.MultiHeadDotProductAttention(num_heads=self.num_heads)(y)
+        x = x + y
+
+        y = nn.LayerNorm()(x)
+        y = nn.Dense(self.hidden_size * self.mlp_ratio)(y)
+        y = nn.gelu(y)
+        y = nn.Dense(self.hidden_size)(y)
+        x = x + y
+        return x
+
+
+class TransformerEncoder(nn.Module):
+    """Issue #169: a `pomdp`-mode observation function (`rgb_first_person`/
+    `categorical_first_person`/`symbolic_first_person`) returns a single
+    current-step frame - no history. A lone frame doesn't disambiguate
+    states that look identical from the agent's current viewpoint but
+    differ in what led there (e.g. which direction something moved before
+    this frame reached it), so a policy conditioned on it only sees a
+    Markovian *approximation* of the true partially-observable state. This
+    encoder instead attends over a short window of the last `context`
+    frames, so the feature it hands to `ActorCritic` is conditioned on a
+    real (if bounded) piece of history.
+
+    History lives in the encoder's **carry**, not in the environment, the
+    observation function, or the agent's training state. The carry is the
+    literal `(context, *frame_shape)` window of the last `context` raw
+    observations, oldest first; `__call__` rolls the new `obs` in (or, on
+    `is_first`, refills the whole window with `obs` so it never reaches
+    back into the episode that just ended) and returns the updated window
+    *unchanged* as the next carry. Keeping the carry as raw frames - not
+    per-frame embeddings - is deliberate: the window then has no
+    dependence on the encoder's parameters, so an agent that stores it at
+    collection time and reuses it in its loss (rather than re-deriving it)
+    gets the exact same gradient, not an approximation.
+
+    `frame_encoder` is applied to each of the `context` frames with
+    *shared* weights (same submodule instance, called once per frame -
+    `context` is a static field, so this unrolls at trace time and
+    repeated calls reuse its parameters rather than creating `context`
+    copies). Its output must already be `hidden_size`-wide, the same
+    implicit dimension contract `ActorCritic` places on its
+    `actor_encoder`/`critic_encoder`.
+
+    A learned positional embedding is added per frame position before
+    attention (plain per-position table, not sinusoidal - the context
+    length is fixed and small). The output is the *last* token's
+    post-attention feature (the current frame, now contextualised by the
+    ones before it), not a pool over all positions, which would blur the
+    current frame's signal into older, less relevant ones."""
+
+    frame_encoder: nn.Module
+    hidden_size: int = 64
+    num_heads: int = 4
+    num_layers: int = 2
+    context: int = 4
+
+    def initial_carry(self, obs_shape: Sequence[int]) -> Array:
+        """The frame window at an episode boundary: `context` zero
+        frames. `obs_shape` is a single observation's shape (no batch
+        axis) - the caller `vmap`s `__call__` over the batch, so it
+        `vmap`s an `initial_carry`-shaped leaf the same way."""
+        return jnp.zeros((self.context, *tuple(obs_shape)), dtype=jnp.float32)
+
+    @nn.compact
+    def __call__(
+        self, carry: Array, obs: Array, is_first: Array
+    ) -> Tuple[Array, Array]:
+        # carry: (context, *frame_shape), oldest first. Roll `obs` in at
+        # the end; on a fresh episode, refill the window with `obs` so no
+        # position holds a frame from the previous episode.
+        obs = obs.astype(carry.dtype)
+        rolled = jnp.concatenate([carry[1:], obs[None]], axis=0)
+        fresh = jnp.broadcast_to(obs, carry.shape)
+        window = jnp.where(is_first, fresh, rolled)
+
+        embed = jnp.stack(
+            [self.frame_encoder((), window[t])[1] for t in range(self.context)],
+            axis=0,
+        )  # (context, hidden_size) - shared frame_encoder, one call per frame
+        pos_embedding = self.param(
+            "pos_embedding",
+            nn.initializers.normal(0.02),
+            (self.context, self.hidden_size),
+        )
+        embed = embed + pos_embedding
+        for _ in range(self.num_layers):
+            embed = TransformerBlock(
+                hidden_size=self.hidden_size, num_heads=self.num_heads
+            )(embed)
+        embed = nn.LayerNorm()(embed)
+        return window, embed[-1]  # (context, *frame), (hidden_size,)
 
 
 class ActorCritic(nn.Module):
@@ -73,35 +219,65 @@ class ActorCritic(nn.Module):
     actor_encoder: nn.Module = MLPEncoder()
     critic_encoder: nn.Module = MLPEncoder()
 
+    def initial_carry(self, obs_shape: Sequence[int]) -> Tuple:
+        """`(actor_carry, critic_carry)` - one per encoder. `()` for the
+        stateless encoders, so threading it through PPO is inert unless a
+        stateful encoder (e.g. `TransformerEncoder`) is plugged in."""
+        return (
+            self.actor_encoder.initial_carry(obs_shape),
+            self.critic_encoder.initial_carry(obs_shape),
+        )
+
     def setup(self):
+        # `layers_0` is an identity passthrough, not the encoder: the
+        # encoder is now called separately (it returns `(carry,
+        # features)`, which `nn.Sequential` can't thread). Keeping the
+        # head at `nn.Sequential` slot `layers_1` preserves its parameter
+        # path (`actor/layers_1`, `critic/layers_1`) - and therefore its
+        # init RNG - byte-for-byte against the pre-carry `ActorCritic`, so
+        # a fixed-seed run with a stateless encoder is unchanged.
         self.actor = nn.Sequential(
             [
-                self.actor_encoder,
+                lambda x: x,
                 nn.Dense(
                     self.action_dim,
                     kernel_init=orthogonal(0.01),
                     bias_init=constant(0.0),
                 ),
-                # lambda x: distrax.Categorical(logits=x),
             ]
         )
-
         self.critic = nn.Sequential(
             [
-                self.critic_encoder,
+                lambda x: x,
                 nn.Dense(1, kernel_init=orthogonal(1.0), bias_init=constant(0.0)),
-                # lambda x: jnp.squeeze(x, axis=-1),
             ]
         )
 
-    def __call__(self, x: Array) -> Tuple[distrax.Distribution, Array]:
-        return distrax.Categorical(self.actor(x)), jnp.squeeze(self.critic(x), -1)
+    def __call__(
+        self, carry: Tuple, x: Array, is_first: Array
+    ) -> Tuple[Tuple, Tuple[distrax.Distribution, Array]]:
+        actor_carry, critic_carry = carry
+        actor_carry, actor_feat = self.actor_encoder(actor_carry, x, is_first)
+        critic_carry, critic_feat = self.critic_encoder(critic_carry, x, is_first)
+        pi = distrax.Categorical(self.actor(actor_feat))
+        value = jnp.squeeze(self.critic(critic_feat), -1)
+        return (actor_carry, critic_carry), (pi, value)
 
-    def policy(self, x: Array) -> distrax.Distribution:
-        return distrax.Categorical(logits=self.actor(x))
+    def policy(
+        self, carry: Tuple, x: Array, is_first: Array
+    ) -> Tuple[Tuple, distrax.Distribution]:
+        actor_carry, critic_carry = carry
+        actor_carry, actor_feat = self.actor_encoder(actor_carry, x, is_first)
+        pi = distrax.Categorical(logits=self.actor(actor_feat))
+        return (actor_carry, critic_carry), pi
 
-    def value(self, x: Array) -> Array:
-        return jnp.squeeze(self.critic(x), -1)
+    def value(
+        self, carry: Tuple, x: Array, is_first: Array
+    ) -> Tuple[Tuple, Array]:
+        actor_carry, critic_carry = carry
+        critic_carry, critic_feat = self.critic_encoder(critic_carry, x, is_first)
+        value = jnp.squeeze(self.critic(critic_feat), -1)
+        return (actor_carry, critic_carry), value
 
 
 # -------------------------

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -16,9 +16,11 @@ same two-method interface, so an agent's training loop is written once and
 works for both fully- and partially-observable settings by swapping only
 the encoder:
 
-- `initial_carry(obs_shape) -> carry` - the encoder's hidden state at an
-  episode boundary. `Encoder`'s default is stateless (`()`); a stateful
-  encoder overrides it.
+- `initial_carry(obs_shape, dtype=float32) -> carry` - the encoder's
+  hidden state at an episode boundary. `Encoder`'s default is stateless
+  (`()`, ignoring both args); a stateful encoder overrides it. `dtype` is
+  the observation's own dtype, so a raw-frame carry isn't silently upcast
+  (`uint8` pixels -> `float32`).
 - `__call__(carry, obs, is_first) -> (carry, features)` - consume one
   observation, emit the next carry and a feature vector. `is_first` (a
   bool, broadcast per batch element) marks `obs` as the first frame of a
@@ -55,11 +57,25 @@ class Encoder(nn.Module):
 
     and, if they hold history across steps, override `initial_carry`. The
     default here is stateless: an empty carry, so threading it through an
-    agent is inert. Not an `nn.Module` you instantiate directly."""
+    agent is inert. Not an `nn.Module` you instantiate directly.
 
-    def initial_carry(self, obs_shape: Sequence[int]) -> Any:
-        """The carry at an episode boundary. Stateless by default (`()`);
-        `TransformerEncoder` overrides this with a zeroed frame window."""
+    The agents that store a per-step carry and replay it in their loss
+    (`PPO`, `PQN` - "Option 1") rely on the carry being a pure function of
+    the observation stream, *independent of the encoder's parameters* - as
+    `TransformerEncoder`'s raw-frame window is. An encoder whose carry is
+    a learned state (a GRU/SSM hidden state) breaks that: the stored carry
+    was produced under stale parameters, so replaying it is no longer what
+    the current network would compute. Such an encoder needs the agent to
+    recompute the carry over the sequence in the loss instead."""
+
+    def initial_carry(
+        self, obs_shape: Sequence[int], dtype: Any = jnp.float32
+    ) -> Any:
+        """The carry at an episode boundary. Stateless by default (`()`,
+        ignoring both args); `TransformerEncoder` overrides this with a
+        zeroed frame window of shape `(context, *obs_shape)` and dtype
+        `dtype` - callers pass the observation's own dtype so the window
+        isn't silently upcast (e.g. `uint8` pixels -> `float32`)."""
         return ()
 
     def __call__(self, carry: Any, obs: Array, is_first: Array):
@@ -191,33 +207,43 @@ class TransformerEncoder(Encoder):
     num_layers: int = 2
     context: int = 4
 
-    def initial_carry(self, obs_shape: Sequence[int]) -> Array:
-        """The frame window at an episode boundary: `context` zero
-        frames. `obs_shape` is a single observation's shape (no batch
-        axis) - the caller `vmap`s `__call__` over the batch, so it
-        `vmap`s an `initial_carry`-shaped leaf the same way."""
-        return jnp.zeros((self.context, *tuple(obs_shape)), dtype=jnp.float32)
+    def initial_carry(
+        self, obs_shape: Sequence[int], dtype: Any = jnp.float32
+    ) -> Array:
+        """The frame window at an episode boundary: `context` zero frames,
+        `(context, *obs_shape)`. `obs_shape` is a single observation's
+        shape (no batch axis) - the caller `vmap`s `__call__` over the
+        batch, so it `vmap`s an `initial_carry`-shaped leaf the same way.
+        `dtype` is the observation's own dtype: the window stores raw
+        frames, so keeping it (e.g. `uint8` for navix's first-person
+        pixel/symbolic observations) rather than upcasting to `float32`
+        keeps `Buffer.carry` from being `context`-frames-wide *and* 4x
+        per element."""
+        return jnp.zeros((self.context, *tuple(obs_shape)), dtype=dtype)
 
     @nn.compact
     def __call__(
         self, carry: Array, obs: Array, is_first: Array
     ) -> Tuple[Array, Array]:
-        # carry: (context, *frame_shape), oldest first. Roll `obs` in at
-        # the end; on a fresh episode, refill the window with `obs` so no
-        # position holds a frame from the previous episode.
+        # carry: (context, *frame_shape), oldest first, in the
+        # observation's own dtype. Roll `obs` in at the end; on a fresh
+        # episode, refill the window with `obs` so no position holds a
+        # frame from the previous episode.
         obs = obs.astype(carry.dtype)
         rolled = jnp.concatenate([carry[1:], obs[None]], axis=0)
         fresh = jnp.broadcast_to(obs, carry.shape)
-        window = jnp.where(is_first, fresh, rolled)
+        window = jnp.where(is_first, fresh, rolled)  # next carry, obs dtype
 
         # `frame_encoder` follows the same encoder contract: a stateless
         # spatial encoder, called per frame with its own blank carry and
-        # no reset flag.
-        fe_carry = self.frame_encoder.initial_carry(window.shape[1:])
+        # no reset flag. Cast to float here (not in the stored window) so
+        # `nn.Dense`/`nn.Conv` see floats without widening what's buffered.
+        frames = window.astype(jnp.float32)
+        fe_carry = self.frame_encoder.initial_carry(frames.shape[1:])
         not_first = jnp.asarray(False)
         embed = jnp.stack(
             [
-                self.frame_encoder(fe_carry, window[t], not_first)[1]
+                self.frame_encoder(fe_carry, frames[t], not_first)[1]
                 for t in range(self.context)
             ],
             axis=0,
@@ -241,7 +267,9 @@ class ActorCritic(nn.Module):
     actor_encoder: Encoder = MLPEncoder()
     critic_encoder: Encoder = MLPEncoder()
 
-    def initial_carry(self, obs_shape: Sequence[int]) -> Any:
+    def initial_carry(
+        self, obs_shape: Sequence[int], dtype: Any = jnp.float32
+    ) -> Any:
         """A single carry, shared by the actor and critic encoders. This
         assumes the two encoders derive their carry the same way from the
         same observation stream - true for the encoders here (a stateless
@@ -250,8 +278,24 @@ class ActorCritic(nn.Module):
         advancing it once per step is correct and avoids the actor's and
         critic's windows drifting apart when only one of `policy`/`value`
         runs (as in `PPO.collect_experience`, which calls `policy` only).
-        `()` for the stateless encoders."""
-        return self.actor_encoder.initial_carry(obs_shape)
+        `()` for the stateless encoders.
+
+        Raises `ValueError` if the actor and critic encoders don't agree
+        on the carry (e.g. a stateless actor with a stateful critic, or
+        two `TransformerEncoder`s with different `context`) - otherwise
+        the mismatch only surfaces as an opaque shape error deep in a
+        later `.apply()` trace."""
+        actor_carry = self.actor_encoder.initial_carry(obs_shape, dtype)
+        critic_carry = self.critic_encoder.initial_carry(obs_shape, dtype)
+        a_shapes = [x.shape for x in jax.tree_util.tree_leaves(actor_carry)]
+        c_shapes = [x.shape for x in jax.tree_util.tree_leaves(critic_carry)]
+        if a_shapes != c_shapes:
+            raise ValueError(
+                "ActorCritic threads one shared encoder carry, so "
+                "actor_encoder and critic_encoder must produce the same "
+                f"carry shape - got actor {a_shapes}, critic {c_shapes}."
+            )
+        return actor_carry
 
     def setup(self):
         # `layers_0` is an identity passthrough, not the encoder: the
@@ -610,9 +654,11 @@ class QNetwork(nn.Module):
     action_dim: int
     encoder: Encoder = QMLPEncoder()
 
-    def initial_carry(self, obs_shape: Sequence[int]) -> Any:
+    def initial_carry(
+        self, obs_shape: Sequence[int], dtype: Any = jnp.float32
+    ) -> Any:
         """The encoder's carry (`()` for the stateless Q-encoders)."""
-        return self.encoder.initial_carry(obs_shape)
+        return self.encoder.initial_carry(obs_shape, dtype)
 
     @nn.compact
     def __call__(self, carry: Any, x: Array, is_first: Array) -> Tuple[Any, Array]:

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -34,7 +34,7 @@ becomes a history-conditioned feature without the agent, the environment,
 or the observation function changing."""
 
 from functools import partial
-from typing import Callable, Sequence, Tuple
+from typing import Any, Callable, Sequence, Tuple
 from jax import Array
 import jax
 import jax.numpy as jnp
@@ -219,14 +219,17 @@ class ActorCritic(nn.Module):
     actor_encoder: nn.Module = MLPEncoder()
     critic_encoder: nn.Module = MLPEncoder()
 
-    def initial_carry(self, obs_shape: Sequence[int]) -> Tuple:
-        """`(actor_carry, critic_carry)` - one per encoder. `()` for the
-        stateless encoders, so threading it through PPO is inert unless a
-        stateful encoder (e.g. `TransformerEncoder`) is plugged in."""
-        return (
-            self.actor_encoder.initial_carry(obs_shape),
-            self.critic_encoder.initial_carry(obs_shape),
-        )
+    def initial_carry(self, obs_shape: Sequence[int]) -> Any:
+        """A single carry, shared by the actor and critic encoders. This
+        assumes the two encoders derive their carry the same way from the
+        same observation stream - true for the encoders here (a stateless
+        `()`, or `TransformerEncoder`'s raw-frame window, which doesn't
+        depend on the encoder's parameters) - so threading one carry and
+        advancing it once per step is correct and avoids the actor's and
+        critic's windows drifting apart when only one of `policy`/`value`
+        runs (as in `PPO.collect_experience`, which calls `policy` only).
+        `()` for the stateless encoders."""
+        return self.actor_encoder.initial_carry(obs_shape)
 
     def setup(self):
         # `layers_0` is an identity passthrough, not the encoder: the
@@ -254,30 +257,30 @@ class ActorCritic(nn.Module):
         )
 
     def __call__(
-        self, carry: Tuple, x: Array, is_first: Array
-    ) -> Tuple[Tuple, Tuple[distrax.Distribution, Array]]:
-        actor_carry, critic_carry = carry
-        actor_carry, actor_feat = self.actor_encoder(actor_carry, x, is_first)
-        critic_carry, critic_feat = self.critic_encoder(critic_carry, x, is_first)
+        self, carry: Any, x: Array, is_first: Array
+    ) -> Tuple[Any, Tuple[distrax.Distribution, Array]]:
+        # Both encoders advance the *same* carry from the same `x`; for
+        # the encoders here they produce the identical next carry, so
+        # returning the actor's is well-defined (see `initial_carry`).
+        next_carry, actor_feat = self.actor_encoder(carry, x, is_first)
+        _, critic_feat = self.critic_encoder(carry, x, is_first)
         pi = distrax.Categorical(self.actor(actor_feat))
         value = jnp.squeeze(self.critic(critic_feat), -1)
-        return (actor_carry, critic_carry), (pi, value)
+        return next_carry, (pi, value)
 
     def policy(
-        self, carry: Tuple, x: Array, is_first: Array
-    ) -> Tuple[Tuple, distrax.Distribution]:
-        actor_carry, critic_carry = carry
-        actor_carry, actor_feat = self.actor_encoder(actor_carry, x, is_first)
+        self, carry: Any, x: Array, is_first: Array
+    ) -> Tuple[Any, distrax.Distribution]:
+        next_carry, actor_feat = self.actor_encoder(carry, x, is_first)
         pi = distrax.Categorical(logits=self.actor(actor_feat))
-        return (actor_carry, critic_carry), pi
+        return next_carry, pi
 
     def value(
-        self, carry: Tuple, x: Array, is_first: Array
-    ) -> Tuple[Tuple, Array]:
-        actor_carry, critic_carry = carry
-        critic_carry, critic_feat = self.critic_encoder(critic_carry, x, is_first)
+        self, carry: Any, x: Array, is_first: Array
+    ) -> Tuple[Any, Array]:
+        next_carry, critic_feat = self.critic_encoder(carry, x, is_first)
         value = jnp.squeeze(self.critic(critic_feat), -1)
-        return (actor_carry, critic_carry), value
+        return next_carry, value
 
 
 # -------------------------

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -396,7 +396,13 @@ class TwoHotHead(nn.Module):
 # -------------------------
 
 
-class Encoder(nn.Module):
+class SymlogEncoder(nn.Module):
+    """Dreamer's RSSM observation encoder: a symlog-input MLP mapping a
+    raw observation to a `embed_size` embedding for the posterior. Named
+    for its distinctive `rlax.signed_logp1` (symlog) input transform -
+    not part of the PPO/PQN `Encoder` carry-contract family above (it has
+    a different `__call__` shape and no carry)."""
+
     hidden_size: int
     embed_size: int
 

--- a/navix/agents/ppo.py
+++ b/navix/agents/ppo.py
@@ -344,7 +344,7 @@ class PPO(Agent):
         # INIT NETWORK
         rng, _rng = jax.random.split(rng)
         init_x = self.env.observation_space.sample(_rng)
-        carry_single = self.network.initial_carry(init_x.shape)
+        carry_single = self.network.initial_carry(init_x.shape, init_x.dtype)
         params = self.network.init(_rng, carry_single, init_x, jnp.asarray(False))
 
         def linear_schedule(count):

--- a/navix/agents/ppo.py
+++ b/navix/agents/ppo.py
@@ -3,7 +3,7 @@
 # which is in turn inspired by:
 # https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo.py
 from functools import partial
-from typing import Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Tuple
 
 import distrax
 import jax
@@ -55,6 +55,15 @@ class PPOHparams(HParams):
 
 
 class Buffer(struct.PyTreeNode):
+    carry: Any
+    """The encoder carry (`navix.agents.models`' encoder contract) that
+    went *into* the network at this step - i.e. the state produced from
+    `o_{t-1}` and earlier, before `o_t` was consumed. `()` for stateless
+    encoders. For `TransformerEncoder` it's the raw `(context, *frame)`
+    window ending at `o_{t-1}`; storing it here and replaying it in
+    `ppo_loss` (rather than re-deriving the window) is exact, because the
+    window has no dependence on the encoder's parameters (see that
+    class's docstring)."""
     done: jax.Array
     action: jax.Array
     reward: jax.Array
@@ -70,10 +79,17 @@ class TrainingState(TrainState):
     rng: jax.Array
     frames: jax.Array
     epoch: jax.Array
-    policy: Callable[[Params, Array], distrax.Distribution] = struct.field(
+    carry: Any
+    """The live encoder carry for the `num_envs` running environments,
+    threaded across `collect_experience` calls the same way `env_state`
+    is; also the pre-step carry for the post-rollout bootstrap in
+    `update`. `()` for stateless encoders."""
+    policy: Callable[
+        [Params, Any, Array, Array], Tuple[Any, distrax.Distribution]
+    ] = struct.field(pytree_node=False)
+    value_fn: Callable[[Params, Any, Array, Array], Tuple[Any, Array]] = struct.field(
         pytree_node=False
     )
-    value_fn: Callable[[Params, Array], Array] = struct.field(pytree_node=False)
 
 
 class PPO(Agent):
@@ -84,18 +100,25 @@ class PPO(Agent):
         self, train_state: TrainingState
     ) -> Tuple[TrainingState, Buffer]:
         def _env_step(
-            collection_state: Tuple[Timestep, jax.Array], _
-        ) -> Tuple[Tuple[Timestep, jax.Array], Buffer]:
-            env_state, rng = collection_state
-            # SELECT ACTION
+            collection_state: Tuple[Timestep, jax.Array, Any], _
+        ) -> Tuple[Tuple[Timestep, jax.Array, Any], Buffer]:
+            env_state, rng, carry = collection_state
+            # SELECT ACTION. `is_first` (o_t is a fresh episode's first
+            # frame) is `t == 0` - deferred-autoreset-proof, unlike a
+            # shifted `done` - so a stateful encoder re-initialises its
+            # carry here instead of reading the previous episode's frames.
             rng, _rng = jax.random.split(rng)
-            pi = train_state.policy(train_state.params, env_state.observation)
+            is_first = env_state.is_start()
+            new_carry, pi = train_state.policy(
+                train_state.params, carry, env_state.observation, is_first
+            )
             action = jnp.asarray(pi.sample(seed=_rng))
             log_prob = jnp.asarray(pi.log_prob(action))
 
             # STEP ENV
             new_env_state = jax.vmap(self.env.step, in_axes=(0, 0))(env_state, action)
             transition = Buffer(
+                carry=carry,  # carry INTO o_t (pre-step) - see Buffer.carry
                 done=new_env_state.is_done(),  # done(o_{t+1})
                 action=action,  # a_t
                 reward=new_env_state.reward,  # R(o_t, a_t)
@@ -105,18 +128,22 @@ class PPO(Agent):
                 t=env_state.t,  # t
                 state=env_state.state,  # s_t
             )
-            return (new_env_state, rng), transition
+            # No explicit carry reset across the episode boundary here:
+            # the next step's `is_first` is True after autoreset, and the
+            # encoder discards a stale carry on `is_first` itself.
+            return (new_env_state, rng, new_carry), transition
 
         # collect experience and update env_state
-        (env_state, rng), experience = jax.lax.scan(
+        (env_state, rng, carry), experience = jax.lax.scan(
             _env_step,
-            (train_state.env_state, train_state.rng),
+            (train_state.env_state, train_state.rng, train_state.carry),
             None,
             self.hparams.num_steps,
         )
         train_state = train_state.replace(
             env_state=env_state,
             rng=rng,
+            carry=carry,
             frames=train_state.frames + self.hparams.num_steps * self.hparams.num_envs,
         )
         return train_state, experience
@@ -124,11 +151,13 @@ class PPO(Agent):
     def evaluate_experience(
         self, train_state: TrainingState, experience: Buffer, last_val: jax.Array
     ) -> Tuple[jax.Array, jax.Array, jax.Array]:
-        values = jnp.asarray(
-            jax.vmap(train_state.value_fn, in_axes=(None, 0))(
-                train_state.params, experience.obs
-            )
-        )  # (1:T, N)
+        _, values = jax.vmap(train_state.value_fn, in_axes=(None, 0, 0, 0))(
+            train_state.params,
+            experience.carry,
+            experience.obs,
+            experience.t == 0,
+        )
+        values = jnp.asarray(values)  # (1:T, N)
         adv = jax.vmap(
             rlax.truncated_generalized_advantage_estimation,
             in_axes=(1, 1, None, 1, None),
@@ -152,9 +181,16 @@ class PPO(Agent):
         targets: Array,
         values_old: Array,
     ):
-        # this is already vmapped over the minibatches
-        pi, value = jax.vmap(self.network.apply, in_axes=(None, 0))(
-            params, transition_batch.obs
+        # this is already vmapped over the minibatches. The carry stored
+        # at collection time is replayed as a constant (no gradient
+        # through carry production) - exact for a param-independent carry
+        # like TransformerEncoder's raw-frame window; `t == 0` reproduces
+        # the same `is_first` the behaviour policy saw.
+        _, (pi, value) = jax.vmap(self.network.apply, in_axes=(None, 0, 0, 0))(
+            params,
+            transition_batch.carry,
+            transition_batch.obs,
+            transition_batch.t == 0,
         )
         log_prob = pi.log_prob(transition_batch.action)
 
@@ -233,9 +269,12 @@ class PPO(Agent):
 
         for _ in range(self.hparams.num_epochs):
             # re-evaluate experience at every epoch as per https://arxiv.org/abs/2006.05990
-            last_val = train_state.value_fn(
-                train_state.params, train_state.env_state.observation
-            )  # boostrap
+            _, last_val = train_state.value_fn(
+                train_state.params,
+                train_state.carry,
+                train_state.env_state.observation,
+                train_state.env_state.is_start(),
+            )  # boostrap - carry is the post-rollout pre-step carry
             values, advantages, targets = self.evaluate_experience(
                 train_state, experience, last_val
             )
@@ -305,7 +344,8 @@ class PPO(Agent):
         # INIT NETWORK
         rng, _rng = jax.random.split(rng)
         init_x = self.env.observation_space.sample(_rng)
-        params = self.network.init(_rng, init_x)
+        carry_single = self.network.initial_carry(init_x.shape)
+        params = self.network.init(_rng, carry_single, init_x, jnp.asarray(False))
 
         def linear_schedule(count):
             frac = (
@@ -331,24 +371,30 @@ class PPO(Agent):
         )
         reset_rng = jax.random.split(_rng, self.hparams.num_envs)
         env_state = jax.vmap(self.env.reset)(reset_rng)
+        # One live encoder carry per parallel env (stateless -> `()`).
+        carry = jax.tree.map(
+            lambda c: jnp.broadcast_to(c, (self.hparams.num_envs, *c.shape)),
+            carry_single,
+        )
 
         # TRAIN LOOP
         num_updates = self.hparams.budget // (
             self.hparams.num_steps * self.hparams.num_envs
         )
         train_state = TrainingState.create(
-            apply_fn=jax.vmap(self.network.apply, in_axes=(None, 0)),
+            apply_fn=jax.vmap(self.network.apply, in_axes=(None, 0, 0, 0)),
             params=params,
             tx=tx,
             env_state=env_state,
             rng=rng,
+            carry=carry,
             frames=jnp.asarray(0, dtype=jnp.int32),
             epoch=jnp.asarray(0, dtype=jnp.int32),
             policy=jax.vmap(
-                partial(self.network.apply, method="policy"), in_axes=(None, 0)
+                partial(self.network.apply, method="policy"), in_axes=(None, 0, 0, 0)
             ),
             value_fn=jax.vmap(
-                partial(self.network.apply, method="value"), in_axes=(None, 0)
+                partial(self.network.apply, method="value"), in_axes=(None, 0, 0, 0)
             ),
         )
         # experiment/costs/fps and experiment/costs/wall_time are NOT set

--- a/navix/agents/pqn.py
+++ b/navix/agents/pqn.py
@@ -401,7 +401,7 @@ class PQN(Agent):
         # INIT NETWORK
         rng, _rng = jax.random.split(rng)
         init_x = self.env.observation_space.sample(_rng)
-        carry_single = self.network.initial_carry(init_x.shape)
+        carry_single = self.network.initial_carry(init_x.shape, init_x.dtype)
         params = self.network.init(_rng, carry_single, init_x, jnp.asarray(False))
 
         num_updates = self.hparams.budget // (

--- a/navix/agents/pqn.py
+++ b/navix/agents/pqn.py
@@ -102,7 +102,7 @@ same); `rejax`'s adaptation caches `Q` at the state the transition
 backward recursion. This module's `evaluate_experience` follows the
 official convention, not rejax's.
 """
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple
 
 import distrax
 import jax
@@ -162,6 +162,12 @@ class PQNHparams(HParams):
 
 
 class Buffer(struct.PyTreeNode):
+    carry: Any
+    """The encoder carry (`navix.agents.models.Encoder`) that went *into*
+    the network at this step - the pre-step state, as in
+    `navix.agents.ppo.Buffer.carry`. `()` for the stateless Q-encoders;
+    for `TransformerEncoder` it's the raw frame window, whose replay in
+    `q_loss` is exact (parameter-independent)."""
     done: jax.Array
     action: jax.Array
     reward: jax.Array
@@ -177,6 +183,10 @@ class TrainingState(TrainState):
     rng: jax.Array
     frames: jax.Array
     epoch: jax.Array
+    carry: Any
+    """The live encoder carry for the `num_envs` running envs, threaded
+    across `collect_experience` like `env_state`; also the pre-step carry
+    for the post-rollout bootstrap. `()` for the stateless Q-encoders."""
 
 
 class PQN(Agent):
@@ -195,9 +205,9 @@ class PQN(Agent):
         self, train_state: TrainingState
     ) -> Tuple[TrainingState, Buffer]:
         def _env_step(
-            collection_state: Tuple[Timestep, jax.Array, jax.Array], _
-        ) -> Tuple[Tuple[Timestep, jax.Array, jax.Array], Buffer]:
-            env_state, rng, frames = collection_state
+            collection_state: Tuple[Timestep, jax.Array, jax.Array, Any], _
+        ) -> Tuple[Tuple[Timestep, jax.Array, jax.Array, Any], Buffer]:
+            env_state, rng, frames, carry = collection_state
             frames = frames + self.hparams.num_envs
 
             # SELECT ACTION: epsilon-greedy over the online network's own
@@ -205,11 +215,14 @@ class PQN(Agent):
             # `train_state.params` the previous update just trained.
             # `distrax.EpsilonGreedy`, not `rlax.epsilon_greedy` - rlax's
             # own docstring flags that one as pending deprecation in
-            # favor of this.
+            # favor of this. `is_first` (`t == 0`) lets a stateful encoder
+            # reset its carry at an episode boundary.
             rng, _rng = jax.random.split(rng)
-            q_values = jnp.asarray(
-                train_state.apply_fn(train_state.params, env_state.observation)
+            is_first = env_state.is_start()
+            new_carry, q_values = train_state.apply_fn(
+                train_state.params, carry, env_state.observation, is_first
             )
+            q_values = jnp.asarray(q_values)
             action = jnp.asarray(
                 distrax.EpsilonGreedy(q_values, self.epsilon(frames)).sample(
                     seed=_rng
@@ -220,6 +233,7 @@ class PQN(Agent):
             # STEP ENV
             new_env_state = jax.vmap(self.env.step, in_axes=(0, 0))(env_state, action)
             transition = Buffer(
+                carry=carry,  # carry INTO o_t (pre-step) - see Buffer.carry
                 done=new_env_state.is_done(),  # done(o_{t+1})
                 action=action,  # a_t
                 reward=new_env_state.reward,  # R(o_t, a_t)
@@ -229,15 +243,22 @@ class PQN(Agent):
                 t=env_state.t,  # t
                 state=env_state.state,  # s_t
             )
-            return (new_env_state, rng, frames), transition
+            return (new_env_state, rng, frames, new_carry), transition
 
-        (env_state, rng, frames), experience = jax.lax.scan(
+        (env_state, rng, frames, carry), experience = jax.lax.scan(
             _env_step,
-            (train_state.env_state, train_state.rng, train_state.frames),
+            (
+                train_state.env_state,
+                train_state.rng,
+                train_state.frames,
+                train_state.carry,
+            ),
             None,
             self.hparams.num_steps,
         )
-        train_state = train_state.replace(env_state=env_state, rng=rng, frames=frames)
+        train_state = train_state.replace(
+            env_state=env_state, rng=rng, frames=frames, carry=carry
+        )
         return train_state, experience
 
     def evaluate_experience(
@@ -249,12 +270,13 @@ class PQN(Agent):
         (`Buffer.value`); the one bootstrap not already cached is
         `max_a Q(o_T, a)` at the post-rollout observation, under the
         same (not-yet-updated-this-round) params."""
-        last_q = jnp.asarray(
-            train_state.apply_fn(
-                train_state.params, train_state.env_state.observation
-            )
+        _, last_q = train_state.apply_fn(
+            train_state.params,
+            train_state.carry,
+            train_state.env_state.observation,
+            train_state.env_state.is_start(),
         )
-        last_val = jnp.max(last_q, axis=-1)
+        last_val = jnp.max(jnp.asarray(last_q), axis=-1)
         next_values = jnp.concatenate(
             [experience.value[1:], last_val[None]], axis=0
         )  # max_a Q(o_{t+1}, a), (T, N)
@@ -270,9 +292,16 @@ class PQN(Agent):
         transition_batch: Buffer,
         targets: Array,
     ) -> Tuple[Array, Dict]:
-        # already vmapped over the minibatch
-        q_values = jax.vmap(self.network.apply, in_axes=(None, 0))(
-            params, transition_batch.obs
+        # already vmapped over the minibatch. The carry stored at
+        # collection time is replayed as a constant (exact for a
+        # parameter-independent carry like TransformerEncoder's frame
+        # window); `t == 0` reproduces the `is_first` the behaviour
+        # policy saw.
+        _, q_values = jax.vmap(self.network.apply, in_axes=(None, 0, 0, 0))(
+            params,
+            transition_batch.carry,
+            transition_batch.obs,
+            transition_batch.t == 0,
         )
         q_taken = rlax.batched_index(q_values, transition_batch.action.astype(jnp.int32))
         # rlax.l2_loss carries the conventional 1/2 factor (its own
@@ -372,7 +401,8 @@ class PQN(Agent):
         # INIT NETWORK
         rng, _rng = jax.random.split(rng)
         init_x = self.env.observation_space.sample(_rng)
-        params = self.network.init(_rng, init_x)
+        carry_single = self.network.initial_carry(init_x.shape)
+        params = self.network.init(_rng, carry_single, init_x, jnp.asarray(False))
 
         num_updates = self.hparams.budget // (
             self.hparams.num_steps * self.hparams.num_envs
@@ -399,13 +429,19 @@ class PQN(Agent):
         rng, _rng = jax.random.split(rng)
         reset_rng = jax.random.split(_rng, self.hparams.num_envs)
         env_state = jax.vmap(self.env.reset)(reset_rng)
+        # One live encoder carry per parallel env (stateless -> `()`).
+        carry = jax.tree.map(
+            lambda c: jnp.broadcast_to(c, (self.hparams.num_envs, *c.shape)),
+            carry_single,
+        )
 
         train_state = TrainingState.create(
-            apply_fn=jax.vmap(self.network.apply, in_axes=(None, 0)),
+            apply_fn=jax.vmap(self.network.apply, in_axes=(None, 0, 0, 0)),
             params=params,
             tx=tx,
             env_state=env_state,
             rng=rng,
+            carry=carry,
             frames=jnp.asarray(0, dtype=jnp.int32),
             epoch=jnp.asarray(0, dtype=jnp.int32),
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,238 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""The carry-based encoder contract (`navix.agents.models`): every PPO
+encoder exposes `initial_carry` + `__call__(carry, obs, is_first) ->
+(carry, features)`. The stateless encoders (`MLPEncoder`, `ConvEncoder`)
+must be inert w.r.t. the carry; `TransformerEncoder` (issue #169) carries
+a rolling raw-frame window and produces a history-conditioned feature."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from navix.agents.models import (
+    MLPEncoder,
+    ConvEncoder,
+    TransformerBlock,
+    TransformerEncoder,
+    ActorCritic,
+)
+
+
+HIDDEN = 8
+CONTEXT = 4
+FRAME = (5,)
+
+
+def _transformer(**overrides) -> TransformerEncoder:
+    kwargs = dict(
+        frame_encoder=MLPEncoder(hidden_size=HIDDEN),
+        hidden_size=HIDDEN,
+        num_heads=2,
+        num_layers=2,
+        context=CONTEXT,
+    )
+    kwargs.update(overrides)
+    return TransformerEncoder(**kwargs)
+
+
+# --------------------------------------------------------------------------
+# stateless encoders: carry is `()` and threading it is a no-op
+# --------------------------------------------------------------------------
+
+
+def test_stateless_encoders_carry_is_empty_and_passes_through():
+    for enc in (MLPEncoder(hidden_size=HIDDEN), ConvEncoder(hidden_size=HIDDEN)):
+        obs = jnp.zeros((6, 6, 3)) if isinstance(enc, ConvEncoder) else jnp.zeros((10,))
+        assert enc.initial_carry(obs.shape) == ()
+        params = enc.init(jax.random.PRNGKey(0), (), obs, jnp.asarray(False))
+        carry, feats = enc.apply(params, (), obs, jnp.asarray(False))
+        assert carry == ()
+        assert feats.shape == (HIDDEN,)
+
+
+def test_stateless_encoder_output_matches_plain_sequential():
+    # the pre-carry MLPEncoder was `nn.Sequential([Dense, tanh, Dense,
+    # tanh])(x)`; the carry version must return exactly that as its
+    # feature, so a fixed-seed agent using it is unchanged.
+    enc = MLPEncoder(hidden_size=HIDDEN)
+    x = jax.random.normal(jax.random.PRNGKey(1), (10,))
+    params = enc.init(jax.random.PRNGKey(0), (), x, jnp.asarray(False))
+    _, feats = enc.apply(params, (), x, jnp.asarray(False))
+
+    d0, d1 = params["params"]["Dense_0"], params["params"]["Dense_1"]
+    h = jnp.tanh(x @ d0["kernel"] + d0["bias"])
+    h = jnp.tanh(h @ d1["kernel"] + d1["bias"])
+    assert np.allclose(feats, h, atol=1e-6)
+
+
+# --------------------------------------------------------------------------
+# TransformerBlock
+# --------------------------------------------------------------------------
+
+
+def test_transformer_block_preserves_shape():
+    block = TransformerBlock(hidden_size=HIDDEN, num_heads=2)
+    x = jax.random.normal(jax.random.PRNGKey(0), (CONTEXT, HIDDEN))
+    params = block.init(jax.random.PRNGKey(1), x)
+    assert block.apply(params, x).shape == x.shape
+
+
+# --------------------------------------------------------------------------
+# TransformerEncoder: shapes, carry contract, history sensitivity
+# --------------------------------------------------------------------------
+
+
+def test_transformer_encoder_shapes_and_carry_roundtrip():
+    enc = _transformer()
+    carry0 = enc.initial_carry(FRAME)
+    assert carry0.shape == (CONTEXT, *FRAME)
+    obs = jax.random.normal(jax.random.PRNGKey(0), FRAME)
+    params = enc.init(jax.random.PRNGKey(1), carry0, obs, jnp.asarray(False))
+    carry1, feats = enc.apply(params, carry0, obs, jnp.asarray(False))
+    assert feats.shape == (HIDDEN,)
+    assert carry1.shape == (CONTEXT, *FRAME)
+
+
+def test_transformer_encoder_is_first_refills_window():
+    # with is_first=True the incoming carry is discarded and the whole
+    # window is set to `obs`, so the feature (and next carry) must match
+    # what a zero carry would have produced.
+    enc = _transformer()
+    carry0 = enc.initial_carry(FRAME)
+    obs = jax.random.normal(jax.random.PRNGKey(0), FRAME)
+    params = enc.init(jax.random.PRNGKey(1), carry0, obs, jnp.asarray(False))
+
+    filled = jax.random.normal(jax.random.PRNGKey(2), (CONTEXT, *FRAME))
+    win_a, feat_a = enc.apply(params, filled, obs, jnp.asarray(True))
+    win_b, feat_b = enc.apply(params, carry0, obs, jnp.asarray(True))
+
+    assert np.allclose(win_a, jnp.broadcast_to(obs, win_a.shape))
+    assert np.allclose(feat_a, feat_b)
+
+
+def test_transformer_encoder_rolls_window_when_not_first():
+    enc = _transformer()
+    carry0 = enc.initial_carry(FRAME)
+    obs = jax.random.normal(jax.random.PRNGKey(0), FRAME)
+    params = enc.init(jax.random.PRNGKey(1), carry0, obs, jnp.asarray(False))
+    filled = jax.random.normal(jax.random.PRNGKey(2), (CONTEXT, *FRAME))
+
+    next_carry, _ = enc.apply(params, filled, obs, jnp.asarray(False))
+    assert np.allclose(
+        next_carry, jnp.concatenate([filled[1:], obs[None]], axis=0)
+    )
+
+
+def test_transformer_encoder_conditions_on_history_not_just_current_frame():
+    # perturbing a frame that is actually inside the attention window
+    # (the current obs, or any of the kept `context - 1` past frames)
+    # must change the output - otherwise this has degenerated to a
+    # single-frame encoder, defeating issue #169.
+    enc = _transformer()
+    carry0 = enc.initial_carry(FRAME)
+    obs = jax.random.normal(jax.random.PRNGKey(0), FRAME)
+    params = enc.init(jax.random.PRNGKey(1), carry0, obs, jnp.asarray(False))
+
+    window = jax.random.normal(jax.random.PRNGKey(2), (CONTEXT, *FRAME))
+    _, base = enc.apply(params, window, obs, jnp.asarray(False))
+    # index 0 of the incoming carry is evicted by the roll; 1..context-1
+    # are the kept past frames.
+    for i in range(1, CONTEXT):
+        perturbed = window.at[i].set(
+            jax.random.normal(jax.random.PRNGKey(10 + i), FRAME)
+        )
+        _, feat = enc.apply(params, perturbed, obs, jnp.asarray(False))
+        assert not np.allclose(base, feat), f"kept past frame {i} had no effect"
+
+
+def test_transformer_encoder_shares_frame_encoder_weights():
+    # one MLPEncoder's worth of leaves (2 Dense -> 4), regardless of
+    # `context` - not `context` independent copies.
+    enc = _transformer(context=6)
+    carry0 = enc.initial_carry(FRAME)
+    obs = jax.random.normal(jax.random.PRNGKey(0), FRAME)
+    params = enc.init(jax.random.PRNGKey(1), carry0, obs, jnp.asarray(False))
+    leaves = jax.tree_util.tree_leaves(params["params"]["frame_encoder"])
+    assert len(leaves) == 4
+
+
+def test_transformer_encoder_jit_vmap_over_batch():
+    enc = _transformer()
+    carry0 = enc.initial_carry(FRAME)
+    obs = jax.random.normal(jax.random.PRNGKey(0), FRAME)
+    params = enc.init(jax.random.PRNGKey(1), carry0, obs, jnp.asarray(False))
+
+    batch = 3
+    carry_b = jnp.broadcast_to(carry0, (batch, *carry0.shape))
+    obs_b = jax.random.normal(jax.random.PRNGKey(2), (batch, *FRAME))
+    first_b = jnp.asarray([True, False, True])
+    fn = jax.jit(jax.vmap(enc.apply, in_axes=(None, 0, 0, 0)))
+    carry_out, feats = fn(params, carry_b, obs_b, first_b)
+    assert carry_out.shape == (batch, CONTEXT, *FRAME)
+    assert feats.shape == (batch, HIDDEN)
+
+
+# --------------------------------------------------------------------------
+# ActorCritic threads a per-encoder carry tuple
+# --------------------------------------------------------------------------
+
+
+def test_actor_critic_carry_is_empty_tuple_for_stateless_encoders():
+    net = ActorCritic(action_dim=4)
+    assert net.initial_carry((10,)) == ((), ())
+    x = jnp.zeros((10,))
+    params = net.init(jax.random.PRNGKey(0), ((), ()), x, jnp.asarray(False))
+    carry, (pi, value) = net.apply(params, ((), ()), x, jnp.asarray(False))
+    assert carry == ((), ())
+    assert pi.logits.shape == (4,)
+    assert value.shape == ()
+
+
+def test_actor_critic_with_transformer_encoders_threads_window_carry():
+    net = ActorCritic(
+        action_dim=4,
+        actor_encoder=_transformer(),
+        critic_encoder=_transformer(),
+    )
+    carry0 = net.initial_carry(FRAME)
+    assert carry0[0].shape == (CONTEXT, *FRAME)
+    x = jax.random.normal(jax.random.PRNGKey(0), FRAME)
+    params = net.init(jax.random.PRNGKey(1), carry0, x, jnp.asarray(False))
+    (ac, cc), (pi, value) = net.apply(params, carry0, x, jnp.asarray(False))
+    assert ac.shape == (CONTEXT, *FRAME) and cc.shape == (CONTEXT, *FRAME)
+    assert pi.logits.shape == (4,)
+    assert value.shape == ()
+
+
+if __name__ == "__main__":
+    test_stateless_encoders_carry_is_empty_and_passes_through()
+    test_stateless_encoder_output_matches_plain_sequential()
+    test_transformer_block_preserves_shape()
+    test_transformer_encoder_shapes_and_carry_roundtrip()
+    test_transformer_encoder_is_first_refills_window()
+    test_transformer_encoder_rolls_window_when_not_first()
+    test_transformer_encoder_conditions_on_history_not_just_current_frame()
+    test_transformer_encoder_shares_frame_encoder_weights()
+    test_transformer_encoder_jit_vmap_over_batch()
+    test_actor_critic_carry_is_empty_tuple_for_stateless_encoders()
+    test_actor_critic_with_transformer_encoders_threads_window_carry()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -197,31 +197,38 @@ def test_transformer_encoder_jit_vmap_over_batch():
 # --------------------------------------------------------------------------
 
 
-def test_actor_critic_carry_is_empty_tuple_for_stateless_encoders():
+def test_actor_critic_carry_is_empty_for_stateless_encoders():
     net = ActorCritic(action_dim=4)
-    assert net.initial_carry((10,)) == ((), ())
+    assert net.initial_carry((10,)) == ()
     x = jnp.zeros((10,))
-    params = net.init(jax.random.PRNGKey(0), ((), ()), x, jnp.asarray(False))
-    carry, (pi, value) = net.apply(params, ((), ()), x, jnp.asarray(False))
-    assert carry == ((), ())
+    params = net.init(jax.random.PRNGKey(0), (), x, jnp.asarray(False))
+    carry, (pi, value) = net.apply(params, (), x, jnp.asarray(False))
+    assert carry == ()
     assert pi.logits.shape == (4,)
     assert value.shape == ()
 
 
-def test_actor_critic_with_transformer_encoders_threads_window_carry():
+def test_actor_critic_with_transformer_encoders_threads_one_shared_window_carry():
+    # actor and critic share a single frame-window carry (they derive it
+    # identically from the obs stream) - so it's advanced once per step
+    # even when only `policy` runs.
     net = ActorCritic(
         action_dim=4,
         actor_encoder=_transformer(),
         critic_encoder=_transformer(),
     )
     carry0 = net.initial_carry(FRAME)
-    assert carry0[0].shape == (CONTEXT, *FRAME)
+    assert carry0.shape == (CONTEXT, *FRAME)
     x = jax.random.normal(jax.random.PRNGKey(0), FRAME)
     params = net.init(jax.random.PRNGKey(1), carry0, x, jnp.asarray(False))
-    (ac, cc), (pi, value) = net.apply(params, carry0, x, jnp.asarray(False))
-    assert ac.shape == (CONTEXT, *FRAME) and cc.shape == (CONTEXT, *FRAME)
+    carry1, (pi, value) = net.apply(params, carry0, x, jnp.asarray(False))
+    assert carry1.shape == (CONTEXT, *FRAME)
     assert pi.logits.shape == (4,)
     assert value.shape == ()
+    # `policy` and `value` advance the shared carry the same way `__call__` does
+    pcarry, _ = net.apply(params, carry0, x, jnp.asarray(False), method="policy")
+    vcarry, _ = net.apply(params, carry0, x, jnp.asarray(False), method="value")
+    assert np.allclose(pcarry, carry1) and np.allclose(vcarry, carry1)
 
 
 if __name__ == "__main__":
@@ -234,5 +241,5 @@ if __name__ == "__main__":
     test_transformer_encoder_conditions_on_history_not_just_current_frame()
     test_transformer_encoder_shares_frame_encoder_weights()
     test_transformer_encoder_jit_vmap_over_batch()
-    test_actor_critic_carry_is_empty_tuple_for_stateless_encoders()
-    test_actor_critic_with_transformer_encoders_threads_window_carry()
+    test_actor_critic_carry_is_empty_for_stateless_encoders()
+    test_actor_critic_with_transformer_encoders_threads_one_shared_window_carry()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from navix.agents.models import (
     Encoder,
@@ -70,6 +71,31 @@ def test_encoder_base_default_carry_is_stateless():
     # subclasses that don't override initial_carry get `()` for free.
     assert MLPEncoder().initial_carry((7, 7, 3)) == ()
     assert ConvEncoder().initial_carry((7, 7, 3)) == ()
+    # the dtype arg is accepted and ignored by the stateless default
+    assert MLPEncoder().initial_carry((7, 7, 3), jnp.uint8) == ()
+
+
+def test_transformer_carry_keeps_the_observation_dtype():
+    # the window stores raw frames - forcing float32 would make
+    # Buffer.carry 4x wider than the uint8 observations navix produces.
+    enc = _transformer()
+    carry = enc.initial_carry(FRAME, jnp.uint8)
+    assert carry.dtype == jnp.uint8
+    obs = jnp.zeros(FRAME, dtype=jnp.uint8)
+    params = enc.init(jax.random.PRNGKey(0), carry, obs, jnp.asarray(False))
+    next_carry, feats = enc.apply(params, carry, obs, jnp.asarray(False))
+    assert next_carry.dtype == jnp.uint8  # storage stays uint8
+    assert feats.dtype == jnp.float32  # features are float
+
+
+def test_actor_critic_rejects_mismatched_encoder_carries():
+    net = ActorCritic(
+        action_dim=4,
+        actor_encoder=MLPEncoder(),  # stateless -> ()
+        critic_encoder=_transformer(),  # stateful -> (context, *obs)
+    )
+    with pytest.raises(ValueError, match="same carry shape"):
+        net.initial_carry(FRAME)
 
 
 # --------------------------------------------------------------------------
@@ -251,6 +277,8 @@ def test_actor_critic_with_transformer_encoders_threads_one_shared_window_carry(
 if __name__ == "__main__":
     test_all_feature_encoders_subclass_encoder()
     test_encoder_base_default_carry_is_stateless()
+    test_transformer_carry_keeps_the_observation_dtype()
+    test_actor_critic_rejects_mismatched_encoder_carries()
     test_stateless_encoders_carry_is_empty_and_passes_through()
     test_stateless_encoder_output_matches_plain_sequential()
     test_transformer_block_preserves_shape()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,6 +30,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from navix.agents.models import (
+    Encoder,
     MLPEncoder,
     ConvEncoder,
     TransformerBlock,
@@ -53,6 +54,22 @@ def _transformer(**overrides) -> TransformerEncoder:
     )
     kwargs.update(overrides)
     return TransformerEncoder(**kwargs)
+
+
+# --------------------------------------------------------------------------
+# the Encoder base: shared carry contract
+# --------------------------------------------------------------------------
+
+
+def test_all_feature_encoders_subclass_encoder():
+    for cls in (MLPEncoder, ConvEncoder, TransformerEncoder):
+        assert issubclass(cls, Encoder)
+
+
+def test_encoder_base_default_carry_is_stateless():
+    # subclasses that don't override initial_carry get `()` for free.
+    assert MLPEncoder().initial_carry((7, 7, 3)) == ()
+    assert ConvEncoder().initial_carry((7, 7, 3)) == ()
 
 
 # --------------------------------------------------------------------------
@@ -232,6 +249,8 @@ def test_actor_critic_with_transformer_encoders_threads_one_shared_window_carry(
 
 
 if __name__ == "__main__":
+    test_all_feature_encoders_subclass_encoder()
+    test_encoder_base_default_carry_is_stateless()
     test_stateless_encoders_carry_is_empty_and_passes_through()
     test_stateless_encoder_output_matches_plain_sequential()
     test_transformer_block_preserves_shape()

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -111,6 +111,19 @@ def test_ppo_stateless_encoder_carry_is_empty_end_to_end():
     assert jax.tree_util.tree_leaves(experience.carry) == []
 
 
+def test_ppo_transformer_critic_window_is_not_degenerate():
+    # collect_experience calls network.policy (actor only); the critic's
+    # window must still be a real rolling window in the loss, not stuck at
+    # the initial all-zero frame. Assert the stored per-step carry the
+    # loss replays actually varies across the rollout.
+    ppo = _make_ppo(_transformer_actor_critic(action_dim=7, context=4))
+    ts = _init_state(ppo, jax.random.PRNGKey(0))
+    _, experience = jax.jit(ppo.collect_experience)(ts)
+    windows = np.asarray(experience.carry)  # (T, N, context, frame)
+    # a window that never advanced would be identical for every t
+    assert not np.allclose(windows[0], windows[-1])
+
+
 def test_ppo_transformer_encoder_trains_one_update_without_nans():
     ppo = _make_ppo(_transformer_actor_critic(action_dim=7, context=4))
     ts, logs = jax.jit(ppo.train)(jax.random.PRNGKey(0))
@@ -129,11 +142,10 @@ def test_ppo_transformer_encoder_buffer_carries_the_frame_window():
     ppo = _make_ppo(_transformer_actor_critic(action_dim=7, context=4))
     ts = _init_state(ppo, jax.random.PRNGKey(0))
     _, experience = jax.jit(ppo.collect_experience)(ts)
-    # Buffer.carry: (T, num_envs, (actor_window, critic_window)) with each
-    # window (context, *frame_shape).
-    actor_window = experience.carry[0]
+    # Buffer.carry is the single shared frame window per step:
+    # (T, num_envs, context, *frame_shape).
     frame_dim = int(np.prod(ppo.env.observation_space.shape))
-    assert actor_window.shape == (
+    assert experience.carry.shape == (
         ppo.hparams.num_steps,
         ppo.hparams.num_envs,
         4,
@@ -182,5 +194,6 @@ if __name__ == "__main__":
     test_ppo_is_an_agent()
     test_ppo_stateless_encoder_trains_one_update_without_nans()
     test_ppo_stateless_encoder_carry_is_empty_end_to_end()
+    test_ppo_transformer_critic_window_is_not_degenerate()
     test_ppo_transformer_encoder_trains_one_update_without_nans()
     test_ppo_transformer_encoder_buffer_carries_the_frame_window()

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -1,0 +1,186 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""`PPO` under the carry-based encoder contract: a stateless encoder
+leaves the training loop numerically unchanged (carry is `()`), and
+swapping in `TransformerEncoder` (issue #169) - and nothing else - trains
+a history-conditioned policy through the same loop."""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+import navix as nx
+from navix import observations
+from navix.agents.agent import Agent
+from navix.agents.ppo import PPO, PPOHparams
+from navix.agents.models import ActorCritic, MLPEncoder, TransformerEncoder
+
+
+def _flatten(env):
+    fn = lambda state: jnp.ravel(env.observation_fn(state))
+    shape = (int(np.prod(env.observation_space.shape)),)
+    return env.replace(
+        observation_fn=fn, observation_space=env.observation_space.replace(shape=shape)
+    )
+
+
+def _hparams(**overrides) -> PPOHparams:
+    # Tiny - just enough for every code path (collection, GAE, minibatch
+    # SGD, bootstrap) to execute. budget = num_steps * num_envs -> 1 update.
+    return PPOHparams(
+        budget=overrides.pop("budget", 8 * 4),
+        num_envs=overrides.pop("num_envs", 4),
+        num_steps=overrides.pop("num_steps", 8),
+        num_minibatches=overrides.pop("num_minibatches", 2),
+        num_epochs=overrides.pop("num_epochs", 2),
+        **overrides,
+    )
+
+
+def _make_ppo(network, **hp) -> PPO:
+    hparams = _hparams(**hp)
+    env = _flatten(
+        nx.make(
+            "Navix-Empty-5x5-v0",
+            observation_fn=observations.symbolic_first_person,
+            max_steps=hparams.num_steps,
+        )
+    )
+    return PPO(hparams=hparams, network=network, env=env)
+
+
+def _transformer_actor_critic(action_dim: int, context: int = 4) -> ActorCritic:
+    enc = lambda: TransformerEncoder(
+        frame_encoder=MLPEncoder(hidden_size=16),
+        hidden_size=16,
+        num_heads=2,
+        num_layers=2,
+        context=context,
+    )
+    return ActorCritic(action_dim=action_dim, actor_encoder=enc(), critic_encoder=enc())
+
+
+def test_ppo_is_an_agent():
+    ppo = _make_ppo(ActorCritic(action_dim=7))
+    assert isinstance(ppo, Agent)
+    assert isinstance(ppo.hparams, PPOHparams)
+    assert PPO.log_to_wandb is Agent.log_to_wandb
+
+
+def test_ppo_stateless_encoder_trains_one_update_without_nans():
+    ppo = _make_ppo(ActorCritic(action_dim=7))
+    ts, logs = jax.jit(ppo.train)(jax.random.PRNGKey(0))
+    for key in (
+        "agent/train/frames",
+        "agent/train/updates",
+        "agent/train/done_mask",
+        "agent/train/returns",
+        "agent/diagnostics/total_loss",
+    ):
+        assert key in logs, f"missing {key!r}"
+    for key, value in logs.items():
+        if key == "agent/train/done_mask":
+            continue
+        assert np.all(np.isfinite(np.asarray(value))), f"non-finite in logs[{key!r}]"
+
+
+def test_ppo_stateless_encoder_carry_is_empty_end_to_end():
+    # a stateless encoder must thread `()` everywhere: the live carry in
+    # TrainingState and the per-step Buffer.carry are both empty pytrees.
+    ppo = _make_ppo(ActorCritic(action_dim=7))
+    ts = _init_state(ppo, jax.random.PRNGKey(0))
+    assert jax.tree_util.tree_leaves(ts.carry) == []
+    _, experience = jax.jit(ppo.collect_experience)(ts)
+    assert jax.tree_util.tree_leaves(experience.carry) == []
+
+
+def test_ppo_transformer_encoder_trains_one_update_without_nans():
+    ppo = _make_ppo(_transformer_actor_critic(action_dim=7, context=4))
+    ts, logs = jax.jit(ppo.train)(jax.random.PRNGKey(0))
+    assert np.all(np.isfinite(np.asarray(logs["agent/diagnostics/total_loss"])))
+    assert np.all(np.isfinite(np.asarray(logs["agent/diagnostics/value_loss"])))
+    # the attention stack actually got parameters
+    paths = [
+        "/".join(str(k.key) for k in p)
+        for p, _ in jax.tree_util.tree_leaves_with_path(ts.params)
+    ]
+    assert any("MultiHeadDotProductAttention" in p for p in paths)
+    assert any("pos_embedding" in p for p in paths)
+
+
+def test_ppo_transformer_encoder_buffer_carries_the_frame_window():
+    ppo = _make_ppo(_transformer_actor_critic(action_dim=7, context=4))
+    ts = _init_state(ppo, jax.random.PRNGKey(0))
+    _, experience = jax.jit(ppo.collect_experience)(ts)
+    # Buffer.carry: (T, num_envs, (actor_window, critic_window)) with each
+    # window (context, *frame_shape).
+    actor_window = experience.carry[0]
+    frame_dim = int(np.prod(ppo.env.observation_space.shape))
+    assert actor_window.shape == (
+        ppo.hparams.num_steps,
+        ppo.hparams.num_envs,
+        4,
+        frame_dim,
+    )
+
+
+def _init_state(ppo: PPO, rng):
+    # The part of PPO.train needed to get a real TrainingState without
+    # running the whole training scan (mirrors tests/test_pqn.py).
+    import optax
+    from functools import partial
+    from navix.agents.ppo import TrainingState
+
+    rng, rng_init, rng_env = jax.random.split(rng, 3)
+    init_x = ppo.env.observation_space.sample(rng_init)
+    carry_single = ppo.network.initial_carry(init_x.shape)
+    params = ppo.network.init(rng_init, carry_single, init_x, jnp.asarray(False))
+    tx = optax.chain(
+        optax.clip_by_global_norm(ppo.hparams.max_grad_norm),
+        optax.inject_hyperparams(optax.adam)(learning_rate=ppo.hparams.lr, eps=1e-5),
+    )
+    env_state = jax.vmap(ppo.env.reset)(jax.random.split(rng_env, ppo.hparams.num_envs))
+    carry = jax.tree.map(
+        lambda c: jnp.broadcast_to(c, (ppo.hparams.num_envs, *c.shape)), carry_single
+    )
+    return TrainingState.create(
+        apply_fn=jax.vmap(ppo.network.apply, in_axes=(None, 0, 0, 0)),
+        params=params,
+        tx=tx,
+        env_state=env_state,
+        rng=rng,
+        carry=carry,
+        frames=jnp.asarray(0, dtype=jnp.int32),
+        epoch=jnp.asarray(0, dtype=jnp.int32),
+        policy=jax.vmap(
+            partial(ppo.network.apply, method="policy"), in_axes=(None, 0, 0, 0)
+        ),
+        value_fn=jax.vmap(
+            partial(ppo.network.apply, method="value"), in_axes=(None, 0, 0, 0)
+        ),
+    )
+
+
+if __name__ == "__main__":
+    test_ppo_is_an_agent()
+    test_ppo_stateless_encoder_trains_one_update_without_nans()
+    test_ppo_stateless_encoder_carry_is_empty_end_to_end()
+    test_ppo_transformer_encoder_trains_one_update_without_nans()
+    test_ppo_transformer_encoder_buffer_carries_the_frame_window()

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -162,7 +162,7 @@ def _init_state(ppo: PPO, rng):
 
     rng, rng_init, rng_env = jax.random.split(rng, 3)
     init_x = ppo.env.observation_space.sample(rng_init)
-    carry_single = ppo.network.initial_carry(init_x.shape)
+    carry_single = ppo.network.initial_carry(init_x.shape, init_x.dtype)
     params = ppo.network.init(rng_init, carry_single, init_x, jnp.asarray(False))
     tx = optax.chain(
         optax.clip_by_global_norm(ppo.hparams.max_grad_norm),

--- a/tests/test_pqn.py
+++ b/tests/test_pqn.py
@@ -57,7 +57,7 @@ def _init_train_state(pqn: PQN, rng: jax.Array) -> TrainingState:
 
     rng, rng_init, rng_env = jax.random.split(rng, 3)
     init_x = pqn.env.observation_space.sample(rng_init)
-    carry_single = pqn.network.initial_carry(init_x.shape)
+    carry_single = pqn.network.initial_carry(init_x.shape, init_x.dtype)
     params = pqn.network.init(rng_init, carry_single, init_x, jnp.asarray(False))
     tx = optax.chain(
         optax.clip_by_global_norm(pqn.hparams.max_grad_norm),

--- a/tests/test_pqn.py
+++ b/tests/test_pqn.py
@@ -57,19 +57,24 @@ def _init_train_state(pqn: PQN, rng: jax.Array) -> TrainingState:
 
     rng, rng_init, rng_env = jax.random.split(rng, 3)
     init_x = pqn.env.observation_space.sample(rng_init)
-    params = pqn.network.init(rng_init, init_x)
+    carry_single = pqn.network.initial_carry(init_x.shape)
+    params = pqn.network.init(rng_init, carry_single, init_x, jnp.asarray(False))
     tx = optax.chain(
         optax.clip_by_global_norm(pqn.hparams.max_grad_norm),
         optax.inject_hyperparams(optax.radam)(learning_rate=pqn.hparams.lr),
     )
     reset_rng = jax.random.split(rng_env, pqn.hparams.num_envs)
     env_state = jax.vmap(pqn.env.reset)(reset_rng)
+    carry = jax.tree.map(
+        lambda c: jnp.broadcast_to(c, (pqn.hparams.num_envs, *c.shape)), carry_single
+    )
     return TrainingState.create(
-        apply_fn=jax.vmap(pqn.network.apply, in_axes=(None, 0)),
+        apply_fn=jax.vmap(pqn.network.apply, in_axes=(None, 0, 0, 0)),
         params=params,
         tx=tx,
         env_state=env_state,
         rng=rng,
+        carry=carry,
         frames=jnp.asarray(0, dtype=jnp.int32),
         epoch=jnp.asarray(0, dtype=jnp.int32),
     )
@@ -141,14 +146,14 @@ def test_qnetwork_has_no_output_activation_and_uses_layernorm():
     # actually there, and that the output head is raw Q-values (no
     # squashing activation that would cap achievable Q-values).
     net = QNetwork(action_dim=3, encoder=QMLPEncoder(hidden_size=8))
-    params = net.init(jax.random.PRNGKey(0), jnp.zeros((5,)))
+    params = net.init(jax.random.PRNGKey(0), (), jnp.zeros((5,)), jnp.asarray(False))
     flat = jax.tree_util.tree_leaves_with_path(params)
     layer_norm_scales = [
         p for path, p in flat if any("LayerNorm" in str(k) for k in path)
     ]
     assert len(layer_norm_scales) > 0, "QNetwork has no LayerNorm parameters"
 
-    q_values = net.apply(params, jnp.ones((5,)) * 1e3)
+    _, q_values = net.apply(params, (), jnp.ones((5,)) * 1e3, jnp.asarray(False))
     assert q_values.shape == (3,)
     # with a large-magnitude input, a bounded output activation (tanh,
     # sigmoid, ...) would saturate near +-1; raw Dense output has no such
@@ -172,8 +177,11 @@ def test_collect_experience_caches_greedy_value_at_collection_time():
     # order that the two legitimately diverge at the ~1e-3 relative level
     # on GPU - same class of cross-compilation float divergence as
     # elsewhere in this codebase, not a sign the cached value is wrong.
-    q_values = jax.vmap(jax.vmap(pqn.network.apply, in_axes=(None, 0)), in_axes=(None, 0))(
-        ts.params, experience.obs
+    apply2 = jax.vmap(
+        jax.vmap(pqn.network.apply, in_axes=(None, 0, 0, 0)), in_axes=(None, 0, 0, 0)
+    )
+    _, q_values = apply2(
+        ts.params, experience.carry, experience.obs, experience.t == 0
     )
     expected_value = jnp.max(q_values, axis=-1)
     np.testing.assert_allclose(
@@ -201,8 +209,8 @@ def test_evaluate_experience_bootstraps_with_online_params_not_a_target_network(
     ts, experience = jax.jit(pqn.collect_experience)(ts)
     targets = jax.jit(pqn.evaluate_experience)(ts, experience)
 
-    last_q = jax.vmap(pqn.network.apply, in_axes=(None, 0))(
-        ts.params, ts.env_state.observation
+    _, last_q = jax.vmap(pqn.network.apply, in_axes=(None, 0, 0, 0))(
+        ts.params, ts.carry, ts.env_state.observation, ts.env_state.is_start()
     )
     last_val = jnp.max(last_q, axis=-1)
     # the final timestep's target must reduce to reward + discounted
@@ -280,3 +288,59 @@ def test_pqn_networks_have_no_replay_buffer_across_updates():
         f.name in ("replay", "buffer")
         for f in TrainingState.__dataclass_fields__.values()
     )
+
+
+# --------------------------------------------------------------------------
+# carry-based encoder contract (issue #169): stateless is inert, and a
+# TransformerEncoder plugs into QNetwork by swapping only the encoder
+# --------------------------------------------------------------------------
+
+
+def test_pqn_stateless_encoder_carry_is_empty_end_to_end():
+    pqn = _make_pqn()
+    ts = _init_train_state(pqn, jax.random.PRNGKey(0))
+    assert jax.tree_util.tree_leaves(ts.carry) == []
+    _, experience = jax.jit(pqn.collect_experience)(ts)
+    assert jax.tree_util.tree_leaves(experience.carry) == []
+
+
+def _transformer_qnetwork(action_dim: int, hidden: int = 8, context: int = 4):
+    from navix.agents.models import TransformerEncoder, QMLPEncoder
+
+    return QNetwork(
+        action_dim=action_dim,
+        encoder=TransformerEncoder(
+            frame_encoder=QMLPEncoder(hidden_size=hidden),
+            hidden_size=hidden,
+            num_heads=2,
+            num_layers=2,
+            context=context,
+        ),
+    )
+
+
+def test_pqn_transformer_encoder_trains_one_update_without_nans():
+    pqn = _make_pqn(budget=8 * 4)
+    pqn = pqn.replace(network=_transformer_qnetwork(len(pqn.env.action_set)))
+    ts, logs = jax.jit(pqn.train)(jax.random.PRNGKey(0))
+    for key, value in logs.items():
+        if key == "agent/train/done_mask":
+            continue
+        assert np.all(np.isfinite(np.asarray(value))), f"non-finite in logs[{key!r}]"
+    paths = [
+        "/".join(str(k.key) for k in p)
+        for p, _ in jax.tree_util.tree_leaves_with_path(ts.params)
+    ]
+    assert any("MultiHeadDotProductAttention" in p for p in paths)
+
+
+def test_pqn_transformer_encoder_buffer_carries_the_frame_window():
+    pqn = _make_pqn(num_steps=5, num_envs=3)
+    pqn = pqn.replace(
+        network=_transformer_qnetwork(len(pqn.env.action_set), context=4)
+    )
+    ts = _init_train_state(pqn, jax.random.PRNGKey(0))
+    _, experience = jax.jit(pqn.collect_experience)(ts)
+    # the window keeps each frame's native shape (QMLPEncoder flattens
+    # internally), so (T, N, context, *obs_shape).
+    assert experience.carry.shape == (5, 3, 4, *pqn.env.observation_space.shape)


### PR DESCRIPTION
_Posted by an AI agent on behalf of @epignatelli._

Closes #169.

## What this does

Generalises every PPO/PQN feature extractor to a **carry-based `Encoder` contract** so the MDP↔POMDP distinction lives entirely in the encoder — you swap the encoder at `ActorCritic(...)` / `QNetwork(...)` construction and nothing else in the agent, the environment, or the observation function changes:

```python
class Encoder(nn.Module):
    def initial_carry(self, obs_shape) -> carry: ...     # () default (stateless)
    def __call__(self, carry, obs, is_first) -> (carry, features): ...
```

- `MLPEncoder` / `ConvEncoder` / `QMLPEncoder` / `QConvEncoder` are stateless `Encoder` subclasses: carry `()`, ignore `is_first`, features unchanged. **Fixed-seed MDP runs of both PPO and PQN are byte-identical to `main`.**
- `TransformerEncoder` (+ `TransformerBlock`) is the stateful one (#169): its carry is the raw `(context, *frame)` window of the last `context` observations. The agent threads the carry like `env_state`; the encoder resets its window on `is_first` (`t == 0`, robust to navix's one-step-deferred autoreset).
- `ActorCritic` / `QNetwork` thread **one shared carry** to their encoder(s) and return `(carry, ...)` from every method.
- Dreamer's `Encoder` is renamed `SymlogEncoder` (symlog-input RSSM encoder — different `__call__` shape, no carry; internal, not re-exported).

Both agents use **Option 1** (stored carry): the per-step window is cached in `Buffer` and replayed in the loss. Because the window is raw frames (no dependence on encoder parameters) this is **exact**, not an approximation — verified against the Option 2 alternative (#208), which produces the same gradient at ~4x the loss cost and is only worth it for a future *learned* recurrent encoder.

## Commits

1. `feat` — carry contract + `TransformerEncoder`, wired through PPO
2. `test` — encoder-contract + PPO-wiring coverage; `examples/ppo_pomdp.py`
3. `fix` — `ActorCritic` threads one shared carry (a per-head tuple left the critic's window frozen, since `collect_experience` only runs `policy`)
4. `style` — uniform `__call__(carry, obs, is_first)` signature
5. `refactor` — rename Dreamer's `Encoder` → `SymlogEncoder`
6. `refactor` — `Encoder` base class for the contract
7. `feat` — thread the carry through PQN

## Not in scope

- Dreamer (its RSSM is already history-conditioned).
- A conv/ViT patch-embed `frame_encoder` for `rgb_first_person` (flatten+Dense per frame is the first cut).
- `FrameStack`-style env wrappers / new observation functions — the encoder owns history instead.

## Tests / examples

- `tests/test_models.py` — the `Encoder` base, contract, `TransformerEncoder` window reset / rolling / history sensitivity / shared per-frame weights / jit+vmap.
- `tests/test_ppo.py`, `tests/test_pqn.py` — each agent trains one update without NaNs with a stateless encoder (carry `()` end to end) and with `TransformerEncoder` (attention params present, `Buffer.carry` is the window).
- `examples/ppo_pomdp.py` — PPO on a first-person observation, identical to `examples/ppo.py` except the encoder.

## Behavior change

None for existing environments or existing PPO/PQN configs — the stateless-encoder path is byte-identical to `main` for both agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
