### PR TITLE
docs: docstring pass over the navix package (#167)

### DIFF
--- a/navix/__init__.py
+++ b/navix/__init__.py
@@ -17,6 +17,49 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""NAVIX: MiniGrid-style gridworld navigation, reimplemented in JAX.
+
+Every environment is a pure JAX function, so `reset`/`step` compose with
+`jax.jit`, `jax.vmap` and `jax.lax.scan`: a whole batch of environments
+advances in one fused device kernel, and an agent's rollout loop can be a
+single compiled `scan`. This is what makes NAVIX ~1000x faster end-to-end
+than a CPU MiniGrid loop for RL training.
+
+Typical use:
+
+```python
+import jax
+import navix as nx
+
+env = nx.make("Navix-DoorKey-5x5-v0")          # a registered environment
+key = jax.random.PRNGKey(0)
+timestep = env.reset(key)                        # -> Timestep
+timestep = env.step(timestep, jax.numpy.asarray(2))   # apply action 2
+```
+
+Layout:
+
+- `navix.environments` - the [`Environment`][navix.environments.environment.Environment]
+  class, the [`Timestep`][navix.environments.environment.Timestep] it
+  returns, and `make` / `register_env` / `registry` for the built-in
+  environment ids.
+- The pluggable pieces an `Environment` is assembled from, each a plain
+  function you can swap: `navix.observations`, `navix.actions`,
+  `navix.transitions`, `navix.rewards`, `navix.terminations`,
+  `navix.events`.
+- `navix.states` / `navix.entities` / `navix.components` - the `State`
+  data model (the true world state an observation is derived from).
+- `navix.grid` - array helpers for grid geometry (cropping, rotation,
+  line of sight).
+- `navix.rendering` - sprite/tile rendering for RGB observations.
+- `navix.spaces` - `Space` descriptors for observations, actions and
+  rewards.
+- `navix.agents` - reference JAX implementations of PPO, PQN and
+  DreamerV3, plus `navix.experiment.Experiment` to run and log them.
+- `navix.benchmarks` - experimental protocols that pin an environment,
+  a frame budget and a metric, so results are comparable across
+  algorithms and against the literature.
+"""
 
 from . import (
     actions,

--- a/navix/actions.py
+++ b/navix/actions.py
@@ -16,8 +16,25 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""The *action* system determines the next state of the environment \
-given the current state and an action."""
+"""The action primitives an integer action indexes into.
+
+Each function here is a pure `State -> State` transformation of the
+world. An `Environment` holds an ordered `action_set` (a tuple of these),
+and `transitions_fn` applies `action_set[a]` for an integer action `a`;
+the environment's `action_space` is `Discrete(len(action_set))`. So the
+*meaning* of action `2` depends on which set the environment uses - see
+`MINIGRID_ACTION_SET` (the default) and `COMPLETE_ACTION_SET`.
+
+Conventions shared by all of them:
+
+- "the player" is `state.get_player(idx=0)` (navix is single-agent for
+  now); "in front" is the cell one step along `player.direction`
+  (`0` east, `1` south, `2` west, `3` north).
+- Movement that would enter a wall or a non-walkable entity is a no-op:
+  the player stays put (and a wall/entity-hit event is recorded).
+- Every action is total - it always returns a `State` of the same
+  structure, so the set can go through `jax.lax.switch`.
+"""
 
 
 from __future__ import annotations
@@ -89,93 +106,113 @@ def _move(state: State, direction: Array) -> State:
 
 
 def noop(state: State) -> State:
-    """No operation. Does nothing.
+    """Does nothing - the world is returned unchanged. Present so an
+    action set can include an explicit "wait".
 
     Args:
-        state (State): The current state.
-    
+        state (State): the current state.
+
     Returns:
-        State: The same state."""
+        State: `state`, unchanged."""
     return state
 
 
 def rotate_cw(state: State) -> State:
-    """Rotates the player clockwise.
-    
+    """Turns the player 90 degrees clockwise (`direction` -> `direction + 1`
+    mod 4). Position is unchanged.
+
     Args:
-        state (State): The current state.
-    
+        state (State): the current state.
+
     Returns:
-        State: The new state with the player rotated clockwise."""
+        State: the state with the player's `direction` updated."""
     return _rotate(state, 1)
 
 
 def rotate_ccw(state: State) -> State:
-    """Rotates the player counter-clockwise.
-    
+    """Turns the player 90 degrees counter-clockwise (`direction` ->
+    `direction - 1` mod 4). Position is unchanged.
+
     Args:
-        state (State): The current state.
+        state (State): the current state.
 
     Returns:
-        State: The new state with the player rotated counter-clockwise."""
+        State: the state with the player's `direction` updated."""
     return _rotate(state, -1)
 
 
 def forward(state: State) -> State:
-    """Moves the player forward.
-    
+    """Moves the player one cell in the direction it faces. No-op if that
+    cell is a wall or a non-walkable entity (a hit event is recorded);
+    `direction` never changes.
+
     Args:
-        state: The current state.
+        state (State): the current state.
 
     Returns:
-        State: The new state with the player moved forward."""
+        State: the state with the player's `position` updated (or not, if
+        blocked)."""
     player = state.get_player(idx=0)
     return _move(state, player.direction)
 
 
 def right(state: State) -> State:
-    """Steps the player to the right without changing the direction.
+    """Strafes the player one cell to its right (90 degrees clockwise of
+    where it faces) *without* turning. Blocked-move rules as for
+    `forward`. Not in the MiniGrid action set.
 
     Args:
-        state (State): The current state.
+        state (State): the current state.
 
     Returns:
-        State: The new state with the player moved to the right."""
+        State: the state with the player's `position` updated (or not, if
+        blocked)."""
     player = state.get_player(idx=0)
     return _move(state, player.direction + 1)
 
 
 def backward(state: State) -> State:
-    """Steps the player backward without changing the direction.
-        
-        Args:
-            state (State): The current state.
+    """Steps the player one cell backwards (opposite to where it faces)
+    without turning. Blocked-move rules as for `forward`. Not in the
+    MiniGrid action set.
 
-        Returns:
-            State: The new state with the player moved backward."""
+    Args:
+        state (State): the current state.
+
+    Returns:
+        State: the state with the player's `position` updated (or not, if
+        blocked)."""
     player = state.get_player(idx=0)
     return _move(state, player.direction + 2)
 
 
 def left(state: State) -> State:
-    """Steps the player to the left without changing the direction.
+    """Strafes the player one cell to its left (90 degrees
+    counter-clockwise of where it faces) without turning. Blocked-move
+    rules as for `forward`. Not in the MiniGrid action set.
 
     Args:
-        state (State): The current state.
-    
+        state (State): the current state.
+
     Returns:
-        State: The new state with the player moved to the left."""
+        State: the state with the player's `position` updated (or not, if
+        blocked)."""
     player = state.get_player(idx=0)
     return _move(state, player.direction + 3)
 
 
 def pickup(state: State) -> State:
-    """Picks up an item (`Key`, `Box`, or `Ball`) in front of the player
-    and puts it in the pocket.
+    """Picks up the pickable entity (`Key`, `Box`, or `Ball`) directly in
+    front of the player: the entity is moved off the grid and its `id` is
+    written to `player.pocket`, overwriting whatever was there. No-op if
+    the cell in front holds nothing pickable. Records a pickup event.
+
     Args:
-        state (State): The current state.
+        state (State): the current state.
+
     Returns:
-        State: The new state with the player entity having the item in the pocket."""
+        State: the state with the item removed from the grid and its
+        `id` in `player.pocket`."""
 
     def pickup_entity(state: State, entity, setter) -> State:
         """Shared logic for one pickable entity type (`Key`/`Box`/
@@ -250,13 +287,16 @@ def pickup(state: State) -> State:
 
 
 def drop(state: State) -> State:
-    """Replaces the position in front of the player with the item in the pocket.
+    """Places the item currently in `player.pocket` on the cell in front
+    of the player and empties the pocket. No-op if the pocket is empty or
+    the cell in front is not walkable (occupied or a wall).
 
     Args:
-        state (State): The current state.
+        state (State): the current state.
 
     Returns:
-        State: The new state with the item in the pocket dropped in front of the player."""
+        State: the state with the pocketed item back on the grid in front
+        of the player and `player.pocket` cleared."""
     player = state.get_player(idx=0)
 
     position_in_front = translate(player.position, player.direction)
@@ -295,13 +335,15 @@ def drop(state: State) -> State:
 
 
 def toggle(state: State) -> State:
-    """Toggles an openable object (like a door) if possible.
+    """MiniGrid's `toggle` action. An alias for `open`: in navix a door,
+    once opened, stays open (there is no close), so "toggle" and "open"
+    are the same operation.
 
     Args:
-        state (State): The current state.
-    
+        state (State): the current state.
+
     Returns:
-        State: The new state with the openable object toggled."""
+        State: see `open`."""
     return open(state)
 
 
@@ -343,14 +385,24 @@ def open_box(state: State, position_in_front: Array) -> State:
 
 
 def open(state: State) -> State:
-    """Unlocks and opens an openable object (like a door), or opens a
-    box to reveal what it contains, if possible.
+    """Opens whatever openable thing is directly in front of the player:
+
+    - a `Box` -> removed, and its contents (a `Key`) revealed at that
+      cell (see `open_box`);
+    - a `Door` -> opened iff it is closed and either unlocked
+      (`requires == -1`) or the player is carrying the required key
+      (`player.pocket == door.requires`), in which case that key is
+      consumed from the pocket. Opening records a door-opening event.
+
+    A `Door` that is already open, and any other cell, are left
+    untouched. `toggle` is an alias for this.
 
     Args:
-        state (State): The current state.
+        state (State): the current state.
 
     Returns:
-        State: The new state with the openable object opened."""
+        State: the state with the door/box in front opened if the
+        conditions held."""
     player = state.get_player(idx=0)
     position_in_front = translate(player.position, player.direction)
 
@@ -410,28 +462,18 @@ def open(state: State) -> State:
 
 
 def done(state: State) -> State:
-    """A placeholder action that does nothing, but is a signal to the environment that the episode is over.
-    This action does not terminate the episode, unless the termination function explicitly checks for it (not default).
-    
+    """The agent's "I'm finished" signal. Returns the state unchanged - it
+    does *not* end the episode by itself. Only environments whose
+    `termination_fn` inspects for it (e.g. `GoToObject`, via
+    `events.on_target_done`) react to it; under the default termination
+    it is a no-op.
+
     Args:
-        state (State): The current state.
-    
+        state (State): the current state.
+
     Returns:
-        State: The same state."""
+        State: `state`, unchanged."""
     return state
-
-
-# DEFAULT_ACTION_SET = (
-#     rotate_ccw,
-#     rotate_cw,
-#     forward,
-#     pickup,
-#     drop,
-#     toggle,
-#     done
-# )
-"""Default action set from Minigrid. See
-https://github.com/Farama-Foundation/Minigrid/blob/master/minigrid/core/actions.py"""
 
 
 COMPLETE_ACTION_SET = (
@@ -446,8 +488,11 @@ COMPLETE_ACTION_SET = (
     open,
     done,
 )
-"""Complete action set for the environment.
-This set includes all the actions that can be taken by the agent, and does not mirror the Minigrid action set."""
+"""Every action navix defines, in index order:
+`0 noop`, `1 rotate_cw`, `2 rotate_ccw`, `3 forward`, `4 right`,
+`5 backward`, `6 left`, `7 pickup`, `8 open`, `9 done`. Wider than
+MiniGrid's set (adds strafing and `noop`); use it for environments that
+need lateral movement."""
 
 MINIGRID_ACTION_SET = (
     rotate_ccw,
@@ -458,7 +503,11 @@ MINIGRID_ACTION_SET = (
     toggle,
     done,
 )
-"""Default action set from Minigrid. See
+"""MiniGrid's seven actions, in the same index order MiniGrid uses:
+`0 rotate_ccw` (MiniGrid "left"), `1 rotate_cw` ("right"), `2 forward`,
+`3 pickup`, `4 drop`, `5 toggle`, `6 done`. See
 https://github.com/Farama-Foundation/Minigrid/blob/master/minigrid/core/actions.py"""
 
 DEFAULT_ACTION_SET = MINIGRID_ACTION_SET
+"""The `action_set` an `Environment` uses unless overridden -
+`MINIGRID_ACTION_SET`."""

--- a/navix/agents/__init__.py
+++ b/navix/agents/__init__.py
@@ -17,6 +17,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""Reference JAX RL agents you can train on navix environments:
+`PPO`, `PQN` (a replay/target-free deep Q-network) and `Dreamer`
+(DreamerV3). Each pairs with an `HParams` struct and plugs into
+`navix.experiment.Experiment`. `models` holds the shared network pieces,
+including the carry-based `Encoder` family (swap `TransformerEncoder` in
+for a history-conditioned policy on partially observable tasks).
+"""
 
 from .ppo import PPO, PPOHparams as PPOHparams
 from .models import (

--- a/navix/agents/agent.py
+++ b/navix/agents/agent.py
@@ -1,3 +1,13 @@
+"""`Agent`: the common interface `Experiment` trains, and `HParams`: the
+base its per-algorithm hyperparameter structs extend.
+
+The concrete agents - `PPO`, `PQN`, `Dreamer` - each subclass `Agent`,
+implement `train`, and carry their own `HParams` subclass. This module
+also holds the shared logging helpers (`masked_mean`,
+`derive_episodic_metrics`) and the `agent/train/*` metric contract every
+agent's `train` must return.
+"""
+
 from dataclasses import dataclass
 import time
 import warnings
@@ -97,11 +107,21 @@ def derive_episodic_metrics(logs: Dict[str, jax.Array]) -> Dict[str, jax.Array]:
 
 
 class HParams(struct.PyTreeNode):
+    """Base for every agent's hyperparameter struct (`PPOHparams`,
+    `PQNHparams`, `DreamerHparams`). Holds only the fields common to all;
+    each subclass adds its own (learning rate, rollout length, ...).
+    Frozen - use `.replace(...)` for a modified copy (this is what the
+    hyperparameter search does)."""
+
     debug: bool = struct.field(pytree_node=False, default=False)
-    """Whether to run in debug mode."""
+    """If `True`, agents run extra `jax.debug` callbacks and per-step
+    wandb logging. Slow; off by default."""
     log_frequency: int = struct.field(pytree_node=False, default=1)
-    """How often to log results."""
+    """Log to wandb every `log_frequency` training updates (`1` = every
+    update)."""
     log_render: bool = struct.field(pytree_node=False, default=False)
+    """If `True`, agents also emit an `rgb` rollout video under
+    `render/human` in their logs."""
 
 
 class Agent(struct.PyTreeNode):

--- a/navix/agents/agent.py
+++ b/navix/agents/agent.py
@@ -209,6 +209,19 @@ class Agent(struct.PyTreeNode):
         raise NotImplementedError
 
     def log_to_wandb(self, logs, inspectable=None, run=None):
+        """Streams one training update's metrics to Weights & Biases,
+        deriving the `agent/episode/*` aggregates from the raw
+        `agent/train/*` buffers first. A no-op unless
+        `logs["agent/train/updates"]` is a multiple of
+        `hparams.log_frequency`. `Experiment.run` calls this; you rarely
+        call it directly.
+
+        Args:
+            logs (dict): one update's metrics (a single-update slice of
+                `Agent.train`'s output).
+            inspectable: optional extra payload for a debug callback.
+            run: an explicit `wandb.Run` to log to; defaults to the
+                module-level current run."""
         if len(logs) == 0 or logs["agent/train/updates"] % self.hparams.log_frequency != 0:
             return
 
@@ -245,6 +258,15 @@ class Agent(struct.PyTreeNode):
         (run or wandb).log(logs, step=step)
 
     def log_to_wandb_on_train_end(self, logs, run=None):
+        """Replays `log_to_wandb` for every recorded update after training
+        has finished - for when `train` ran fully inside `jax.jit` and
+        streaming live was not possible. `logs` here has a leading
+        update axis (the whole history); each kept update is logged in
+        order.
+
+        Args:
+            logs (dict): the full `Agent.train` output.
+            run: an explicit `wandb.Run`; defaults to the current run."""
         print(jax.tree.map(lambda x: x.shape, logs))
         len_logs = len(logs["agent/train/updates"])
         updates = logs["agent/train/updates"]

--- a/navix/agents/dreamer.py
+++ b/navix/agents/dreamer.py
@@ -111,6 +111,11 @@ from ..states import State
 
 
 class DreamerHparams(HParams):
+    """Hyperparameters for `Dreamer` (DreamerV3). Frozen; `.replace(...)`
+    for a variant. Groups the world-model, actor and critic knobs plus
+    the imagination-rollout schedule; sized for navix's small
+    observations rather than Atari."""
+
     # Training schedule
     budget: int = struct.field(pytree_node=False, default=1_000_000)
     """Number of environment frames to train for."""

--- a/navix/agents/models.py
+++ b/navix/agents/models.py
@@ -83,6 +83,10 @@ class Encoder(nn.Module):
 
 
 class MLPEncoder(Encoder):
+    """Two `tanh` `Dense` layers - the default `ActorCritic` encoder for
+    a flat (fully-observable / pre-flattened) observation. Stateless (see
+    `Encoder`); its output is `hidden_size`-wide."""
+
     hidden_size: int = 64
 
     @nn.compact
@@ -263,6 +267,20 @@ class TransformerEncoder(Encoder):
 
 
 class ActorCritic(nn.Module):
+    """PPO's network: two independent `Encoder` towers (actor, critic)
+    each followed by a linear head - a categorical policy over
+    `action_dim` and a scalar value. Swap `actor_encoder` /
+    `critic_encoder` to change what the agent sees (e.g.
+    `TransformerEncoder` for frame history); the training loop is
+    unchanged.
+
+    Attributes:
+        action_dim: number of discrete actions (`len(env.action_set)`).
+        actor_encoder: `Encoder` for the policy tower.
+        critic_encoder: `Encoder` for the value tower. Must produce the
+            same carry shape as `actor_encoder` (they share one carry).
+    """
+
     action_dim: int
     actor_encoder: Encoder = MLPEncoder()
     critic_encoder: Encoder = MLPEncoder()

--- a/navix/agents/ppo.py
+++ b/navix/agents/ppo.py
@@ -2,6 +2,13 @@
 # https://github.com/luchris429/purejaxrl/blob/main/purejaxrl/ppo.py
 # which is in turn inspired by:
 # https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo.py
+"""`PPO`: a Proximal Policy Optimization agent whose whole training run
+(`num_updates` iterations of rollout collection + minibatch SGD) is one
+`jax.lax.scan`. `PPOHparams` holds the knobs; `ActorCritic` (from
+`navix.agents.models`) is the network - swap its encoder for
+partial-observability. Structurally mirrored by `navix.agents.pqn`.
+"""
+
 from functools import partial
 from typing import Any, Callable, Dict, Tuple
 

--- a/navix/agents/ppo.py
+++ b/navix/agents/ppo.py
@@ -31,6 +31,10 @@ from .models import ActorCritic
 
 
 class PPOHparams(HParams):
+    """Hyperparameters for `PPO`. Frozen; `.replace(...)` for a variant.
+    The per-field defaults are tuned for navix's small gridworlds, not
+    copied from a CartPole reference."""
+
     budget: int = struct.field(pytree_node=False, default=1_000_000)
     """Number of environment frames to train for."""
     num_envs: int = struct.field(pytree_node=False, default=16)

--- a/navix/agents/pqn.py
+++ b/navix/agents/pqn.py
@@ -123,6 +123,11 @@ from .models import QNetwork
 
 
 class PQNHparams(HParams):
+    """Hyperparameters for `PQN`. Frozen; `.replace(...)` for a variant.
+    Several defaults (`num_epochs`, `num_minibatches`, `end_e`,
+    `exploration_fraction`) are set for navix's gridworlds and differ
+    from CleanRL's CartPole reference - see this module's docstring."""
+
     budget: int = struct.field(pytree_node=False, default=1_000_000)
     """Number of environment frames to train for."""
     num_envs: int = struct.field(pytree_node=False, default=16)

--- a/navix/benchmarks/benchmark.py
+++ b/navix/benchmarks/benchmark.py
@@ -463,14 +463,18 @@ class BenchmarkResult(struct.PyTreeNode):
 
 
 class Benchmark(struct.PyTreeNode):
-    """A benchmark protocol - not tied to any one algorithm.
+    """An **experimental protocol** - the fixed set of choices that make
+    two algorithms' numbers comparable: which environments, what frame
+    budget, how many seeds, and how a run is scored and summarised. It
+    says nothing about *how* an algorithm is implemented, only how it is
+    measured, so any `AlgorithmEntry` can be run against it and against
+    the literature.
 
-    Used as an instance, e.g. `Navix1M().run(entry)`; its display name
-    is `type(self).__name__`. `run`/`summary`/`details` have no
-    protocol-agnostic default and must be overridden by a concrete
-    protocol (e.g. `FromScratchBenchmark`). `submit_entry` is concrete
-    here - it writes out whatever `run`/`summary`/`details` already
-    produced, the same way for every protocol.
+    Use an instance, e.g. `Navix1M().run(entry)`; the protocol's name is
+    `type(self).__name__`. A concrete protocol (e.g. `FromScratchBenchmark`,
+    behind `Navix1M` / `Navix100K`) supplies `run` / `summary` /
+    `details`; `submit_entry` is shared - it writes out whatever those
+    produced, identically for every protocol.
     """
 
     seeds: Tuple[int, ...] = struct.field(pytree_node=False, default_factory=lambda: tuple(range(16)))

--- a/navix/components.py
+++ b/navix/components.py
@@ -18,6 +18,17 @@
 # under the License.
 
 
+"""The reusable "capability" mixins that `navix.entities` compose into
+concrete entities.
+
+Each `Component` subclass adds one field (or one abstract property) plus
+its semantics: `Positionable` -> `position`, `Directional` ->
+`direction`, `Openable` -> `requires`/`open`, and so on. An entity like
+`Door` is just `Positionable + Directional + Openable + HasColour + ...`.
+Every field is a JAX array and the leading axis is the entity-instance
+axis, so a whole batch of doors is one `Door` struct.
+"""
+
 from __future__ import annotations
 from typing import Tuple
 
@@ -29,93 +40,138 @@ import dataclasses
 
 
 DISCARD_PILE_COORDS = jnp.asarray((0, -1), dtype=jnp.int32)
+"""The off-grid `(row, col)` an entity's `position` is set to once it has
+been picked up / consumed. Column `-1` is outside every grid, so such an
+entity renders nowhere and matches no real cell."""
 DISCARD_PILE_IDX = jnp.asarray(-1, dtype=jnp.int32)
+"""The flat patch index that `DISCARD_PILE_COORDS` maps to; rendering
+slices it off (`patches[:DISCARD_PILE_IDX]`)."""
 EMPTY_POCKET_ID = jnp.asarray(-1, dtype=jnp.int32)
+"""`Holder.pocket` / `Player.pocket` value meaning "carrying nothing"."""
 UNSET_DIRECTION = jnp.asarray(-1, dtype=jnp.int32)
+"""`Directional.direction` sentinel for an entity whose facing is
+irrelevant (it is never used as a rotation)."""
 UNSET_CONSUMED = jnp.asarray(-1, dtype=jnp.int32)
+"""Sentinel for a "consumed key" slot that has not been used yet."""
 
 
 def field(shape: Tuple[int, ...], **kwargs):
+    """A `dataclasses.field` that also records the per-instance `shape`
+    of the array (excluding the leading instance axis) in its metadata,
+    so `Component.check_ndim` can validate batched vs unbatched structs.
+
+    Args:
+        shape (tuple[int, ...]): the shape of one instance's value -
+            `()` for a scalar field, `(2,)` for a `(row, col)` position.
+        **kwargs: forwarded to `dataclasses.field` (e.g. `default_factory`).
+
+    Returns:
+        dataclasses.Field: the field descriptor."""
     return dataclasses.field(metadata={"shape": shape}, **kwargs)
 
 
 class Component(struct.PyTreeNode):
-    """Base class for all components in the game.
-    Components are used to store the data of the entities in the game."""
+    """Base of every capability mixin. A `Component` is a frozen
+    `flax.struct` pytree; concrete entities inherit from several at once.
+    Carries no data itself."""
 
     def check_ndim(self, batched: bool = False) -> None:
+        """Hook for asserting each field has the expected rank (one extra
+        axis when `batched`). The base implementation does nothing;
+        subclasses may override. Not called on the hot path.
+
+        Args:
+            batched (bool): whether an extra leading instance axis is
+                expected."""
         return
 
 
 class Positionable(Component):
-    """Flags an entity as positionable in the grid, and provides the `position` attribute"""
+    """Entity has a location on the grid."""
 
     position: Array = field(shape=(2,))
-    """The (row, column) position of the entity in the grid as a JAX array, defaults to the discard pile (-1, -1)"""
+    """`(row, col)` as `i32[2]` (or `i32[n_instances, 2]` batched).
+    `DISCARD_PILE_COORDS` (`(0, -1)`) once the entity has been picked up
+    or consumed."""
 
 
 class Directional(Component):
-    """Flags an entity as directional, and provides the `direction` attribute"""
+    """Entity has a facing direction."""
 
     direction: Array = field(shape=())
-    """The direction the entity: 0 = east, 1 = south, 2 = west, 3 = north"""
+    """`i32[]` in `0..3`: `0` east, `1` south, `2` west, `3` north
+    (clockwise). Used directly by `grid.translate` / `grid.rotate`."""
 
 
 class HasColour(Component):
-    """Flags an entity as having a colour, and provides the `colour` attribute"""
+    """Entity is drawn/encoded in one of the palette colours."""
 
     colour: Array = field(shape=())
-    """The colour of the object for rendering. """
+    """`i32[]` index into `navix.rendering.registry.PALETTE` (`0` red,
+    `1` green, `2` blue, `3` purple, `4` yellow, `5` grey). This is the
+    `colour` channel of a `symbolic` observation and picks the sprite
+    variant for `rgb`."""
 
 
 class Stochastic(Component):
-    """Flags an entity as stochastic, and provides the `probability` attribute
-
-    TODO:
-        * consider replace probability (Array) with a distrax.Distribution
-
-    """
+    """Entity's reward (e.g. a `Goal`) is granted only with some
+    probability when reached."""
 
     probability: Array = field(shape=())
-    """The probability of receiving the reward, if reached."""
+    """`f32[]` in `[0, 1]` - the chance the reward fires on contact.
+    `1.0` for a deterministic goal."""
 
 
 class Openable(Component):
-    """Flags an entity as openable, and provides the `requires` and `open` attributes"""
+    """Entity (a `Door`) can be opened, possibly after unlocking."""
 
     requires: Array = field(shape=())
-    """The id of the item required to consume this item. If set, it must be > 0.
-    If -1, the door is unlocked and does not require any key to open."""
+    """`i32[]` - the `Pickable.id` of the key that unlocks this door, or
+    `-1` if it needs no key. Set to `-1` once the door has been
+    unlocked."""
     open: Array = field(shape=())
-    """Open is jnp.asarray(0) if the entity is closed and 1 if open."""
+    """`0` closed, `1` open. navix doors do not re-close, so this only
+    ever goes `0 -> 1`."""
 
 
 class Pickable(Component):
-    """Flags an entity as pickable, and provides the `id` attribute, which is used to identify the item in the inventory"""
+    """Entity can be picked up into a pocket (`Key`, `Ball`, `Box`)."""
 
     id: Array = field(shape=())
-    """The id of the item. If set, it must be >= 1."""
+    """`i32[] >= 1` - the identity written to `player.pocket` when this
+    entity is picked up, and matched against `Openable.requires`."""
 
 
 class Holder(Component):
-    """Flags an entity as a holder, and provides the `pocket` attribute. The pocket is used to store the id of the item in the pocket."""
+    """Entity can carry one `Pickable` in a pocket (the `Player`)."""
 
     pocket: Array = field(shape=())
-    """The id of the item in the pocket (0 if empty)"""
+    """`i32[]` - the `Pickable.id` currently carried, or `EMPTY_POCKET_ID`
+    (`-1`) when empty."""
 
 
 class HasTag(Component):
-    """Flags an entity as having a tag, and provides the `tag` attribute. The tag is used to identify the type of the entity in the observations."""
+    """Entity has an integer tag identifying its *type* in observations."""
 
     @property
     def tag(self) -> Array:
-        """The tag of the component, used to identify the type of the component in `observations.categorical`"""
+        """`i32[]` - the value this entity's cells take in a `categorical`
+        observation and the first channel of a `symbolic` one. Constant
+        per entity type (see `entities.EntityIds`).
+
+        Raises:
+            NotImplementedError: on the base class."""
         raise NotImplementedError()
 
 
 class HasSprite(Component):
-    """Flags an entity as having a sprite, and provides the `sprite` attribute. The sprite is used to render the entity in the game."""
+    """Entity has an RGB sprite for `rgb` rendering."""
 
     @property
     def sprite(self) -> Array:
+        """`u8[TILE_SIZE, TILE_SIZE, 3]` (or with leading instance /
+        direction axes) - the tile drawn for this entity.
+
+        Raises:
+            NotImplementedError: on the base class."""
         raise NotImplementedError()

--- a/navix/entities.py
+++ b/navix/entities.py
@@ -1,3 +1,17 @@
+"""The concrete things that live on a grid: `Player`, `Goal`, `Wall`,
+`Key`, `Door`, `Lava`, `Ball`, `Box`.
+
+Each is a frozen `flax.struct` pytree built by composing the mixins in
+`navix.components` (`Positionable`, `Directional`, `Openable`, ...). All
+fields are batched: `state.entities["key"]` is a single `Key` struct
+holding *every* key in the environment, with the instance count as the
+leading axis (`key.position` is `i32[n_keys, 2]`). Index into a batch
+with `entity[i]`.
+
+Entities also expose derived, per-instance properties the engine reads:
+`walkable`, `transparent`, `tag`, `sprite`, `symbolic_state`.
+"""
+
 from __future__ import annotations
 from typing import Tuple, TypeVar
 
@@ -24,7 +38,9 @@ T = TypeVar("T", bound="Entity")
 
 
 class Entities(struct.PyTreeNode):
-    """Entities enum class to store the names of the entities in the game."""
+    """The string keys used in `state.entities` (a `dict[str, Entity]`).
+    Use `Entities.KEY` etc. rather than the bare literal `"key"` so a
+    rename is caught statically."""
 
     WALL: str = struct.field(pytree_node=False, default="wall")
     FLOOR: str = struct.field(pytree_node=False, default="floor")
@@ -38,7 +54,13 @@ class Entities(struct.PyTreeNode):
 
 
 class EntityIds:
-    """EntityIds enum class to store the ids of the entities in the game."""
+    """The integer tag each entity type takes in a `categorical`
+    observation and in the first channel of a `symbolic` one. `uint8`
+    scalars. The values are not contiguous (there is no `3`) - treat them
+    as opaque ids, and `MAX_CATEGORICAL_VALUE` (in
+    `environments.environment`) as the count the observation `Space` uses.
+    `UNKNOWN` (`0`) is also the value of a cell that has not been seen in
+    a first-person observation."""
 
     UNKNOWN: Array = jnp.asarray(0, dtype=jnp.uint8)
     FLOOR: Array = jnp.asarray(1, dtype=jnp.uint8)
@@ -53,7 +75,8 @@ class EntityIds:
 
 
 class Directions:
-    """Directions enum class to store the directions in the game."""
+    """Named values for `Directional.direction`: `EAST=0`, `SOUTH=1`,
+    `WEST=2`, `NORTH=3` (clockwise). `rotate_cw` adds 1 (mod 4)."""
 
     EAST = jnp.asarray(0)
     SOUTH = jnp.asarray(1)
@@ -62,57 +85,78 @@ class Directions:
 
 
 class Entity(Positionable, HasTag, HasSprite):
-    """Entities are components that can be placed in the environment, and have a position and a tag.
-    To create an entity, use the `create` method."""
+    """Base of every concrete entity: has a `position`, a `tag` and a
+    `sprite`. Subclasses add more mixins and fill in the derived
+    properties below. Build one with the subclass's `create`."""
 
     def __getitem__(self: T, idx) -> T:
+        """Selects instance(s) from the batch - `key[0]` is the first key,
+        `key[mask]` the masked subset - by indexing every field's leading
+        axis."""
         return jax.tree.map(lambda x: x[idx], self)
 
     @property
     def name(self) -> str:
-        """The name of the entity
-
-        Returns:
-            str: the name of the entity"""
+        """The class name (`"Key"`, `"Door"`, ...)."""
         return self.__class__.__name__
 
     @property
     def shape(self) -> Tuple[int, ...]:
-        """The batch shape of the entity. The batch shape is the shape of the entity excluding the dimensions of the component.
-        For example, if the entity has a position of shape (batch_size, 2), the shape of the entity is (batch_size,).
-        """
+        """The batch shape - the entity's axes *excluding* each field's
+        own trailing axes. `()` for a single instance, `(n,)` for a batch
+        of `n` (`position` is then `(n, 2)`)."""
         return self.position.shape[:-1]
 
     @property
     def ndim(self) -> int:
-        """The number of dimensions of the entity. The number of dimensions is the number of dimensions of the position minus 1."""
+        """Number of batch dimensions (`len(self.shape)`) - `0` for a
+        single instance, `1` for a flat batch."""
         return self.position.ndim - 1
 
     @property
     def walkable(self) -> Array:
-        """The walkable attribute of the entity. The walkable attribute is a boolean array that indicates if the entity can be walked on."""
+        """`bool[*shape]` - can the player step onto this entity's cell?
+        (`False` for walls and closed doors, `True` for goal/lava/floor.)
+
+        Raises:
+            NotImplementedError: on the base class."""
         raise NotImplementedError()
 
     @property
     def transparent(self) -> Array:
-        """The transparent attribute of the entity. The transparent attribute is a boolean array that indicates if the entity is transparent to rendering."""
+        """`bool[*shape]` - does line of sight pass through this cell?
+        Feeds the first-person view cone (`False` blocks vision).
+
+        Raises:
+            NotImplementedError: on the base class."""
         raise NotImplementedError()
 
     @property
     def symbolic_state(self) -> Array:
-        """The symbolic state representation of the entity. The symbolic state is as the
-        last channel in the symbolic_observation function."""
+        """`i32[*shape]` - the third channel of a `symbolic` observation
+        for this entity (e.g. a door's open/closed/locked; `0` for
+        entities with no internal state).
+
+        Raises:
+            NotImplementedError: on the base class."""
         raise NotImplementedError()
 
 
 class Wall(Entity, HasColour):
-    """Walls are entities that cannot be walked through"""
+    """An impassable, opaque cell. Not walkable, not transparent. The
+    grid border is walls; interior walls form rooms and corridors."""
 
     @classmethod
     def create(
         cls,
         position: Array,
     ) -> Wall:
+        """Args:
+            position (Array): `(row, col)` of each wall, `i32[n, 2]`.
+                Colour is fixed to grey.
+
+        Returns:
+            Wall: the batch of walls."""
         shape = position.shape[:-1]
         grey = jnp.ones(shape, dtype=jnp.uint8) * 5
         return cls(position=position, colour=grey)
@@ -140,7 +184,9 @@ class Wall(Entity, HasColour):
 
 
 class Player(Entity, Directional, Holder):
-    """Players are entities that can act around the environment"""
+    """The agent. Has a `direction` it faces and a `pocket` holding at
+    most one `Pickable`. navix is single-agent, so `state.entities["player"]`
+    is a batch of one."""
 
     @classmethod
     def create(
@@ -149,6 +195,14 @@ class Player(Entity, Directional, Holder):
         direction: Array,
         pocket: Array,
     ) -> Player:
+        """Args:
+            position (Array): `(row, col)`, `i32[2]` (or batched).
+            direction (Array): facing, `i32[]` in `0..3` (see
+                `Directions`).
+            pocket (Array): carried item id, or `EMPTY_POCKET_ID` (`-1`).
+
+        Returns:
+            Player: the entity."""
         return cls(position=position, direction=direction, pocket=pocket)
 
     @property
@@ -178,7 +232,10 @@ class Player(Entity, Directional, Holder):
 
 
 class Goal(Entity, HasColour, Stochastic):
-    """Goals are entities that can be reached by the player"""
+    """The target cell. Walkable and transparent. Reaching it fires a
+    `(GOAL, REACH)` event with probability `probability` (`1.0` in the
+    standard tasks) - `rewards.on_goal_reached` /
+    `terminations.on_goal_reached` react to it."""
 
     @classmethod
     def create(
@@ -186,6 +243,14 @@ class Goal(Entity, HasColour, Stochastic):
         position: Array,
         probability: Array,
     ) -> Goal:
+        """Args:
+            position (Array): `(row, col)`, `i32[2]` (or batched).
+            probability (Array): `f32[]` in `[0, 1]` - chance the reward
+                fires on contact (`1.0` for the standard tasks). Colour
+                is fixed to green.
+
+        Returns:
+            Goal: the entity."""
         shape = position.shape[:-1]
         green = jnp.ones(shape, dtype=jnp.uint8)
         return cls(position=position, probability=probability, colour=green)
@@ -219,8 +284,10 @@ class Goal(Entity, HasColour, Stochastic):
 
 
 class Key(Entity, Pickable, HasColour):
-    """Pickable items are world objects that can be picked up by the player.
-    Examples of pickable items are keys, coins, etc."""
+    """A pickable key. Not walkable, transparent. `pickup` puts its `id`
+    in the player's pocket; a `Door` whose `requires` equals that `id`
+    can then be opened, consuming the key. Its `colour` matches the door
+    it opens."""
 
     @classmethod
     def create(
@@ -229,6 +296,13 @@ class Key(Entity, Pickable, HasColour):
         colour: Array,
         id: Array,
     ) -> Key:
+        """Args:
+            position (Array): `(row, col)`, `i32[2]` (or batched).
+            colour (Array): palette index (see `HasColour`).
+            id (Array): `i32[] >= 1`, matched against `Door.requires`.
+
+        Returns:
+            Key: the entity."""
         colour = jnp.asarray(colour, dtype=jnp.uint8)
         return cls(position=position, id=id, colour=colour)
 
@@ -261,13 +335,11 @@ class Key(Entity, Pickable, HasColour):
 
 
 class Door(Entity, Openable, HasColour):
-    """Consumable items are world objects that can be consumed by the player.
-    Consuming an item requires a tool (e.g. a key to open a door).
-    A tool is an id (int) of another item, specified in the `requires` field (-1 if no tool is required).
-    After an item is consumed, it is both removed from the `state.entities` collection, and replaced in the grid
-    by the item specified in the `replacement` field (0 = floor by default).
-    Examples of consumables are doors (to open) food (to eat) and water (to drink), etc.
-    """
+    """A door in a wall. While closed it is not walkable and not
+    transparent; once open it is both. Opening needs the `open` action
+    while facing it and, if `requires != -1`, the matching `Key` in the
+    pocket (which is then consumed and `requires` set to `-1`). navix
+    doors do not re-close."""
 
     @classmethod
     def create(
@@ -277,6 +349,15 @@ class Door(Entity, Openable, HasColour):
         colour: Array,
         open: Array,
     ) -> Door:
+        """Args:
+            position (Array): `(row, col)`, `i32[2]` (or batched).
+            requires (Array): `Key.id` needed to unlock, or `-1` for an
+                unlocked door.
+            colour (Array): palette index (see `HasColour`).
+            open (Array): `0` closed, `1` open.
+
+        Returns:
+            Door: the entity."""
         colour = jnp.asarray(colour, dtype=jnp.uint8)
         return cls(
             position=position,
@@ -312,6 +393,8 @@ class Door(Entity, Openable, HasColour):
 
     @property
     def locked(self) -> Array:
+        """`bool[*shape]` - `True` while the door still needs a key
+        (`requires != -1`). Becomes `False` once unlocked."""
         return self.requires != jnp.asarray(-1)
 
     @property
@@ -333,13 +416,21 @@ class Door(Entity, Openable, HasColour):
 
 
 class Lava(Entity):
-    """Goals are entities that can be reached by the player"""
+    """A hazard cell. Walkable and transparent (the player *can* step
+    onto it), but doing so fires a `(LAVA, FALL)` event that
+    `terminations.on_lava_fall` turns into a `TERMINATION` - stepping in
+    ends the episode with no reward."""
 
     @classmethod
     def create(
         cls,
         position: Array,
     ) -> Lava:
+        """Args:
+            position (Array): `(row, col)`, `i32[2]` (or batched).
+
+        Returns:
+            Lava: the entity."""
         return cls(position=position)
 
     @property
@@ -371,24 +462,20 @@ class Lava(Entity):
 
 
 class Ball(Entity, Pickable, HasColour, Stochastic):
-    """A pickable obstacle - `id` (from `Pickable`) identifies this ball
-    instance for `actions.pickup`/`actions.drop`, the same way `Key.id`/
-    `Box.id` do. `probability` (from `Stochastic`, pre-existing) is
-    unrelated to pickup - unused by `Ball` itself; every `Ball`
-    instance actually moves unconditionally each step under the default
-    `transitions.stochastic_transition` (`transitions.update_balls`,
-    regardless of `probability`'s value), which is why any environment
-    wanting a static `Ball` (a pickup target/decoy, not a wandering
-    obstacle) must register with `transitions_fn=transitions.
-    deterministic_transition` instead - see `GoToObject`/`Fetch`/
-    `PutNear`/`BlockedUnlockPickup`.
+    """A blocking obstacle that is also pickable. Not walkable,
+    transparent. Colliding with the player fires a `(BALL, HIT)` event
+    (`terminations.on_ball_hit`).
 
-    BREAKING CHANGE: `Ball` becoming `Pickable` means `actions.pickup`
-    no longer no-ops facing a `Ball` in any environment whose
-    action_set includes `pickup` and whose transitions_fn is the
-    default `stochastic_transition` - concretely, this changes
-    `Navix-Dynamic-Obstacles-*`'s existing dynamics: `pickup` now
-    removes the faced obstacle from play instead of doing nothing."""
+    Under the default `transitions.stochastic_transition`, every ball
+    moves one random step each timestep (`transitions.update_balls`), so
+    it acts as a wandering hazard. An environment that wants a *static*
+    ball - a pickup target or decoy - must use
+    `transitions_fn=transitions.deterministic_transition` instead (as
+    `GoToObject` / `Fetch` / `PutNear` / `BlockedUnlockPickup` do).
+
+    `id` (from `Pickable`) is the pickup identity, matched against
+    `player.pocket`; `probability` (from `Stochastic`) is unused by
+    `Ball`."""
 
     @classmethod
     def create(
@@ -398,6 +485,14 @@ class Ball(Entity, Pickable, HasColour, Stochastic):
         probability: Array,
         id: Array,
     ) -> Ball:
+        """Args:
+            position (Array): `(row, col)`, `i32[2]` (or batched).
+            colour (Array): palette index (see `HasColour`).
+            probability (Array): unused by `Ball`; pass `1.0`.
+            id (Array): `i32[] >= 1` pickup identity.
+
+        Returns:
+            Ball: the entity."""
         colour = jnp.asarray(colour, dtype=jnp.uint8)
         return cls(position=position, colour=colour, probability=probability, id=id)
 
@@ -430,23 +525,15 @@ class Ball(Entity, Pickable, HasColour, Stochastic):
 
 
 class Box(Entity, Pickable, HasColour, Holder):
-    """A pickable container - `id` (from `Pickable`) identifies this box
-    instance the same way `Key.id` does, for `actions.pickup` to match
-    against `player.pocket`; `pocket` (from `Holder`) is a *different*
-    field, for whatever item is hidden inside the box (e.g. a `Key`'s
-    id), unrelated to the box's own pickup-identity.
+    """A pickable container. Not walkable, transparent. `open` (the
+    `toggle` action) while facing it removes the box and, if its `pocket`
+    holds a `Key`'s id, reveals that key at the box's former cell
+    (matching MiniGrid's `Box.toggle`). Used by `ObstructedMaze` to hide
+    keys.
 
-    BREAKING CHANGE: `actions.open` (the `toggle` action) now also
-    handles `Box` - toggling one removes it from play and, if its
-    `pocket` held a `Key`'s id, reveals that `Key` at the box's former
-    position (verified against MiniGrid's actual `Box.toggle`: `env.
-    grid.set(pos, self.contains)`). Previously boxes were inert to
-    `toggle` in every environment. This changes the dynamics of any
-    existing environment whose `action_set` includes `toggle` and
-    which places a `Box` (`GoToObject`, `PutNear`, `Unlock`/
-    `UnlockPickup`/`BlockedUnlockPickup`'s decoy box) - the box can now
-    be made to disappear by toggling it, where it previously could
-    not."""
+    Two separate id fields: `id` (from `Pickable`) is the box's own
+    pickup identity, matched against `player.pocket`; `pocket` (from
+    `Holder`) is the id of the item hidden *inside*."""
 
     @classmethod
     def create(
@@ -456,6 +543,15 @@ class Box(Entity, Pickable, HasColour, Holder):
         id: Array,
         pocket: Array,
     ) -> Box:
+        """Args:
+            position (Array): `(row, col)`, `i32[2]` (or batched).
+            colour (Array): palette index (see `HasColour`).
+            id (Array): `i32[] >= 1`, the box's own pickup identity.
+            pocket (Array): id of the contained item, or
+                `EMPTY_POCKET_ID` (`-1`) for an empty box.
+
+        Returns:
+            Box: the entity."""
         colour = jnp.asarray(colour, dtype=jnp.uint8)
         return cls(position=position, colour=colour, id=id, pocket=pocket)
 

--- a/navix/environments/__init__.py
+++ b/navix/environments/__init__.py
@@ -17,6 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""The `Environment` base class, the `Timestep` it returns, and every
+built-in environment (each a MiniGrid task reimplemented in JAX).
+Importing this package registers all of their `Navix-*` ids; get one
+with `navix.make(id)`.
+"""
 
 from __future__ import annotations
 

--- a/navix/environments/crossings.py
+++ b/navix/environments/crossings.py
@@ -17,6 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""MiniGrid's Crossing environments: `SimpleCrossing` / `LavaCrossing`.
+
+See the environment class in this module for the task, layout and
+reward/termination details.
+"""
+
 
 from typing import Union
 import jax

--- a/navix/environments/crossings.py
+++ b/navix/environments/crossings.py
@@ -201,6 +201,20 @@ def _crossings_grid(key: Array, H: int, W: int, n: int) -> Array:
 
 
 class Crossings(Environment):
+    """`Navix-SimpleCrossing-*` / `Navix-LavaCrossing-*`. A square room
+    crossed by `n_crossings` full-width "rivers" of obstacle cells, each
+    with one gap; the gaps sit on a guaranteed-solvable monotone path
+    from the top-left (player) to the bottom-right (goal). Same
+    river-placement as MiniGrid's `CrossingEnv`.
+
+    Attributes:
+        n_crossings: number of rivers. More rivers -> harder.
+        obstacle_type: `"wall"` (`SimpleCrossing` - rivers merely block
+            movement) or `"lava"` (`LavaCrossing` - the river is
+            walkable but stepping in ends the episode via
+            `on_lava_fall`).
+    """
+
     n_crossings: int = struct.field(pytree_node=False, default=1)
     obstacle_type: str = struct.field(pytree_node=False, default="wall")
     """`"wall"` (`SimpleCrossing` - the obstacle blocks movement, no

--- a/navix/environments/dist_shift.py
+++ b/navix/environments/dist_shift.py
@@ -37,6 +37,19 @@ from .registry import register_env
 
 
 class DistShift(Environment):
+    """`Navix-DistShift1-v0` / `Navix-DistShift2-v0`. A small room with a
+    fixed strip of `Lava` between the player (top-left) and the goal
+    (top-right). The two ids differ only in where the lava's far edge
+    sits (`split_lava`), so a policy that overfits the first layout fails
+    on the second - the environment exists to test distribution shift.
+    Nothing is randomised.
+
+    Attributes:
+        split_lava: `False` -> the compact `DistShift1` layout; `True` ->
+            the `DistShift2` layout with the lava strip reaching further
+            down.
+    """
+
     split_lava: bool = struct.field(pytree_node=False, default=False)
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:

--- a/navix/environments/dist_shift.py
+++ b/navix/environments/dist_shift.py
@@ -17,6 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""MiniGrid's DistShift environment - two fixed layouts to test distribution shift.
+
+See the environment class in this module for the task, layout and
+reward/termination details.
+"""
+
 
 from __future__ import annotations
 from typing import Union

--- a/navix/environments/door_key.py
+++ b/navix/environments/door_key.py
@@ -17,6 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""MiniGrid's DoorKey environment - fetch a key to unlock a door to the goal.
+
+See the environment class in this module for the task, layout and
+reward/termination details.
+"""
+
 
 from typing import Union
 import jax

--- a/navix/environments/door_key.py
+++ b/navix/environments/door_key.py
@@ -37,6 +37,19 @@ from .registry import register_env
 
 
 class DoorKey(Environment):
+    """`Navix-DoorKey-*`. A room split in two by an interior wall with a
+    single locked yellow door; a matching key lies in the first half, the
+    goal in the second. The agent must pick up the key, unlock and open
+    the door, then reach the goal. Default reward/termination (`+1` at
+    the goal minus a step cost). The wall column and door row are
+    randomised every reset.
+
+    Attributes:
+        random_start: `False` puts the player at a fixed corner of the
+            first room; `True` (the `-Random-` ids) samples the player
+            and key positions within the first room.
+    """
+
     random_start: bool = struct.field(pytree_node=False, default=False)
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:

--- a/navix/environments/dynamic_obstacles.py
+++ b/navix/environments/dynamic_obstacles.py
@@ -17,6 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""MiniGrid's Dynamic-Obstacles environment - reach the goal past moving balls.
+
+See the environment class in this module for the task, layout and
+reward/termination details.
+"""
+
 
 from __future__ import annotations
 from typing import Union

--- a/navix/environments/empty.py
+++ b/navix/environments/empty.py
@@ -37,6 +37,18 @@ from .registry import register_env
 
 
 class Room(Environment):
+    """A single empty walled room - navix's `Empty` environments
+    (`Navix-Empty-*`). One goal, one player, no obstacles; the task is
+    pure navigation. Reward and termination are the defaults: `+1` on
+    reaching the goal minus a per-step cost, episode ends on the goal.
+
+    Attributes:
+        random_start: `False` (the `Navix-Empty-NxN-v0` ids) places the
+            player at `(1, 1)` facing east and the goal at the opposite
+            corner. `True` (the `-Random-` ids) samples both positions
+            and the player's facing each reset.
+    """
+
     random_start: bool = struct.field(pytree_node=False, default=False)
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:

--- a/navix/environments/empty.py
+++ b/navix/environments/empty.py
@@ -17,6 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""MiniGrid's Empty environment - navigation in a bare walled room (`Room`).
+
+See the environment class in this module for the task, layout and
+reward/termination details.
+"""
+
 
 from __future__ import annotations
 from typing import Union

--- a/navix/environments/environment.py
+++ b/navix/environments/environment.py
@@ -16,6 +16,22 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""The `Environment` class and the `Timestep` it produces.
+
+An `Environment` is a frozen JAX pytree: it holds the grid geometry
+(`height`, `width`, `max_steps`) and a set of *pluggable functions* -
+`observation_fn`, `reward_fn`, `termination_fn`, `transitions_fn`,
+`action_set` - that together define the task. `reset` and `step` are pure
+functions of `(key)` / `(timestep, action)`, so they compose with
+`jax.jit`, `jax.vmap` (a batch of environments) and `jax.lax.scan` (a
+whole rollout in one compiled loop).
+
+Concrete environments (`navix.environments.Empty`, `DoorKey`, ...)
+subclass `Environment` and implement `_reset` to lay out their grid;
+everything else is inherited. Build one with `navix.make(id)` or
+`SomeEnv.create(...)`.
+"""
+
 from __future__ import annotations
 
 import abc
@@ -41,49 +57,153 @@ MAX_CATEGORICAL_VALUE = 1 + max(
 
 
 class StepType(struct.PyTreeNode):
+    """The three kinds of timestep, stored as `Timestep.step_type`. The
+    distinction between the two "episode over" cases matters for
+    bootstrapping a value function: bootstrap through a `TRUNCATION`,
+    but not through a `TERMINATION`."""
+
     TRANSITION = jnp.asarray(0)
-    """Standard timestep transition: the episode continues"""
+    """The episode continues; `step` will keep advancing it."""
     TRUNCATION = jnp.asarray(1)
-    """The environment reached its maximum number of timesteps.
-    The episode ended, but the agent could have still collected rewards.
-    The value of the state is not 0"""
+    """The episode was cut off at `max_steps` while still ongoing. The
+    final state is *not* absorbing - its value is non-zero - so a value
+    estimate should bootstrap through it."""
     TERMINATION = jnp.asarray(2)
-    """The episode ended and the current state is an absorbing state."""
+    """The episode reached a genuine terminal (absorbing) state - the
+    goal, lava, a wrong toggle, etc. Its value is 0; do not bootstrap."""
 
 
 class Timestep(struct.PyTreeNode):
+    """What `Environment.reset` and `Environment.step` return - one moment
+    in a trajectory.
+
+    Read it as the *result* of the transition that produced it: `state`
+    and `t` describe the world now, and `action` / `reward` / `step_type`
+    are the action that got here and its consequences. So after
+    `ts_next = env.step(ts, a)`: `ts_next.state` is $s_{t+1}$,
+    `ts_next.action` is $a$ (`ts.action` is discarded), `ts_next.reward`
+    is $R(s_t, a, s_{t+1})$, and `ts_next.observation` is the observation
+    of $s_{t+1}$.
+
+    Every field is a JAX array (or a pytree of them), so a `Timestep`
+    `vmap`s over a batch of environments and `scan`s over time.
+
+    Attributes:
+        t: steps since the last reset, `i32[]` (or `i32[batch]` when
+            vmapped). `0` exactly on a `reset` output.
+        observation: the agent's view of `state`, produced by the
+            environment's `observation_fn`. Shape and dtype are described
+            by `env.observation_space`; for a `pomdp` observation
+            function this is a partial (first-person, cropped) view.
+        action: the action that led to this timestep, `i32[]`. On a
+            `reset` output it is a placeholder `0`.
+        reward: the scalar reward for the transition into this timestep,
+            `f32[]`, produced by the environment's `reward_fn` (bounds
+            given by `env.reward_space`).
+        step_type: a `StepType` value (`0`/`1`/`2`) - see `StepType`.
+        state: the full `State` (the true MDP state); the observation is
+            a function of this. Also carries the PRNG `key` and the
+            rendering `cache`.
+        info: a plain dict for extra per-step quantities. navix populates
+            `info["return"]` (undiscounted return so far this episode);
+            you may add your own keys.
+    """
+
     t: Array
-    """The number of timesteps elapsed from the last reset of the environment"""
     observation: Array
-    """The observation corresponding to the current state (for POMDPs)"""
     action: Array
-    """The action taken by the agent at the current timestep a_t = $\\pi(s_t)$, where $s_t$ is `state`"""
     reward: Array
-    """The reward $r_{t=1}$ received by the agent after taking action $a_t$"""
     step_type: Array
-    """The type of the current timestep, 0 for TRANSITION, 1 for TRUNCATION, 2 for TERMINATION"""
     state: State
-    """The true state of the MDP, $s_t$ before taking action `action`"""
     info: Dict[str, Any] = struct.field(default_factory=dict)
-    """Additional information about the environment. Useful for accumulations (e.g. returns)"""
 
     def is_truncation(self) -> Array:
+        """`True` where `step_type == StepType.TRUNCATION` (episode cut off
+        at `max_steps`). Boolean, same batch shape as `step_type`."""
         return self.step_type == StepType.TRUNCATION
 
     def is_termination(self) -> Array:
+        """`True` where `step_type == StepType.TERMINATION` (genuine
+        absorbing terminal state). Boolean, same batch shape as
+        `step_type`."""
         return self.step_type == StepType.TERMINATION
 
     def is_transition(self) -> Array:
+        """`True` where the episode is still ongoing
+        (`step_type == StepType.TRANSITION`). Boolean."""
         return self.step_type == StepType.TRANSITION
 
     def is_done(self) -> Array:
+        """`True` where the episode has ended for either reason -
+        truncation or termination. This is the mask you use to segment
+        trajectories or to stop bootstrapping a return."""
         return jnp.logical_or(self.is_truncation(), self.is_termination())
 
     def is_start(self) -> Array:
+        """`True` on the first timestep of an episode (`t == 0`) - both
+        the initial `reset` and every post-autoreset step. Robust to
+        navix deferring autoreset by one `step` call, unlike checking a
+        previous step's `is_done()`."""
         return self.t == 0
 
 
 class Environment(struct.PyTreeNode):
+    """A gridworld task as a frozen JAX pytree.
+
+    The task is defined by five pluggable pieces, each a plain function
+    you can override per-`make`/`create` call:
+
+    - `observation_fn(state) -> Array` - what the agent sees.
+    - `transitions_fn(state, action, action_set) -> State` - the world
+      dynamics (applies `action_set[action]`, then any stochastic
+      entity updates).
+    - `reward_fn(prev_state, action, state) -> f32[]` - the reward for a
+      transition. The `(prev_state, action, state)` triple is the
+      convention across `navix.rewards` / `terminations` / `events`:
+      `prev_state` is $s_t$, `state` is $s_{t+1}$.
+    - `termination_fn(prev_state, action, state) -> bool[]` - whether
+      $s_{t+1}$ is a genuine terminal state (truncation at `max_steps`
+      is added on top automatically).
+    - `action_set` - the tuple of `state -> state` primitives an integer
+      action indexes into.
+
+    Subclasses only implement `_reset` (the initial grid layout);
+    `reset`/`step` are inherited. Instances are immutable - use
+    `env.replace(...)` (from `flax.struct`) to get a modified copy.
+
+    Attributes:
+        height: grid height in cells, including the surrounding wall.
+        width: grid width in cells, including the surrounding wall.
+        max_steps: truncation horizon - `step` returns `StepType.TRUNCATION`
+            once `t >= max_steps`. Default (via `create`) is
+            `4 * height * width`.
+        observation_space: `Space` describing `observation_fn`'s output
+            (shape, dtype, bounds).
+        action_space: `Discrete` over `len(action_set)`.
+        reward_space: `Continuous` bound on the reward, `[-1, 1]` by
+            default.
+        disable_autoreset: if `False` (default), calling `step` on a
+            timestep whose episode already ended returns a fresh `reset`
+            instead of stepping. Set `True` to handle episode boundaries
+            yourself.
+        gamma: discount factor. Not used by `step` itself - carried here
+            so agents and `reward_fn`s (e.g. time-discounted goal
+            rewards) can read it off the environment.
+        penality_coeff: if non-zero, a terminating reward is reduced by
+            `penality_coeff * (t / max_steps)`, i.e. finishing later is
+            worth less. `0.0` disables it.
+        observation_fn: `state -> observation`. One of the functions in
+            `navix.observations`.
+        reward_fn: `(prev_state, action, state) -> f32[]`.
+        termination_fn: `(prev_state, action, state) -> bool[]`.
+        transitions_fn: `(state, action, action_set) -> state`. Usually
+            `transitions.deterministic_transition` or
+            `transitions.stochastic_transition` (the default, which also
+            moves balls).
+        action_set: tuple of `state -> state` callables; an integer
+            action `a` applies `action_set[a]`.
+    """
+
     height: int = struct.field(pytree_node=False)
     width: int = struct.field(pytree_node=False)
     max_steps: int = struct.field(pytree_node=False)
@@ -130,6 +250,38 @@ class Environment(struct.PyTreeNode):
         disable_autoreset: bool = False,
         **kwargs,
     ) -> Environment:
+        """Builds an environment, filling in the spaces and `max_steps`
+        that weren't given.
+
+        This is the shared constructor concrete environments call from
+        their own `create`; `navix.make(id, **kwargs)` ends up here too.
+
+        Args:
+            height (int): grid height in cells (walls included).
+            width (int): grid width in cells (walls included).
+            max_steps (int | None): truncation horizon. `None` ->
+                `4 * height * width`.
+            observation_fn (Callable): `state -> observation`, from
+                `navix.observations`. Default `observations.symbolic`.
+            reward_fn (Callable): `(prev_state, action, state) -> f32[]`.
+            termination_fn (Callable): `(prev_state, action, state) -> bool[]`.
+            transitions_fn (Callable): `(state, action, action_set) -> state`.
+            action_set (tuple[Callable, ...]): `state -> state`
+                primitives indexed by the integer action.
+            observation_space (Space | None): `None` infers it from
+                `observation_fn` and the grid size (works for the
+                built-in observation functions; pass one explicitly for
+                a custom `observation_fn`).
+            action_space (Space | None): `None` -> `Discrete(len(action_set))`.
+            reward_space (Space | None): `None` -> `Continuous((), -1, 1)`.
+            disable_autoreset (bool): see the class attribute.
+            **kwargs: extra fields forwarded to the subclass constructor
+                (e.g. `gamma`, `penality_coeff`, or an environment's own
+                layout options like `random_start`).
+
+        Returns:
+            Environment: the constructed environment.
+        """
         if observation_space is None:
             observation_space = cls._get_obs_space_from_fn(
                 width, height, observation_fn
@@ -160,15 +312,64 @@ class Environment(struct.PyTreeNode):
 
     @abc.abstractmethod
     def _reset(self, key: Array, cache: RenderingCache | None = None) -> Timestep:
+        """Lays out the initial grid and returns the first `Timestep`.
+        Implemented by each concrete environment; call `reset` (which
+        wraps this) rather than this directly.
+
+        Args:
+            key (Array): PRNG key for any randomised placement.
+            cache (RenderingCache | None): reuse a rendering cache built
+                for a same-shaped grid; `None` builds a fresh one.
+
+        Returns:
+            Timestep: `t = 0`, `step_type = TRANSITION`, placeholder
+            `action`/`reward`."""
         raise NotImplementedError()
 
     def reset(self, key: Array, cache: RenderingCache | None = None) -> Timestep:
+        """Starts a new episode.
+
+        Args:
+            key (Array): a `jax.random` PRNG key. Split it yourself
+                across a batch (`jax.vmap(env.reset)(keys)`).
+            cache (RenderingCache | None): optional pre-built rendering
+                cache (see `_reset`).
+
+        Returns:
+            Timestep: the first timestep - `t = 0`, `is_start()` true,
+            `info["return"] = 0.0`. `state.key` is a fresh key derived
+            from `key`, so the environment's own stochasticity is
+            reproducible from the single seed you pass here.
+        """
         k1, k2 = jax.random.split(key)
         timestep = self._reset(k1, cache)
         timestep.info["return"] = jnp.asarray(0.0)
         return timestep.replace(state=timestep.state.replace(key=k2))
 
     def step(self, timestep: Timestep, action: Array) -> Timestep:
+        """Advances one timestep, or auto-resets at an episode boundary.
+
+        If `timestep` already ended an episode (its `step_type > 0`) and
+        `disable_autoreset` is `False`, this ignores `action` and returns
+        a fresh `reset` seeded from `timestep.state.key`. Otherwise it
+        applies `action` via `transitions_fn`, then evaluates
+        `reward_fn`, `termination_fn` and `observation_fn` on the result.
+
+        Autoreset is deferred by one call: the terminal timestep is
+        returned as-is (so you can read its final reward), and the reset
+        happens on the *next* `step`. Detect a fresh episode with
+        `timestep.is_start()`, not by looking back at `is_done()`.
+
+        Args:
+            timestep (Timestep): the current timestep (from `reset` or a
+                previous `step`).
+            action (Array): an integer action, `i32[]`, in
+                `[0, len(action_set))`. Indexes `action_set`.
+
+        Returns:
+            Timestep: the next timestep. `info["return"]` accumulates the
+            undiscounted episodic reward.
+        """
         # autoreset if necessary: 0 = transition, 1 = truncation, 2 = termination
         should_reset = timestep.step_type > 0
         return jax.lax.cond(
@@ -179,12 +380,16 @@ class Environment(struct.PyTreeNode):
         )
 
     def _step(self, timestep: Timestep, action: Array) -> Timestep:
-        """
+        """The non-autoreset half of `step`: apply `action` to
+        `timestep.state` and build the resulting `Timestep` at `t + 1`.
+        `step` calls this; call `step`, not this.
+
         Args:
-            timestep (Timestep): The timestep at time $t$.
-            action (Array): The action $a_t \\sim \\pi(A_t | s_t)$
+            timestep (Timestep): the timestep at time $t$.
+            action (Array): the integer action $a_t$.
+
         Returns:
-            (Timestep): The timestep at time $t + 1$
+            Timestep: the timestep at time $t + 1$.
         """
         # events are a per-step record - EventsManager's own docstring
         # says "which events happened this timestep" - but
@@ -240,6 +445,20 @@ class Environment(struct.PyTreeNode):
     def termination(
         self, prev_state: State, action: Array, state: State, t: Array
     ) -> Array:
+        """Combines the task's `termination_fn` with the `max_steps`
+        truncation into a single `StepType`.
+
+        Args:
+            prev_state (State): $s_t$.
+            action (Array): $a_t$.
+            state (State): $s_{t+1}$.
+            t (Array): the step count of `state` (`i32[]`).
+
+        Returns:
+            Array: a `StepType` value - `TERMINATION` if `termination_fn`
+            fired, else `TRUNCATION` if `t >= max_steps`, else
+            `TRANSITION`. Termination takes precedence over truncation.
+        """
         terminated = self.termination_fn(prev_state, action, state)
         truncated = t >= self.max_steps
         return terminations.check_truncation(terminated, truncated)
@@ -248,6 +467,10 @@ class Environment(struct.PyTreeNode):
     def _get_obs_space_from_fn(
         width: int, height: int, observation_fn: Callable[[State], Array]
     ) -> Space:
+        """Infers the `observation_space` for a built-in `observation_fn`
+        and grid size. Raises `NotImplementedError` for an unrecognised
+        function - pass `observation_space` explicitly to `create` in
+        that case."""
         if observation_fn == observations.none:
             return Continuous.create(
                 shape=(), minimum=jnp.asarray(0.0), maximum=jnp.asarray(0.0)

--- a/navix/environments/fetch.py
+++ b/navix/environments/fetch.py
@@ -52,6 +52,17 @@ from .registry import register_env
 
 
 class Fetch(Environment):
+    """`Navix-Fetch-*`. A room scattered with `n_objects` coloured
+    `Key`/`Ball` objects; one is named as the target in `State.mission`.
+    Picking up *any* object ends the episode - reward `1` only if it was
+    the target, `0` otherwise. See the module docstring for MiniGrid
+    parity notes.
+
+    Attributes:
+        n_objects: how many objects to scatter (split roughly half keys,
+            half balls).
+    """
+
     n_objects: int = struct.field(pytree_node=False, default=2)
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:

--- a/navix/environments/four_rooms.py
+++ b/navix/environments/four_rooms.py
@@ -17,6 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""MiniGrid's FourRooms environment - four quadrants joined by narrow doorways.
+
+See the environment class in this module for the task, layout and
+reward/termination details.
+"""
+
 
 from __future__ import annotations
 from typing import Union

--- a/navix/environments/four_rooms.py
+++ b/navix/environments/four_rooms.py
@@ -43,6 +43,13 @@ from .registry import register_env
 
 
 class FourRooms(Environment):
+    """`Navix-FourRooms-*`. The classic four-rooms layout: a cross of
+    interior walls divides the room into quadrants, each connected to its
+    neighbours by a one-cell doorway at a randomised position. Player and
+    goal are placed at random free cells (any two rooms). Default
+    reward/termination; the difficulty is the long, gap-constrained path
+    between quadrants."""
+
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
         assert self.height > 4, f"Insufficient height for room {self.height} < 4"
         assert self.width > 4, f"Insufficient width for room {self.width} < 4"

--- a/navix/environments/go_to_door.py
+++ b/navix/environments/go_to_door.py
@@ -17,6 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""MiniGrid's GoToDoor environment - signal `done` at the named coloured door.
+
+See the environment class in this module for the task, layout and
+reward/termination details.
+"""
+
 
 from __future__ import annotations
 from typing import Union

--- a/navix/environments/go_to_door.py
+++ b/navix/environments/go_to_door.py
@@ -39,6 +39,16 @@ from .registry import register_env
 
 
 class GoToDoor(Environment):
+    """`Navix-GoToDoor-*`. A room with a coloured `Door` on each of the
+    four walls; one is named in `State.mission`. The agent succeeds by
+    signalling `done` next to the target door. Door positions and colours
+    and the room size are randomised each reset.
+
+    Attributes:
+        split_lava: unused by `GoToDoor`; kept for constructor
+            compatibility.
+    """
+
     split_lava: bool = struct.field(pytree_node=False, default=False)
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:

--- a/navix/environments/go_to_object.py
+++ b/navix/environments/go_to_object.py
@@ -63,6 +63,17 @@ from .registry import register_env
 
 
 class GoToObject(Environment):
+    """`Navix-GoToObject-*`. A room scattered with `n_objects` coloured
+    `Key`/`Ball`/`Box` objects of distinct colours; one is named in
+    `State.mission`. The agent succeeds by signalling `done` while
+    orthogonally adjacent to the target (using `toggle` fails outright).
+    Each object's type is drawn independently per episode. Uses
+    `deterministic_transition` so balls stay put.
+
+    Attributes:
+        n_objects: how many objects to scatter.
+    """
+
     n_objects: int = struct.field(pytree_node=False, default=2)
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:

--- a/navix/environments/key_corridor.py
+++ b/navix/environments/key_corridor.py
@@ -17,6 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""MiniGrid's KeyCorridor environment - find a key off a corridor to reach a locked room.
+
+See the environment class in this module for the task, layout and
+reward/termination details.
+"""
+
 
 from __future__ import annotations
 

--- a/navix/environments/lava_gap.py
+++ b/navix/environments/lava_gap.py
@@ -17,6 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""MiniGrid's LavaGap environment - cross a lava strip through its single gap.
+
+See the environment class in this module for the task, layout and
+reward/termination details.
+"""
+
 
 from typing import Union
 

--- a/navix/environments/lava_gap.py
+++ b/navix/environments/lava_gap.py
@@ -37,6 +37,13 @@ from .registry import register_env
 
 
 class LavaGap(Environment):
+    """`Navix-LavaGap-*`. A room with a vertical strip of `Lava` spanning
+    it, broken by a single one-cell gap at a randomised row. The agent
+    starts in one corner, the goal is in the opposite one; it must find
+    and pass through the gap. Stepping into lava ends the episode with no
+    reward (via the default `on_lava_fall` termination); reaching the
+    goal gives `+1` minus a step cost."""
+
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
         # check minimum height and width
         assert (

--- a/navix/environments/locked_room.py
+++ b/navix/environments/locked_room.py
@@ -93,6 +93,14 @@ def room_layout(height: int, width: int) -> Tuple[Array, Array, Array, int, int]
 
 
 class LockedRoom(Environment):
+    """`Navix-LockedRoom-v0`. Six rooms lining a central hallway, each
+    with its own coloured door onto the hallway. One room is locked and
+    holds the goal; the matching key is hidden in one of the other five.
+    The agent must find the key, unlock that door, and reach the goal.
+    Room geometry is a fixed function of the grid size; which room is
+    locked, the door colours, the key's room and every exact position
+    are randomised."""
+
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
         tops, sizes, doors_pos, left_wall, right_wall = room_layout(self.height, self.width)
 

--- a/navix/environments/memory.py
+++ b/navix/environments/memory.py
@@ -17,6 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""MiniGrid's Memory environment - recall a cue seen at the start to pick the right exit.
+
+See the environment class in this module for the task, layout and
+reward/termination details.
+"""
+
 
 from __future__ import annotations
 from typing import Union

--- a/navix/environments/playground.py
+++ b/navix/environments/playground.py
@@ -111,6 +111,13 @@ def wall_segments(
 
 
 class Playground(Environment):
+    """`Navix-Playground-v0`. A 3x3 grid of rooms joined by one random
+    unlocked door per adjacent pair, with 12 randomly-typed
+    `Key`/`Ball`/`Box` objects scattered throughout. There is no goal:
+    reward is always `0` (`rewards.free`) and the episode only ever ends
+    at `max_steps`. Intended as a sandbox for exploration / unsupervised
+    objectives."""
+
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
         vertical_walls, horizontal_walls = wall_segments(self.height, self.width)
         room_size = self.height // 3  # square rooms - == self.width // 3 too

--- a/navix/environments/put_near.py
+++ b/navix/environments/put_near.py
@@ -66,6 +66,17 @@ from .registry import register_env
 
 
 class PutNear(Environment):
+    """`Navix-PutNear-*`. A room scattered with `n_objects` coloured
+    `Key`/`Ball`/`Box` objects; two are named in `State.mission` - one to
+    carry (`mission[0]`) and one to drop it next to (`mission[1]`).
+    Success: pick up the carry object and drop it within Chebyshev
+    distance 1 of the target. Picking up the wrong object, or any drop
+    attempt, ends the episode (reward `1` only on a correct near-drop).
+
+    Attributes:
+        n_objects: how many objects to scatter.
+    """
+
     n_objects: int = struct.field(pytree_node=False, default=2)
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:

--- a/navix/environments/red_blue_doors.py
+++ b/navix/environments/red_blue_doors.py
@@ -55,6 +55,12 @@ from .registry import register_env
 
 
 class RedBlueDoors(Environment):
+    """`Navix-RedBlueDoors-*`. One room, a dividing wall holding a red and
+    a blue `Door` (both reachable from the start side). Success is
+    opening the blue door *after* the red one is already open; opening
+    blue first ends the episode with no reward. The task is about
+    ordering, not navigation."""
+
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
         k_wall, k_rows, k_pos, k_dir = jax.random.split(key, 4)
 

--- a/navix/environments/registry.py
+++ b/navix/environments/registry.py
@@ -16,6 +16,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""The environment registry: `make` an environment by string id, and
+`register_env` to add your own.
+
+Every built-in environment registers itself at import time (importing
+`navix` is enough), so `navix.make(id)` is the normal way to get an
+`Environment`. The ids follow MiniGrid's naming with a `Navix-` prefix
+and a `-v0` suffix, e.g. `Navix-Empty-5x5-v0`, `Navix-DoorKey-8x8-v0`,
+`Navix-MultiRoom-N4-S5-v0`.
+"""
+
 from typing import Callable
 import difflib
 import warnings
@@ -24,11 +34,28 @@ import warnings
 _ENVS_REGISTRY = {}
 
 
-def registry():
+def registry() -> dict:
+    """The full id -> constructor mapping.
+
+    Returns:
+        dict: maps each registered environment id (e.g.
+        `"Navix-Empty-5x5-v0"`) to a zero-argument-or-kwargs callable
+        that builds the `Environment`. The live dict, not a copy -
+        `sorted(navix.registry())` lists every available id."""
     return _ENVS_REGISTRY
 
 
 def register_env(name: str, ctor: Callable):
+    """Adds an environment id to the registry (or overwrites one).
+
+    Args:
+        name (str): the id `make` will accept, e.g.
+            `"Navix-MyEnv-8x8-v0"`.
+        ctor (Callable): builds and returns the `Environment`. `make`
+            calls it as `ctor(**kwargs)`, forwarding whatever keyword
+            arguments were passed to `make` (`observation_fn`, `gamma`,
+            `max_steps`, ...), so `ctor` typically ends in
+            `MyEnv.create(...)`."""
     _ENVS_REGISTRY[name] = ctor
 
 
@@ -47,9 +74,49 @@ V1_ALIASES = {
     "MiniGrid-ObstructedMaze-Full-v1": "Navix-ObstructedMaze-Full-v0",
     "MiniGrid-MultiRoom-N4-S5-v1": "Navix-MultiRoom-N4-S5-v0",
 }
+"""MiniGrid `-v1` ids that navix implements under a plain `-v0` id rather
+than as a separate `-v1` registration: for these families navix ports
+MiniGrid's `-v1` behaviour and calls it `-v0` (the per-environment
+behavioural difference is documented in each target's module docstring).
+`make` redirects a `-v1` key here to its `-v0` value and warns, so code
+written against MiniGrid's own id still resolves."""
 
 
 def make(name: str, **kwargs):
+    """Builds a registered environment by id.
+
+    Args:
+        name (str): a registered id (see `sorted(navix.registry())` for
+            the full list). A handful of MiniGrid `-v1` ids are accepted
+            too and transparently redirected to their navix `-v0`
+            equivalent with a warning (see `V1_ALIASES`).
+        **kwargs: forwarded verbatim to the environment's constructor.
+            Common ones: `observation_fn` (a function from `navix.observations`,
+            default is environment-specific), `gamma` (discount, default
+            `0.99`), `max_steps` (episode truncation horizon, default
+            `4 * height * width`), `observation_space` (override the
+            inferred `Space`). Anything the specific environment's
+            `create` accepts also works.
+
+    Returns:
+        Environment: the constructed environment.
+
+    Raises:
+        NotImplementedError: if `name` is not registered. The message
+            lists close matches and links the feature-request form.
+
+    Example:
+        ```python
+        import navix as nx
+        from navix import observations
+
+        env = nx.make(
+            "Navix-DoorKey-8x8-v0",
+            observation_fn=observations.rgb_first_person,
+            gamma=0.995,
+        )
+        ```
+    """
     if name in V1_ALIASES:
         target = V1_ALIASES[name]
         warnings.warn(
@@ -74,10 +141,8 @@ def make(name: str, **kwargs):
     return ctor(**kwargs)
 
 
-# Every MiniGrid id without a navix equivalent used to be tracked here.
-# As of this commit that list is empty - every remaining MiniGrid id
-# either has a matching Navix-* registration, or (the "-v1" family
-# above) resolves through V1_ALIASES instead. Kept as a named, exported
-# list (rather than deleted) so a future gap has an obvious place to be
-# added back to.
 NotImplementedEnvs = []
+"""MiniGrid environment ids that navix does not yet cover. Currently
+empty - every MiniGrid id either has a `Navix-*` registration or resolves
+through `V1_ALIASES`. Kept as a named list so a future gap has an obvious
+place to be recorded."""

--- a/navix/environments/wrappers.py
+++ b/navix/environments/wrappers.py
@@ -1,3 +1,9 @@
+"""Adapt a navix `Environment` to the `gymnax` API, so navix
+environments can be dropped into agents and tooling written against
+gymnax (`(obs, state)` from `reset`, `(obs, state, reward, done, info)`
+from `step`, with an explicit `params`).
+"""
+
 from typing import Any, Dict, Tuple
 import jax
 from jax import Array
@@ -14,26 +20,73 @@ from .environment import Environment, Timestep
 
 @struct.dataclass
 class GymnaxState(EnvState):
+    """A gymnax `EnvState` that simply carries the wrapped navix
+    `Timestep`. `ToGymnax.step` unwraps `timestep`, advances the navix
+    environment, and rewraps.
+
+    Attributes:
+        timestep: the underlying navix `Timestep`.
+        time: `timestep.t`, exposed at the top level because gymnax reads
+            `state.time` for its own truncation bookkeeping.
+    """
+
     timestep: Timestep
     time: Array
 
 
 class ToGymnax(GymnaxEnv):
+    """Wraps a navix `Environment` as a `gymnax.environments.Environment`.
+
+    Prefer `ToGymnax.wrap(env)`, which returns the `(gymnax_env, params)`
+    pair gymnax callers expect.
+
+    ```python
+    import navix as nx
+    from navix.environments.wrappers import ToGymnax
+
+    gymnax_env, params = ToGymnax.wrap(nx.make("Navix-Empty-5x5-v0"))
+    obs, state = gymnax_env.reset(key, params)
+    obs, state, reward, done, info = gymnax_env.step(key, state, action, params)
+    ```
+
+    `done` merges navix's truncation and termination into gymnax's single
+    boolean; `StepType` is still available via `state.timestep.step_type`.
+    Autoreset follows navix's rules (see `Environment.step`), not
+    gymnax's.
+    """
+
     def __init__(self, env: Environment):
+        """Args:
+        env (Environment): the navix environment to wrap."""
         self.env = env
 
     @property
     def default_params(self) -> EnvParams:
+        """A gymnax `EnvParams` carrying the wrapped env's `max_steps` as
+        `max_steps_in_episode`."""
         return EnvParams(max_steps_in_episode=self.env.max_steps)
 
     @classmethod
     def wrap(cls, env: Environment) -> Tuple[GymnaxEnv, EnvParams]:
+        """Builds the wrapper and its params in one call.
+
+        Args:
+            env (Environment): the navix environment to wrap.
+
+        Returns:
+            tuple: `(ToGymnax(env), EnvParams(max_steps_in_episode=env.max_steps))`.
+        """
         return cls(env=env), EnvParams(max_steps_in_episode=env.max_steps)
 
     def action_space(self, params: Any):
+        """The gymnax `Discrete` action space, `len(env.action_set)`
+        values. `params` is ignored (kept for API compatibility)."""
         return GymnaxDiscrete(len(self.env.action_set))
 
     def observation_space(self, params: Any):
+        """The wrapped env's observation `Space` as a gymnax `Box`
+        (`low`/`high`/`shape`/`dtype` copied across). `params` is
+        ignored."""
         o_space = self.env.observation_space
         return GymnaxBox(
             low=o_space.minimum,
@@ -45,6 +98,16 @@ class ToGymnax(GymnaxEnv):
     def reset(
         self, key: jax.Array, params: EnvParams | None = None
     ) -> Tuple[Array, EnvState]:
+        """Resets the wrapped environment.
+
+        Args:
+            key (Array): PRNG key.
+            params (EnvParams | None): ignored; `max_steps` comes from the
+                wrapped env.
+
+        Returns:
+            tuple: `(observation, GymnaxState)`.
+        """
         timestep = self.env.reset(key)
         return (
             timestep.observation,
@@ -54,6 +117,20 @@ class ToGymnax(GymnaxEnv):
     def step(
         self, key: Array, state: GymnaxState, action: jax.Array, params: EnvParams
     ) -> Tuple[Array, EnvState, Array, Array, Dict[str, Any]]:
+        """Advances the wrapped environment one step.
+
+        Args:
+            key (Array): PRNG key (unused - navix carries its own key in
+                `state.timestep.state.key`).
+            state (GymnaxState): the state returned by the previous
+                `reset`/`step`.
+            action (Array): integer action, `[0, len(action_set))`.
+            params (EnvParams): ignored.
+
+        Returns:
+            tuple: `(observation, GymnaxState, reward, done, info)`, where
+            `done = timestep.is_done()` (truncation or termination).
+        """
         timestep = self.env.step(state.timestep, action)
         return (
             timestep.observation,

--- a/navix/es.py
+++ b/navix/es.py
@@ -48,12 +48,28 @@ class LogUniform(distrax.Uniform):
     the known-good region."""
 
     def __init__(self, low: float, high: float):
+        """Args:
+            low (float): lower bound, `> 0`.
+            high (float): upper bound, `> low`."""
         super().__init__(low=jnp.log(low), high=jnp.log(high))
 
     def sample(self, *, seed, sample_shape=()):
+        """Draws a log-uniform sample in `[low, high]`.
+
+        Args:
+            seed: a `jax.random` PRNG key.
+            sample_shape: extra leading shape for a batch of draws.
+
+        Returns:
+            Array: the sample(s), always positive."""
         return jnp.exp(super().sample(seed=seed, sample_shape=sample_shape))
 
     def sample_n(self, rng, n):
+        """`n` log-uniform samples, shape `(n, ...)`.
+
+        Args:
+            rng: a `jax.random` PRNG key.
+            n (int): how many samples."""
         return jnp.exp(super().sample_n(rng, n))
 
 

--- a/navix/events.py
+++ b/navix/events.py
@@ -17,18 +17,27 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Issue #192: every function in this module takes the uniform
-`(prev_state, action, state)` triple, even where its own body only
-reads a subset of it - matching the convention `rewards.py`/
-`terminations.py`'s wrapper functions already use unconditionally
-(e.g. `rewards.on_goal_reached(prev_state, action, state)` ignores the
-first two args entirely). Before this, 5 different signature shapes
-were spread across this module's functions (`(state)`, `(prev_state,
-state)`, `(action, state)`, `(action)`, `(prev_state, action)`), each
-needing its own docstring paragraph explaining why it deviated from a
-single-state "convention" that was never actually uniform. One honest,
-uniform contract instead - unused args are still named in each
-function's docstring, marked `(unused)`."""
+"""Event detectors: given a transition, did some notable thing happen?
+
+An *event* is a thing that occurred during one step - the goal was
+reached, a ball hit the player, a door was unlocked. The transition
+pipeline records events into `state.events` (an `EventsManager`, reset
+every step), and the functions here read that record - together with
+`prev_state`/`action`/`state` - to answer yes/no questions about the
+step. `navix.rewards` and `navix.terminations` are thin, dtype-coercing
+wrappers around these; this module is where each condition's exact
+semantics live.
+
+Every function has the same signature,
+
+    fn(prev_state: State, action: Array, state: State) -> Array
+
+returning a boolean scalar `bool[]`. Not all three arguments are used by
+every function - some only need `state`, a few need `prev_state` to
+detect a *change* this step (the event record alone can't say whether a
+flag just flipped or was already set). Each function's docstring marks
+the arguments it ignores.
+"""
 
 from __future__ import annotations
 
@@ -47,8 +56,15 @@ from .entities import Entities, Player
 # default action_set (matches the existing precedent of
 # `rewards.action_cost` hardcoding an action index the same way).
 DONE_ACTION = jnp.asarray(actions.MINIGRID_ACTION_SET.index(actions.done))
+"""The integer that means `actions.done` in the default action set -
+used by detectors like `on_target_done` that care *which* action was
+taken. Only correct for environments using `MINIGRID_ACTION_SET`."""
 TOGGLE_ACTION = jnp.asarray(actions.MINIGRID_ACTION_SET.index(actions.toggle))
+"""The integer that means `actions.toggle` in the default action set
+(see `DONE_ACTION`)."""
 DROP_ACTION = jnp.asarray(actions.MINIGRID_ACTION_SET.index(actions.drop))
+"""The integer that means `actions.drop` in the default action set (see
+`DONE_ACTION`)."""
 
 
 def on_goal_reached(prev_state: State, action: Array, state: State) -> Array:
@@ -245,24 +261,25 @@ def on_ordered_doors_failure(prev_state: State, action: Array, state: State) -> 
 
 
 def on_target_done(prev_state: State, action: Array, state: State) -> Array:
-    """`GoToObject`'s real win condition (verified directly against
-    MiniGrid's actual `GoToObjectEnv.step` source): the `done` action
-    was called while orthogonally adjacent to `state.mission`'s target -
-    NOT while facing it. An earlier version of this function required
-    facing too, which was a misreading of the source: real MiniGrid's
-    check is pure position, `(ax==tx and abs(ay-ty)==1) or (ay==ty and
-    abs(ax-tx)==1)`, with no facing/direction test at all (PR #191
-    review caught this - reproduced directly: with the player adjacent
-    but facing perpendicular to the target, this function used to
-    return `False` where real MiniGrid rewards it).
+    """`GoToObject`'s win condition: the `done` action was taken while
+    the player is **orthogonally adjacent** to the target named by
+    `state.mission` - direction/facing is not checked. This is a pure
+    position test, `(row == target_row and |col - target_col| == 1) or
+    (col == target_col and |row - target_row| == 1)`, matching
+    MiniGrid's `GoToObjectEnv.step`.
+
+    `state.mission` must be non-empty (an `AssertionError` otherwise).
+    "The `done` action" is `action == DONE_ACTION`, i.e. only meaningful
+    for an environment using the default action set.
 
     Args:
-        prev_state (State): The state before this step's action (unused).
-        action (Array): The action taken by the player.
-        state (State): The current state of the game.
+        prev_state (State): $s_t$ (unused).
+        action (Array): the integer action taken.
+        state (State): $s_{t+1}$ - source of the player and target
+            positions.
 
     Returns:
-        Array: A boolean scalar."""
+        Array: `bool[]`."""
     assert (
         len(state.mission) > 0
     ), "on_target_done requires the state to specify a mission."

--- a/navix/experiment.py
+++ b/navix/experiment.py
@@ -90,24 +90,30 @@ def hparam_search_fitness(logs: Dict[str, jax.Array]) -> jax.Array:
 
 
 class Experiment:
-    """A class to run an experiment with a given agent and environment.
+    """Trains one `agent` on one `env` for a list of `seeds` and collects
+    the metrics.
+
+    `run()` compiles the agent's `train` once and runs it for every seed
+    (each seed is an independent training run from a different PRNG key),
+    returning the stacked final train state and a `logs` pytree with a
+    leading seed axis. `run_hparam_search()` wraps that in an
+    Evolution-Strategies loop over hyperparameters.
 
     Args:
-        name (str): The name of the experiment.
-        agent (Agent): The agent to use in the experiment.
-        env (Environment): The environment to use in the experiment.
-        env_id (str): The ID of the environment.
-        seeds (Tuple[int, ...]): The seeds to use in the experiment.
-        group (str): The group to use in the experiment.
-
-    Attributes:
-        name (str): The name of the experiment.
-        agent (Agent): The agent to use in the experiment.
-        env (Environment): The environment to use in the experiment.
-        env_id (str): The ID of the environment.
-        seeds (Tuple[int, ...]): The seeds to use in the experiment.
-        group (str): The group to use in the experiment.
-
+        name (str): experiment name; used as the wandb project and as a
+            prefix for run names.
+        agent (Agent): the agent to train (`PPO`, `PQN`, `Dreamer`, or a
+            custom `Agent`). It already holds its own `hparams`.
+        env (Environment): the environment to train on. Usually the same
+            one `nx.make(env_id)` returns.
+        env_id (str): the registered id of `env` (e.g.
+            `"Navix-Empty-5x5-v0"`). Logged as metadata and used to match
+            a run to a `navix.benchmarks` protocol; `""` if `env` is not
+            a registered environment.
+        seeds (Tuple[int, ...]): one training run per seed. Default
+            `(0,)`.
+        group (str): optional wandb group, for aggregating related runs
+            in the dashboard.
     """
 
     def __init__(

--- a/navix/grid.py
+++ b/navix/grid.py
@@ -18,6 +18,31 @@
 # under the License.
 
 
+"""Array helpers for grid geometry - the low-level toolkit the
+environments, `navix.actions` and `navix.observations` are built from.
+
+Everything here is a pure JAX function over plain arrays; nothing knows
+about `State` or `Entity`. Groups:
+
+- coordinate <-> flat-index conversion (`coordinates`,
+  `idx_from_coordinates`, ...);
+- movement and rotation of a `(row, col)` position or a direction
+  (`translate`, `rotate`, `translate_forward/left/right`);
+- rotating an image patch to align it with a direction (`align`,
+  `rotate_tile`);
+- random placement (`random_positions`, `random_distinct_positions`,
+  `random_position_far_from`, `random_directions`, `random_colour`);
+- building maps (`room`, `two_rooms`, `vertical_wall`, `horizontal_wall`,
+  `from_ascii_map`) and the multi-room grid helpers (`room_grid*`,
+  `room_*`, `RoomsGrid`);
+- cropping and first-person rendering (`crop`, `view_cone`,
+  `draw_grid_lines`, `apply_minigrid_opacity`).
+
+Convention: positions are `(row, col)`, directions are `0` east, `1`
+south, `2` west, `3` north, and a "grid" is `i32[H, W]` with `0` = floor
+and `-1` = wall.
+"""
+
 from __future__ import annotations
 from functools import partial
 import math
@@ -32,6 +57,8 @@ from navix.rendering.registry import TILE_SIZE
 
 
 Coordinates = Tuple[Array, Array]
+"""A `(rows, cols)` pair of index arrays, as returned by `coordinates` -
+the shape `jnp.where` / advanced indexing expect."""
 
 
 def coordinates(grid: Array) -> Coordinates:

--- a/navix/observations.py
+++ b/navix/observations.py
@@ -18,6 +18,34 @@
 # under the License.
 
 
+"""Observation functions: how a `State` is turned into what the agent sees.
+
+Pick one and pass it as `observation_fn` to `navix.make` / `Environment.create`.
+Two families:
+
+- **Fully observable** (`categorical`, `symbolic`, `rgb`) - the whole
+  `height x width` grid, always the same orientation.
+- **First person / POMDP** (`categorical_first_person`,
+  `symbolic_first_person`, `rgb_first_person`) - cropped to a
+  `(2 * RADIUS + 1)` square with the player at the bottom-centre facing
+  *up*, so the observation is egocentric and rotation-invariant. Cells
+  the player cannot see (behind a wall, outside the view cone) are masked
+  to a "not seen" fill.
+
+Three encodings, shared by both families:
+
+- **categorical** - one integer per cell, the entity's tag (see
+  `entities.EntityIds`); shape `(H, W)`.
+- **symbolic** - three integers per cell `(tag, colour, state)` as in
+  MiniGrid; shape `(H, W, 3)`, `uint8`.
+- **rgb** - a rendered image, `uint8`, each cell a `TILE_SIZE x TILE_SIZE`
+  sprite; shape `(H * TILE_SIZE, W * TILE_SIZE, 3)`.
+
+`Environment` infers the matching `observation_space` for these built-in
+functions; a custom `observation_fn` needs `observation_space` passed
+explicitly.
+"""
+
 from __future__ import annotations
 import jax
 
@@ -38,36 +66,48 @@ from .entities import EntityIds
 
 
 RADIUS = 3
+"""Half-size of the first-person view: those observations are
+`(2 * RADIUS + 1)` cells on a side (default `3` -> a 7x7 window). Change
+it with `set_radius` *before* building an environment - `Environment`
+reads it when it computes `observation_space`."""
 
 
 def set_radius(radius: int):
+    """Sets the module-global `RADIUS` used by every `*_first_person`
+    observation. Call it before `navix.make` so the environment's
+    `observation_space` picks up the new size.
+
+    Args:
+        radius (int): the new half-window size; the view becomes
+            `(2 * radius + 1)` cells square."""
     global RADIUS
     RADIUS = radius
 
 
 def none(state: State) -> Array:
-    """An empty observation represented as an array of shape f32[0].
-    Useful for testing purposes.
+    """The empty observation - shape `f32[0]`. Use it when the agent
+    should learn from `state`/`reward` directly (e.g. debugging, or a
+    hand-coded policy) and never looks at `observation`.
 
     Args:
-        state (State): The current state of the game.
+        state (State): the current state (ignored).
 
     Returns:
-        Array: A 0-shaped array `f32[0]`."""
+        Array: an empty `f32[0]` array."""
     return jnp.asarray(())
 
 
 def categorical(state: State) -> Array:
-    """Fully observable grid with a categorical state representation.
-    Each entity is represented by its unique integer tag.
-    
+    """The whole grid as one integer per cell: the tag of whatever entity
+    occupies it (`0` for empty floor, `-1`-marked walls become their tag
+    via `entities.EntityIds`), fully observable.
+
     Args:
-        state (State): The current state of the game.
-    
+        state (State): the current state.
+
     Returns:
-        Array: A grid of integers, where each integer represents an entity, \
-        represented as an array of shape `i32[H, W]`, where `H` and `W` are the height \
-        and width of the grid."""
+        Array: `i32[H, W]` (`H = env.height`, `W = env.width`). Entities
+        that have been picked up (off-grid) do not appear."""
     # get idx of entity on the set of patches
     indices = idx_from_coordinates(state.grid, state.get_positions())
     # get tags corresponding to the entities
@@ -87,15 +127,16 @@ def categorical(state: State) -> Array:
 
 
 def categorical_first_person(state: State) -> Array:
-    """Categorical state representation, but cropped to the agent's view, and aligned \
-    with the agent's direction, such that the agent always points upwards.
-    
+    """The egocentric version of `categorical`: one tag per cell, cropped
+    to a `(2 * RADIUS + 1)` square around the player and rotated so the
+    player sits at the bottom-centre facing up. Cells outside the view
+    cone or occluded by a wall are set to `0` (not seen).
+
     Args:
-        state (State): The current state of the game.
+        state (State): the current state.
 
     Returns:
-        Array: A grid of integers, where each integer represents an entity, \
-        represented as an array of shape `i32[2 * RADIUS + 1, 2 * RADIUS + 1]`."""
+        Array: `i32[2 * RADIUS + 1, 2 * RADIUS + 1]`."""
     # get transparency map
     transparency_map = jnp.where(state.grid == 0, 1, 0)
     positions = state.get_positions()
@@ -133,19 +174,18 @@ def categorical_first_person(state: State) -> Array:
 
 
 def symbolic(state: State) -> Array:
-    """Fully observable grid with a symbolic state representation as originally \
-    proposed in the MiniGrid environment.
-    The symbol is a triple of (OBJECT_TAG, COLOUR_IDX, OPEN/CLOSED/LOCKED). The
-    last layer might also contain the direction of the entity, for example, the
-    direction of the agent.
-    
+    """MiniGrid's symbolic encoding: three integers per cell,
+    `(object_tag, colour_index, state)`, fully observable. `object_tag` is
+    the entity id (empty floor and walls have their own tags);
+    `colour_index` indexes the palette (`0` when the entity has no
+    colour); the third channel is the entity's own discrete state - a
+    door's open/closed/locked, or the player's facing direction.
+
     Args:
-        state (State): The current state of the game.
-        
+        state (State): the current state.
+
     Returns:
-        Array: A grid of integers, where each integer represents an entity, \
-        represented as an array of shape `u8[H, W, 3]`, where `H` and `W` are the height \
-        and width of the grid."""
+        Array: `u8[H, W, 3]` (`H = env.height`, `W = env.width`)."""
     # initialise as all floors
     H, W = state.grid.shape
     obs = jnp.zeros((H, W, 3), dtype=jnp.uint8)
@@ -183,16 +223,17 @@ def symbolic(state: State) -> Array:
 
 
 def symbolic_first_person(state: State) -> Array:
-    """First person view with a symbolic state representation, but cropped to the \
-    agent's view, and aligned with the agent's direction, such that the agent always \
-    points upwards. See `symbolic` for more details.
-    
+    """The egocentric version of `symbolic`: the `(tag, colour, state)`
+    triple per cell, cropped to a `(2 * RADIUS + 1)` square around the
+    player and rotated so the player faces up. Out-of-view / occluded
+    cells are filled with the wall symbol; the player's own cell shows
+    what it is carrying.
+
     Args:
-        state (State): The current state of the game.
-    
+        state (State): the current state.
+
     Returns:
-        Array: A grid of integers, where each integer represents an entity, \
-        represented as an array of shape `u8[2 * RADIUS + 1, 2 * RADIUS + 1, 3]`."""
+        Array: `u8[2 * RADIUS + 1, 2 * RADIUS + 1, 3]`."""
     # get transparency map
     obs = symbolic(state)
 
@@ -217,18 +258,16 @@ def symbolic_first_person(state: State) -> Array:
 
 
 def rgb(state: State) -> Array:
-    """Fully observable grid with an RGB state representation.
-    Each entity is represented by its unique RGB sprite. The RGB sprites are \
-    stored in a cache, and the entities are placed on the grid according to their \
-    positions.
-    
+    """The whole grid rendered as an RGB image, fully observable. Each
+    cell is a `TILE_SIZE x TILE_SIZE` sprite (walls, floor grid lines,
+    entities) drawn from `state.cache`.
+
     Args:
-        state (State): The current state of the game.
-    
+        state (State): the current state.
+
     Returns:
-        Array: An RGB image of the grid, represented as an array of shape \
-        `u8[H * S, W * S, 3]`, where `H` and `W` are the height and width of the grid,
-        and `S` is the size of the tile."""
+        Array: `u8[H * TILE_SIZE, W * TILE_SIZE, 3]` (`H = env.height`,
+        `W = env.width`)."""
     # get idx of entity on the flat set of patches
     indices = idx_from_coordinates(state.grid, state.get_positions())
     # get tiles corresponding to the entities
@@ -247,18 +286,16 @@ def rgb(state: State) -> Array:
 
 
 def rgb_first_person(state: State) -> Array:
-    """First person view with an RGB state representation.
-    The image is cropped to the agent's view, and aligned with the agent's direction, \
-    such that the agent always points upwards. See `rgb` for more details.
-    See `rgb` for more details.
+    """The egocentric version of `rgb`: the rendered image cropped to a
+    `(2 * RADIUS + 1)`-tile square around the player and rotated so the
+    player faces up. Out-of-view / occluded tiles are filled with the
+    dimmed "unseen" grey.
 
     Args:
-        state (State): The current state of the game.
-    
+        state (State): the current state.
+
     Returns:
-        Array: An RGB image of the agent's view, represented as an array of shape \
-        `u8[(2 * RADIUS + 1) * S, (2 * RADIUS + 1) * S, 3]`, where 
-        `S` is the size of the tile."""
+        Array: `u8[(2 * RADIUS + 1) * TILE_SIZE, (2 * RADIUS + 1) * TILE_SIZE, 3]`."""
     # get the player
     player = state.get_player()
 

--- a/navix/rendering/__init__.py
+++ b/navix/rendering/__init__.py
@@ -18,4 +18,8 @@
 # under the License.
 
 
+"""Sprite/tile rendering for `rgb` observations: the colour `PALETTE`
+and sprite `SPRITES_REGISTRY` (`registry`), and the pre-rendered
+`RenderingCache` + patch plumbing (`cache`)."""
+
 from . import cache, registry

--- a/navix/rendering/cache.py
+++ b/navix/rendering/cache.py
@@ -18,6 +18,16 @@
 # under the License.
 
 
+"""The rendering cache and the patch <-> image plumbing behind `rgb`
+observations.
+
+An `rgb` observation is the grid drawn as `TILE_SIZE x TILE_SIZE`
+sprites. The static parts (walls, floor, grid lines) never change during
+an episode, so they are rendered once into a flat list of tile
+`patches`, stored on `State.cache`, and only the cells holding moving
+entities are re-drawn each step.
+"""
+
 from __future__ import annotations
 
 from typing import Dict, Tuple
@@ -32,11 +42,25 @@ from .registry import TILE_SIZE, SPRITES_REGISTRY
 
 
 class RenderingCache(struct.PyTreeNode):
+    """The pre-rendered background, carried on `State.cache` so `rgb`
+    observations are cheap. Build one with `RenderingCache.init`; it is
+    valid for any state on the same-shaped grid."""
+
     patches: Array
-    """A flat set of patches representing the RGB values of each tile in the base map"""
+    """`u8[H * W + 1, TILE_SIZE, TILE_SIZE, 3]` - one RGB tile per grid
+    cell (row-major), plus a trailing all-zero "discard pile" tile that
+    off-grid entities render into and that `rgb` slices off."""
 
     @classmethod
     def init(cls, grid: Array) -> RenderingCache:
+        """Renders `grid`'s static background (walls / floor / grid lines)
+        once into the flat patch list.
+
+        Args:
+            grid (Array): `i32[H, W]` base map (`0` floor, `-1` wall).
+
+        Returns:
+            RenderingCache: the cache for that grid shape."""
         background = render_background(grid)
         patches = flatten_patches(background)
 
@@ -54,6 +78,17 @@ class RenderingCache(struct.PyTreeNode):
 def render_background(
     grid: Array, sprites_registry: Dict[str, Array] = SPRITES_REGISTRY
 ) -> Array:
+    """Draws the static layer of an `rgb` frame: a wall sprite on every
+    `-1` cell, a floor sprite (with MiniGrid-matched grid lines) on every
+    `0` cell. No entities.
+
+    Args:
+        grid (Array): `i32[H, W]` base map.
+        sprites_registry (dict): sprite lookup; defaults to the global
+            `SPRITES_REGISTRY`.
+
+    Returns:
+        Array: `u8[H * TILE_SIZE, W * TILE_SIZE, 3]`."""
     image_width = grid.shape[0] * TILE_SIZE
     image_height = grid.shape[1] * TILE_SIZE
     n_channels = 3
@@ -99,6 +134,17 @@ def tile_grid(grid: Array, tile: Array) -> Array:
 def flatten_patches(
     image: Array, patch_size: Tuple[int, int] = (TILE_SIZE, TILE_SIZE)
 ) -> Array:
+    """Splits an image into a row-major list of fixed-size tiles - the
+    inverse of `unflatten_patches`.
+
+    Args:
+        image (Array): `(H, W, C)`, with `H`/`W` multiples of
+            `patch_size`.
+        patch_size (tuple[int, int]): tile `(height, width)`; defaults to
+            `(TILE_SIZE, TILE_SIZE)`.
+
+    Returns:
+        Array: `(H//ph * W//pw, ph, pw, C)`."""
     height = image.shape[0] // patch_size[0]
     width = image.shape[1] // patch_size[1]
     n_channels = image.shape[2]
@@ -115,6 +161,16 @@ def flatten_patches(
 
 
 def unflatten_patches(patches: Array, image_size: Tuple[int, int]) -> Array:
+    """Reassembles a row-major list of tiles into an image - the inverse
+    of `flatten_patches`.
+
+    Args:
+        patches (Array): `(n_tiles, ph, pw, C)`.
+        image_size (tuple[int, int]): the target `(H, W)`;
+            `H * W == n_tiles * ph * pw`.
+
+    Returns:
+        Array: `(H, W, C)`."""
     image_height = image_size[0]
     image_width = image_size[1]
     patch_height = patches.shape[1]

--- a/navix/rendering/registry.py
+++ b/navix/rendering/registry.py
@@ -18,6 +18,11 @@
 # under the License.
 
 
+"""The colour palette and the on-disk sprite tiles used to render `rgb`
+observations. Everything is loaded once at import into the module-level
+`SPRITES_REGISTRY`.
+"""
+
 from __future__ import annotations
 
 import os
@@ -31,17 +36,22 @@ import jax.numpy as jnp
 SPRITES_DIR = os.path.normpath(
     os.path.join(__file__, "..", "..", "..", "assets", "sprites")
 )
+"""Directory the `.png` sprite files are loaded from."""
 MIN_TILE_SIZE = 8
+"""Smallest supported tile edge, in pixels."""
 TILE_SIZE = MIN_TILE_SIZE
+"""Edge length (pixels) of one rendered grid cell. An `rgb` observation
+of an `H x W` grid is `H * TILE_SIZE` by `W * TILE_SIZE`."""
 
 
 def load_sprite(name: str) -> Array:
-    """Loads an image from disk in RGB space.
+    """Loads `assets/sprites/<name>.png`, resized to `TILE_SIZE`.
+
     Args:
-        path(str): the filepath of the image on disk
+        name (str): sprite basename without extension, e.g. `"key_red"`.
 
     Returns:
-        (Array): a jax.Array of shape (H, W, C)"""
+        Array: `u8[TILE_SIZE, TILE_SIZE, 3]`."""
     path = os.path.join(SPRITES_DIR, f"{name}.png")
     image = Image.open(path)
     array = jnp.asarray(image)
@@ -50,6 +60,10 @@ def load_sprite(name: str) -> Array:
 
 
 class PALETTE:
+    """The six entity colours, as `uint8` indices. `HasColour.colour`
+    holds one of these; it is the `colour` channel of a `symbolic`
+    observation and selects the coloured sprite variant for `rgb`."""
+
     RED: Array = jnp.asarray(0, dtype=jnp.uint8)
     GREEN: Array = jnp.asarray(1, dtype=jnp.uint8)
     BLUE: Array = jnp.asarray(2, dtype=jnp.uint8)
@@ -57,23 +71,37 @@ class PALETTE:
     YELLOW: Array = jnp.asarray(4, dtype=jnp.uint8)
     GREY: Array = jnp.asarray(5, dtype=jnp.uint8)
     UNSET: Array = jnp.asarray(255, dtype=jnp.uint8)
+    """Sentinel for "no colour" - used by colourless entities and empty
+    event slots. Not a real palette index."""
 
     @classmethod
     def as_string(cls):
+        """The colour names in index order: `["red", "green", "blue",
+        "purple", "yellow", "grey"]`. Sprite files are named
+        `<entity>_<name>.png`."""
         return ["red", "green", "blue", "purple", "yellow", "grey"]
 
     @classmethod
     def as_array(cls):
+        """`[RED, GREEN, BLUE, PURPLE, YELLOW, GREY]` - the index values
+        in the same order as `as_string`."""
         return [cls.RED, cls.GREEN, cls.BLUE, cls.PURPLE, cls.YELLOW, cls.GREY]
 
 
 class SpritesRegistry:
+    """Loads every entity sprite from disk into a `dict` keyed by
+    `Entities` name. Coloured / directional entities map to a stacked
+    array (leading axis = colour, or direction, or `(colour, state)` for
+    doors). Instantiated once at import as `SPRITES_REGISTRY`."""
+
     def __init__(self):
+        """Builds the registry immediately (reads the PNG files)."""
         self.registry = {}
         self.build_registry()
 
     def build_registry(self):
-        """Populates the sprites registry for all entities."""
+        """Loads and stores the sprite array for every entity type. Each
+        `set_*_sprite` helper populates one `registry` key."""
         self.set_wall_sprite()
         self.set_floor_sprite()
         self.set_goal_sprite()
@@ -135,5 +163,6 @@ class SpritesRegistry:
         self.registry["box"] = jnp.stack(box_coloured, axis=0)
 
 
-# initialise sprites registry
 SPRITES_REGISTRY = SpritesRegistry().registry
+"""The loaded sprites: `dict` from an `Entities` name (`"wall"`, `"key"`,
+`"door"`, ...) to a `uint8` sprite array. `State.get_sprites` reads it."""

--- a/navix/rewards.py
+++ b/navix/rewards.py
@@ -16,6 +16,25 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Reward functions: the scalar reward for one transition.
+
+An `Environment`'s `reward_fn` has the signature shared with
+`navix.terminations` and `navix.events`:
+
+    fn(prev_state: State, action: Array, state: State) -> Array
+
+- `prev_state` is $s_t$, `action` is $a_t$, `state` is $s_{t+1}$. Some
+  functions need `prev_state` to reward a *change* this step; most only
+  read `state`.
+- The return is a scalar `f32[]`. `Environment.reward_space` bounds it
+  (`[-1, 1]` by default). Positive functions here return `1.0` on the
+  rewarded event and `0.0` otherwise; the `*_cost` functions return a
+  small negative shaping term every step.
+
+`compose` reduces several into one (summed by default), and
+`DEFAULT_TASK` is `on_goal_reached` minus a per-step `action_cost`.
+"""
+
 from __future__ import annotations
 from typing import Callable
 
@@ -31,19 +50,19 @@ def compose(
     *reward_functions: Callable[[State, Array, State], Array],
     operator: Callable = jnp.sum,
 ) -> Callable:
-    """Compose multiple reward functions into a single reward function.
-    The functions are called in order and the results are reduced using the `operator` \
-    function.
-    
+    """Combines several reward functions into one.
+
     Args:
-        *reward_functions (Callable[[State, Array, State], Array]): A list of reward functions.
-        operator (Callable): The operator to reduce the results of the reward functions.
-        It must be a function that takes a list of arrays, or an array and returns an \
-        array of size `f32[]`.
-    
+        *reward_functions (Callable): reward functions to combine, each
+            `(prev_state, action, state) -> f32[]`.
+        operator (Callable): reduces the stacked `f32[len(reward_functions)]`
+            results to a scalar `f32[]`. Default `jnp.sum` - the rewards
+            add up (use `on_goal_reached` for `+1` and an `action_cost`
+            for the `-` shaping term, as `DEFAULT_TASK` does).
+
     Returns:
-        Callable: A composed reward function that applies the `operator` to the results of the \
-        reward functions."""
+        Callable: a single `(prev_state, action, state) -> f32[]`
+        function."""
     return lambda prev_state, action, state: operator(
         jnp.asarray(
             [f(prev_state, action, state) for f in reward_functions], dtype=jnp.float32
@@ -52,15 +71,12 @@ def compose(
 
 
 def free(prev_state: State, action: Array, state: State) -> Array:
-    """A reward function that always returns 0, to simulate reward-free learning.
-
-    Args:
-        prev_state (State): The state before the action was taken.
-        action (Array): The action taken by the player.
-        state (State): The current state of the game.
+    """Always `0.0` - the reward-free setting, for unsupervised or
+    exploration-driven training where only the transition dynamics
+    matter.
 
     Returns:
-        Array: A scalar array `f32[]` with value 0."""
+        Array: `f32[]`, always `0.0`."""
     return jnp.asarray(0.0, dtype=jnp.float32)
 
 
@@ -79,18 +95,19 @@ def on_goal_reached(prev_state: State, action: Array, state: State) -> Array:
 def action_cost(
     prev_state: State, action: Array, new_state: State, cost: float = 0.01
 ) -> Array:
-    """A reward function that returns a negative value when an action is taken. 
-    All actions have a cost of `cost`, except for noops.
-    
+    """A per-step penalty of `-cost` on every action except the one at
+    index `6` (the `done` action in the default `MINIGRID_ACTION_SET`),
+    which is free. Part of `DEFAULT_TASK`, where it makes shorter
+    successful episodes score higher.
+
     Args:
-        prev_state (State): The previous state of the game.
-        action (Array): The action taken.
-        new_state (State): The new state of the game.
-        cost (float): The cost of taking an action.
-    
+        prev_state (State): $s_t$ (unused).
+        action (Array): the integer action taken.
+        new_state (State): $s_{t+1}$ (unused).
+        cost (float): the per-action penalty magnitude. Default `0.01`.
+
     Returns:
-        Array: A scalar array `f32[]` with value -`cost` if the action is not a noop, \
-        and 0 otherwise."""
+        Array: `f32[]` - `-cost` if `action != 6`, else `0.0`."""
     # noops are free
     return -jnp.asarray(action != 6, dtype=jnp.float32) * cost
 
@@ -98,17 +115,17 @@ def action_cost(
 def time_cost(
     prev_state: State, action: Array, new_state: State, cost: float = 0.01
 ) -> Array:
-    """A reward function that returns a negative value as time passes, paying a cost \
-    of `cost` at each time step.
+    """A flat `-cost` on every step, regardless of the action (unlike
+    `action_cost`, which exempts `done`).
 
     Args:
-        prev_state (State): The previous state of the game.
-        action (Array): The action taken.
-        new_state (State): The new state of the game.
-        cost (float): The cost of time passing.
-    
+        prev_state (State): $s_t$ (unused).
+        action (Array): the integer action taken (unused).
+        new_state (State): $s_{t+1}$ (unused).
+        cost (float): the per-step penalty magnitude. Default `0.01`.
+
     Returns:
-        Array: A scalar array `f32[]` with value -`cost`.
+        Array: `f32[]`, always `-cost`.
     """
     # time always has a cost
     return -jnp.asarray(cost, dtype=jnp.float32)
@@ -117,16 +134,21 @@ def time_cost(
 def wall_hit_cost(
     prev_state: State, action: Array, state: State, cost: float = 0.01
 ) -> Array:
-    """A reward function that returns a negative value when the agent hits a wall, \
-    paying a cost of `cost` for each wall hit.
-    
+    """`cost` on any step where the player moved into a wall this step
+    (detected via `events.on_wall_hit`), `0.0` otherwise. Opt-in shaping
+    for tasks that want to discourage bumping walls.
+
     Args:
-        state (State): The current state of the game.
-        cost (float): The cost of hitting a wall.
-    
+        prev_state (State): $s_t$ (unused).
+        action (Array): the integer action taken (unused).
+        state (State): $s_{t+1}$ - read for the wall-hit event.
+        cost (float): the magnitude applied on a wall hit. Default
+            `0.01`.
+
     Returns:
-        Array: A scalar array `f32[]` with value -`cost` if the agent hits a wall, \
-        and 0 otherwise."""
+        Array: `f32[]` - `cost` on a wall hit, else `0.0`. Add it with a
+        negative sign (or via `compose` with a negating operator) to
+        make it a penalty."""
     return jnp.asarray(events.on_wall_hit(prev_state, action, state), dtype=jnp.float32) * cost
 
 
@@ -189,16 +211,13 @@ def on_ordered_doors_success(prev_state: State, action: Array, state: State) -> 
 
 
 def on_target_done(prev_state: State, action: Array, state: State) -> Array:
-    """`GoToObject`'s reward: 1 if `done` was called while facing the
-    mission target, 0 otherwise.
-
-    Args:
-        prev_state (State): The previous state of the game.
-        action (Array): The action taken by the player.
-        state (State): The current state of the game.
+    """`GoToObject`'s reward: `1.0` if the `done` action was taken while
+    the player is orthogonally adjacent to the mission's target object
+    (facing it is not required; see `events.on_target_done`), else
+    `0.0`.
 
     Returns:
-        Array: A scalar array `f32[]`."""
+        Array: `f32[]`."""
     return jnp.asarray(events.on_target_done(prev_state, action, state), dtype=jnp.float32)
 
 
@@ -254,4 +273,6 @@ def on_memory_success(prev_state: State, action: Array, state: State) -> Array:
 
 
 DEFAULT_TASK = compose(on_goal_reached, action_cost)
-"""The default task for the game, composed of the `on_goal_reached` and `action_cost` reward functions."""
+"""The `reward_fn` an `Environment` uses unless overridden: `+1.0` on
+reaching the goal, plus a small negative `action_cost` on every step, so
+shorter successful episodes score higher."""

--- a/navix/spaces.py
+++ b/navix/spaces.py
@@ -25,16 +25,34 @@ Shape = Tuple[int, ...]
 
 
 class Space(struct.PyTreeNode):
-    """Base class for all spaces in the game. Spaces define the shape and type of the \
-        observations, actions and rewards in the game.
-        The `sample` method is used to generate random samples from the space.
+    """Describes one array that flows through an environment: its shape, its
+    dtype, and its element-wise value bounds.
 
-    !!! note
-        To initialize a space, use the `create` method of the specific space class.
-        
-    TODO: 
-        * maximum and minimum should be static objects, not arrays.
-    But how do we handle the case when they are not scalars? Maybe numpy arrays?"""
+    An [`Environment`][navix.environments.environment.Environment] exposes
+    three of these - `observation_space`, `action_space` and
+    `reward_space` - so a caller knows what `reset`/`step` will return and
+    what `step` expects, without having to run the environment. `sample`
+    draws a random array that conforms to the space, which is useful for
+    smoke tests and for shaping neural-network inputs/outputs.
+
+    Use the `create` classmethod of a concrete subclass
+    ([`Discrete`][navix.spaces.Discrete] or
+    [`Continuous`][navix.spaces.Continuous]) to build one; the bare
+    constructor does no validation or bound broadcasting.
+
+    Attributes:
+        shape: the shape of the array the space describes. `()` means a
+            single scalar (e.g. a discrete action index or a scalar
+            reward); `(H, W)` / `(H, W, 3)` etc. describe a grid or image
+            observation, with every element independently constrained to
+            `[minimum, maximum]`.
+        dtype: the array's dtype (e.g. `jnp.int32` for a `Discrete`
+            action, `jnp.uint8` for a pixel observation, `jnp.float32`
+            for a reward).
+        minimum: element-wise lower bound (inclusive). A scalar array
+            broadcasts to `shape`.
+        maximum: element-wise upper bound (inclusive). A scalar array
+            broadcasts to `shape`."""
 
     shape: Shape = struct.field(pytree_node=False)
     dtype: jnp.dtype = struct.field(pytree_node=False)
@@ -42,30 +60,50 @@ class Space(struct.PyTreeNode):
     maximum: Array
 
     def sample(self, key: Array) -> Array:
-        """Generate a random sample from the space.
+        """Draws one array of shape `shape` and dtype `dtype` whose
+        elements lie within `[minimum, maximum]`.
 
         Args:
-            key (Array): A random key to generate the sample.
+            key (Array): a `jax.random` PRNG key.
 
         Returns:
-            Array: A random sample from the space."""
+            Array: the sampled array, shape `shape`, dtype `dtype`.
+
+        Raises:
+            NotImplementedError: `Space` is abstract; call `sample` on a
+                `Discrete` or `Continuous` instance."""
         raise NotImplementedError()
 
 
 class Discrete(Space):
+    """An integer-valued space: every element is one of the `n_elements`
+    integers `0, 1, ..., n_elements - 1`.
+
+    With `shape=()` it describes a single categorical value - the usual
+    case for an action index (`Environment.action_space`). With a
+    non-empty `shape` it describes an array of independent categoricals,
+    e.g. a `categorical` observation is `Discrete` over entity tags with
+    `shape=(H, W)`."""
+
     @classmethod
     def create(
         cls, n_elements: int | jax.Array, shape: Shape = (), dtype=jnp.int32
     ) -> Discrete:
-        """Create a discrete space with a given number of elements.
+        """Builds a `Discrete` space over `0 .. n_elements - 1`.
 
         Args:
-            n_elements (int | jax.Array): The number of elements in the space.
-            shape (Shape): The shape of the space.
-            dtype (jnp.dtype): The data type of the space.
+            n_elements (int | Array): number of distinct values; must be
+                `>= 1`. Stored as `maximum = n_elements - 1` (with
+                `minimum = 0`), so `space.n` recovers it.
+            shape (tuple[int, ...]): shape of the integer array the space
+                describes. `()` (the default) is a single scalar.
+            dtype: integer dtype of the sampled array (default
+                `jnp.int32`). Unsigned dtypes are allowed - `sample`
+                draws with a signed generator and casts.
 
         Returns:
-            Discrete: A discrete space with the given number of elements."""
+            Discrete: the space, with `minimum = 0` and
+            `maximum = n_elements - 1`."""
         return Discrete(
             shape=shape,
             dtype=dtype,
@@ -74,52 +112,67 @@ class Discrete(Space):
         )
 
     def sample(self, key: Array) -> Array:
-        """Generate a random sample from the space.
+        """Draws integers uniformly from `0 .. n_elements - 1`,
+        independently per element.
 
         Args:
-            key (Array): A random key to generate the sample.
+            key (Array): a `jax.random` PRNG key.
 
         Returns:
-            Array: A random sample from the space."""
+            Array: shape `shape`, dtype `dtype`."""
         item = jax.random.randint(key, self.shape, self.minimum, self.maximum)
         # randint cannot draw jnp.uint, so we cast it later
         return jnp.asarray(item, dtype=self.dtype)
 
     @property
     def n(self) -> Array:
-        """The number of elements in the space.
-
-        Returns:
-            Array: The number of elements in the space."""
+        """The number of distinct values, `n_elements` (i.e.
+        `maximum + 1`). For an action space, `len(env.action_set)`."""
         return self.maximum + 1
 
 
 class Continuous(Space):
+    """A floating-point space: every element lies in `[minimum, maximum]`.
+
+    navix uses it for `reward_space` (`shape=()`, bounds `[-1, 1]` by
+    default) and for float observations. Bounds may be infinite
+    (`-jnp.inf` / `jnp.inf`) to express "unbounded"; `sample` then falls
+    back to a finite range (see below)."""
+
     @classmethod
     def create(
         cls, shape: Shape, minimum: Array, maximum: Array, dtype=jnp.float32
     ) -> Continuous:
-        """Create a continuous space with a given shape, minimum and maximum values.
+        """Builds a `Continuous` space.
 
         Args:
-            shape (Shape): The shape of the space.
-            minimum (Array): The minimum value of the space.
-            maximum (Array): The maximum value of the space.
-            dtype (jnp.dtype): The data type of the space.
+            shape (tuple[int, ...]): shape of the array the space
+                describes. `()` is a scalar (e.g. a reward).
+            minimum (Array): element-wise lower bound (inclusive); a
+                scalar broadcasts to `shape`. May be `-jnp.inf`.
+            maximum (Array): element-wise upper bound (inclusive); a
+                scalar broadcasts to `shape`. May be `jnp.inf`.
+            dtype: floating dtype of the sampled array (default
+                `jnp.float32`).
 
         Returns:
-            Continuous: A continuous space with the given shape, minimum and maximum values.
-        """
+            Continuous: the space."""
         return Continuous(shape=shape, dtype=dtype, minimum=minimum, maximum=maximum)
 
     def sample(self, key: Array) -> Array:
-        """Generate a random sample from the space.
+        """Draws values uniformly from `[minimum, maximum)`, independently
+        per element. Infinite bounds are first mapped to the largest
+        finite value of `dtype` (via `jnp.nan_to_num`), so an unbounded
+        space still yields a finite draw rather than `nan`.
 
         Args:
-            key (Array): A random key to generate the sample.
+            key (Array): a `jax.random` PRNG key.
 
         Returns:
-            Array: A random sample from the space."""
+            Array: shape `shape`, dtype `dtype`.
+
+        Raises:
+            AssertionError: if `dtype` is not a floating type."""
         assert jnp.issubdtype(self.dtype, jnp.floating)
         # see: https://github.com/google/jax/issues/14003
         lower = jnp.nan_to_num(self.minimum)

--- a/navix/spaces.py
+++ b/navix/spaces.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 
+"""`Space` descriptors for an environment's observation, action and
+reward arrays - shape, dtype and element-wise bounds, plus a `sample`
+that draws a conforming array. `Discrete` for integers, `Continuous` for
+floats.
+"""
+
 from __future__ import annotations
 from typing import Tuple
 
@@ -22,6 +28,7 @@ from jax import Array
 from flax import struct
 
 Shape = Tuple[int, ...]
+"""An array shape, i.e. a tuple of ints (`()` for a scalar)."""
 
 
 class Space(struct.PyTreeNode):

--- a/navix/states.py
+++ b/navix/states.py
@@ -452,17 +452,29 @@ class EventsManager(struct.PyTreeNode):
 
 
 class State(struct.PyTreeNode):
-    """The Markovian state of the environment"""
+    """The full, true state of the world - everything `step` needs to
+    compute the next state, and everything an `observation_fn` reads.
+    A frozen `flax.struct` pytree (`vmap`s over a batch of environments).
+    `Timestep.state` is one of these.
+
+    The `get_*` / `set_*` helpers below are the convenient way to reach
+    into `entities`; the raw `entities` dict is also fine to use
+    directly."""
 
     key: Array
-    """The random number generator state"""
+    """PRNG key for this environment's own stochasticity (ball motion,
+    stochastic goals). Advanced by the functions that consume it."""
     grid: Array
-    """The base map of the environment that remains constant throughout the training"""
+    """`i32[H, W]` static base map: `0` is floor, `-1` marks a wall cell.
+    Fixed for the lifetime of an episode; moving entities live in
+    `entities`, not here."""
     cache: RenderingCache
-    """The rendering cache to speed up rendering"""
+    """Pre-rendered tile patches, so `rgb` observations only re-draw the
+    cells that changed. Carried in the state so it survives `jax.jit`."""
     entities: Dict[str, Entity] = struct.field(default_factory=dict)
-    """The entities in the environment, indexed via entity type string representation.
-    Batched over the number of entities for each type"""
+    """Maps an `Entities` key (`"player"`, `"key"`, ...) to a single
+    batched `Entity` holding every instance of that type. A type with no
+    instances in this environment is simply absent from the dict."""
     events: EventsManager = EventsManager()
     """A struct indicating which events happened this timestep. For example, the
     goal is reached, or the player is hit by a ball. Left at its default (empty)
@@ -489,24 +501,35 @@ class State(struct.PyTreeNode):
             object.__setattr__(self, "events", EventsManager.create(self.entities))
 
     def get_entity(self, entity_enum: str) -> Entity:
-        """Get an entity from the state by its enum.
+        """The batched `Entity` for one type. The typed helpers
+        (`get_keys`, `get_doors`, ...) are thin wrappers around this.
 
         Args:
-            entity_enum (str): The enum of the entity to get.
+            entity_enum (str): an `Entities` key, e.g. `Entities.KEY`.
 
         Returns:
-            Entity: The entity from the state."""
+            Entity: every instance of that type, batched (leading axis =
+            instance count).
+
+        Raises:
+            KeyError: if this environment has no entity of that type -
+            check `entity_enum in state.entities` first if unsure."""
         return self.entities[entity_enum]
 
     def set_entity(self, entity_enum: str, entity: Entity) -> State:
-        """Set an entity in the state by its enum.
+        """Replaces one entity type's batch. Mutates `self.entities` in
+        place *and* returns `self` (it does not build a new `State`), so
+        `state.set_entity(...)` and `state = state.set_entity(...)` are
+        equivalent.
 
         Args:
-            entity_enum (str): The enum of the entity to set.
-            entity (Entity): The entity to set.
+            entity_enum (str): an `Entities` key.
+            entity (Entity): the new batched entity (its shape may differ
+                from the old one - e.g. after a pickup moves an instance
+                off-grid).
 
         Returns:
-            State: The updated state."""
+            State: `self`."""
         self.entities[entity_enum] = entity
         return self
 
@@ -520,7 +543,15 @@ class State(struct.PyTreeNode):
         return self
 
     def get_player(self, idx: int = 0) -> Player:
-        """Gets the player entity from the state."""
+        """The player, *unbatched* (navix is single-agent). Unlike the
+        other `get_*` helpers this indexes into the batch and returns one
+        `Player`.
+
+        Args:
+            idx (int): which player - only `0` is meaningful today.
+
+        Returns:
+            Player: the player entity, no leading instance axis."""
         return self.entities[Entities.PLAYER][idx]  # type: ignore
 
     def set_player(self, player: Player, idx: int = 0) -> State:
@@ -584,19 +615,30 @@ class State(struct.PyTreeNode):
         return self.replace(events=events)
 
     def get_positions(self) -> Array:
-        """Get the positions of all the entities in the state."""
+        """Every entity instance's `(row, col)`, concatenated across all
+        types into one `i32[N, 2]` (`N` = total instance count). The
+        ordering matches `get_tags` / `get_sprites` / `get_transparency`,
+        so they can be zipped - this is what the observation functions
+        do to paint entities onto the grid."""
         return jnp.concatenate([self.entities[k].position for k in self.entities])
 
     def get_tags(self) -> Array:
-        """Get the tags of all the entities in the state."""
+        """Every entity instance's `tag`, concatenated into `i32[N]`, in
+        the same order as `get_positions`. Used to build a `categorical`
+        observation."""
         return jnp.concatenate([self.entities[k].tag for k in self.entities])
 
     def get_sprites(self) -> Array:
-        """Get the sprites of all the entities in the state."""
+        """Every entity instance's RGB sprite, concatenated into
+        `u8[N, TILE_SIZE, TILE_SIZE, 3]`, in the same order as
+        `get_positions`. Used to build an `rgb` observation."""
         return jnp.concatenate([self.entities[k].sprite for k in self.entities])
 
     def get_sprites_first_person(self) -> Array:
-        """Returns the sprites with the agent aligned in the north position"""
+        """Like `get_sprites`, but the player's sprite is forced to its
+        north-facing variant. First-person observations rotate the whole
+        view so the player always points up, so its sprite must not also
+        carry a rotation."""
         player_sprite = SPRITES_REGISTRY[Entities.PLAYER][-1][None]  # -1 is north
         sprites = []
         for k, v in self.entities.items():
@@ -607,5 +649,7 @@ class State(struct.PyTreeNode):
         return jnp.concatenate(sprites)
 
     def get_transparency(self) -> Array:
-        """Get the transparency of all the entities in the state."""
+        """Every entity instance's `transparent` flag, concatenated into
+        `bool[N]`, in the same order as `get_positions`. Feeds the
+        first-person view cone."""
         return jnp.concatenate([self.entities[k].transparent for k in self.entities])

--- a/navix/states.py
+++ b/navix/states.py
@@ -16,6 +16,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""`State` - the full, true world state - and the per-step `Event` /
+`EventsManager` record it carries.
+
+`State` bundles the static `grid`, the batched `entities` dict, a
+rendering `cache` and a PRNG `key`; an `observation_fn` derives what the
+agent sees from it. `EventsManager` is a small fixed set of `Event`
+slots that the transition pipeline writes ("goal reached", "ball hit",
+...) and that `navix.events` / `rewards` / `terminations` read.
+"""
+
 from __future__ import annotations
 from typing import Dict, Tuple
 

--- a/navix/terminations.py
+++ b/navix/terminations.py
@@ -16,6 +16,28 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Termination functions: does a transition land in a terminal state?
+
+An `Environment`'s `termination_fn` has the signature shared across this
+module, `navix.rewards` and `navix.events`:
+
+    fn(prev_state: State, action: Array, state: State) -> Array
+
+- `prev_state` is $s_t$ (before the action), `action` is $a_t$, `state`
+  is $s_{t+1}$ (after). Most conditions only need `state`; a few need
+  `prev_state` to detect a *change* this step (e.g. a door going
+  closed -> open), because navix clears the per-step event record every
+  step.
+- The return is a boolean scalar `bool[]` (`True` = terminate). Truncation
+  at `max_steps` is added separately by `Environment.termination`, so a
+  termination function only reports genuine absorbing states.
+
+Most functions here are thin, correctly-typed wrappers around the
+matching detector in `navix.events` (which holds the precise semantics);
+`compose` ORs several into one, and `DEFAULT_TERMINATION` is the goal /
+lava / ball-hit combination MiniGrid uses.
+"""
+
 from __future__ import annotations
 
 from typing import Callable
@@ -30,29 +52,35 @@ def compose(
     *term_functions: Callable[[State, Array, State], Array],
     operator: Callable = jnp.any,
 ) -> Callable:
-    """Compose termination functions into a single termination function.
+    """Combines several termination functions into one.
 
     Args:
-        *term_functions (Callable): List of termination functions.
-        operator (Callable): Operator to combine the termination functions.
+        *term_functions (Callable): termination functions to combine,
+            each `(prev_state, action, state) -> bool[]`.
+        operator (Callable): reduces the stacked results to a scalar.
+            Default `jnp.any` - terminate if *any* condition fires.
 
     Returns:
-        Callable: A single termination function."""
+        Callable: a single `(prev_state, action, state) -> bool[]`
+        function. This is how `DEFAULT_TERMINATION` and the per-task
+        combinations are built."""
     return lambda prev_state, action, state: operator(
         jnp.asarray([term_f(prev_state, action, state) for term_f in term_functions])
     )
 
 
 def check_truncation(terminated: Array, truncated: Array) -> Array:
-    """Check if the episode is truncated or terminated, and returns a value
-    that conforms to the `StepType` enum.
+    """Merges a termination flag and a truncation flag into a single
+    `StepType` value. Used by `Environment.termination`.
 
     Args:
-        terminated (Array): A boolean array indicating whether the episode is terminated.
-        truncated (Array): A boolean array indicating whether the episode is truncated.
+        terminated (Array): `bool[]`, `True` if `termination_fn` fired.
+        truncated (Array): `bool[]`, `True` if `t >= max_steps`.
 
     Returns:
-        Array: An integer array that represents the step type."""
+        Array: `i32[]` - `2` (`TERMINATION`) if `terminated`, else `1`
+        (`TRUNCATION`) if `truncated`, else `0` (`TRANSITION`).
+        Termination wins over truncation."""
     result = jnp.asarray(truncated + 2 * terminated, dtype=jnp.int32)
     return jnp.clip(result, 0, 2)
 
@@ -176,16 +204,13 @@ def on_ordered_doors_resolved(prev_state: State, action: Array, state: State) ->
 
 
 def on_target_done(prev_state: State, action: Array, state: State) -> Array:
-    """`GoToObject`'s success termination: `done` was called while
-    facing the mission target.
-
-    Args:
-        prev_state (State): The previous state of the game.
-        action (Array): The action taken by the player.
-        state (State): The current state of the game.
+    """`GoToObject`'s success termination: the `done` action was taken
+    while the player is orthogonally adjacent to the mission's target
+    object - facing it is *not* required (matches MiniGrid; see
+    `events.on_target_done`).
 
     Returns:
-        Array: A boolean array."""
+        Array: `bool[]`."""
     return jnp.asarray(events.on_target_done(prev_state, action, state), dtype=jnp.bool_)
 
 
@@ -294,3 +319,6 @@ def on_memory_failure(prev_state: State, action: Array, state: State) -> Array:
 
 
 DEFAULT_TERMINATION = compose(on_goal_reached, on_lava_fall, on_ball_hit)
+"""The `termination_fn` an `Environment` uses unless overridden: the
+episode ends on reaching the goal, falling into lava, or being hit by a
+moving ball (MiniGrid's default terminal conditions)."""

--- a/navix/transitions.py
+++ b/navix/transitions.py
@@ -18,6 +18,15 @@
 # under the License.
 
 
+"""Transition functions: given `(state, action, action_set)`, produce the
+next `State`.
+
+An `Environment`'s `transitions_fn` is one of these. They all start by
+applying the agent's action (`action_set[action]`, a `state -> state`
+primitive - see `navix.actions`) and then optionally advance any
+autonomous entities. `DEFAULT_TRANSITION` is `stochastic_transition`.
+"""
+
 from __future__ import annotations
 
 from typing import Callable, Tuple
@@ -32,33 +41,37 @@ from .grid import positions_equal, translate
 def deterministic_transition(
     state: State, action: Array, actions_set: Tuple[Callable[[State], State], ...]
 ) -> State:
-    """Deterministic transition function. It selects the action from the set of actions
-    and applies it to the state.
-    
+    """Applies only the agent's action - nothing else in the world moves.
+
     Args:
-        state (State): The current state of the game.
-        action (Array): The action to be taken.
-        actions_set (Tuple[Callable[[State], State]): A set of actions that can be taken.
-    
+        state (State): the current state, $s_t$.
+        action (Array): a scalar integer action, `i32[]`, in
+            `[0, len(actions_set))`.
+        actions_set (tuple[Callable, ...]): the environment's
+            `action_set`; `actions_set[action]` is applied via
+            `jax.lax.switch`.
+
     Returns:
-        State: The new state of the game."""
+        State: $s_{t+1}$."""
     return jax.lax.switch(action, actions_set, state)
 
 
 def stochastic_transition(
     state: State, action: Array, actions_set: Tuple[Callable[[State], State], ...]
 ) -> State:
-    """Stochastic transition function. It selects the action from the set of actions
-    and applies it to the state, and updates entities that have stochastic transitions,
-    such as balls.
-    
+    """Applies the agent's action, then moves every `Ball` one random
+    step (`update_balls`). This is `DEFAULT_TRANSITION` - environments
+    without balls behave identically to `deterministic_transition`.
+
     Args:
-        state (State): The current state of the game.
-        action (Array): The action to be taken.
-        actions_set (Tuple[Callable[[State], State]): A set of actions that can be taken.
-    
+        state (State): the current state, $s_t$.
+        action (Array): a scalar integer action, `i32[]`, in
+            `[0, len(actions_set))`.
+        actions_set (tuple[Callable, ...]): the environment's
+            `action_set`.
+
     Returns:
-        State: The new state of the game."""
+        State: $s_{t+1}$, with balls advanced."""
     # actions
     state = jax.lax.switch(action, actions_set, state)
 
@@ -67,14 +80,19 @@ def stochastic_transition(
 
 
 def update_balls(state: State) -> State:
-    """Update the position of the balls in the game.
-    Balls move in a random direction if they can, otherwise they stay in place.
+    """Moves every `Ball` one cell in a uniformly random direction, or
+    leaves it in place if that cell is blocked. A ball that would move
+    onto the player instead stays put and records a
+    `(BALL, HIT)` event (used by `rewards.on_ball_hit` /
+    `terminations.on_ball_hit`).
 
     Args:
-        state (State): The current state of the game.
+        state (State): the current state. If it has no `Ball` entities
+            this is a no-op.
 
     Returns:
-        State: The new state of the game."""
+        State: the state with ball positions and ball-hit events
+        updated, and `state.key` advanced."""
     def update_one(ball: Ball, key: Array) -> Tuple[Array, Array]:
         direction = jax.random.randint(key, (), minval=0, maxval=4)
         new_position = translate(ball.position, direction)
@@ -116,3 +134,5 @@ def _can_spawn_there(state: State, ball: Ball) -> Tuple[Array, Array]:
 
 
 DEFAULT_TRANSITION = stochastic_transition
+"""The `transitions_fn` an `Environment` uses unless overridden:
+`stochastic_transition` (agent action + random ball motion)."""


### PR DESCRIPTION
_Posted by an AI agent on behalf of @epignatelli._

Closes #167 — a docstring pass over the whole `navix` package (outside `navix/benchmarks/`, already covered by #130).

Docstrings only, no code changes. Issues found along the way (bugs, misspellings, docstring↔code mismatches, the leading-underscore members the "no private" convention wants public) are in a comment below for separate follow-up, per the instruction not to touch code.

## What changed

Every module now has a module docstring, and every public class/function users interact with has a real one — Args state shape/dtype/meaning/bounds and semantics (not "the array as input"), examples where a shape contract is hard to phrase, and no change-history narrative in docstrings.

- **Core API** — `spaces`, `navix/__init__.py`, `Environment`/`Timestep`/`StepType`/`create`/`reset`/`step`, `registry.make`/`register_env`, `environments.wrappers.ToGymnax` (was undocumented).
- **Customization surface** — `actions`, `transitions`, `rewards`, `terminations`, `events`: the `(prev_state, action, state)` convention stated once per module; per-function condition/semantics; the direction and blocked-move conventions; each `*_ACTION_SET`'s index→action map.
- **Observations & state model** — `observations` (the fully-observable vs first-person families, the categorical/symbolic/rgb encodings, exact output shapes); `entities` / `components` / `states` (batched-pytree model, every field's dtype/range/meaning, the entity accessors).
- **Environments** — a task-level class docstring on every environment (layout, win/lose condition, what's randomised) plus a one-line module docstring.
- **Grid / rendering** — module docstrings and the previously-undocumented `RenderingCache`, `render_background`, patch helpers, `PALETTE`, `SpritesRegistry`.
- **Agents** — package + `agent` module docstrings, `HParams` and the three `*Hparams` classes, `ActorCritic`/`MLPEncoder`, `Agent.log_to_wandb*`.
- **Benchmarks** — `Benchmark` reframed explicitly as an *experimental protocol*.

Fixes applied (docstring-only): `on_target_done` "facing" → "orthogonally adjacent" in `terminations`/`rewards`; history narrative stripped from `events.on_target_done`, `events`, `Ball`/`Box`, `spaces`/`components` `TODO:` blocks; `components.Positionable.position` (`(0, -1)`) and `Holder.pocket` (`-1`) corrected; `Lava` had `Goal`'s docstring; `Door`'s referenced a non-existent field; `rewards.action_cost`/`wall_hit_cost` docstrings now match the code.

`main...HEAD`: ~44 files. No doctest config in the repo, so the test suite is unaffected; per-module test files and the PPO examples pass.

Refs #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
