### PR TITLE
fix: Discrete.sample range, wall_hit_cost sign, penalty_coeff rename, dead GoToDoor field (#210 #212 #213 #214)

### DIFF
--- a/navix/environments/environment.py
+++ b/navix/environments/environment.py
@@ -35,6 +35,7 @@ everything else is inherited. Build one with `navix.make(id)` or
 from __future__ import annotations
 
 import abc
+import warnings
 from typing import Any, Callable, Dict, Tuple
 import jax
 import jax.numpy as jnp
@@ -189,9 +190,10 @@ class Environment(struct.PyTreeNode):
         gamma: discount factor. Not used by `step` itself - carried here
             so agents and `reward_fn`s (e.g. time-discounted goal
             rewards) can read it off the environment.
-        penality_coeff: if non-zero, a terminating reward is reduced by
-            `penality_coeff * (t / max_steps)`, i.e. finishing later is
-            worth less. `0.0` disables it.
+        penalty_coeff: if non-zero, a terminating reward is reduced by
+            `penalty_coeff * (t / max_steps)`, i.e. finishing later is
+            worth less. `0.0` disables it. (The old misspelled name
+            `penality_coeff` still works as a deprecated read-only alias.)
         observation_fn: `state -> observation`. One of the functions in
             `navix.observations`.
         reward_fn: `(prev_state, action, state) -> f32[]`.
@@ -212,7 +214,7 @@ class Environment(struct.PyTreeNode):
     reward_space: Space = struct.field(pytree_node=False)
     disable_autoreset: bool = struct.field(pytree_node=False, default=False)
     gamma: float = struct.field(pytree_node=False, default=0.99)
-    penality_coeff: float = struct.field(pytree_node=False, default=0.0)
+    penalty_coeff: float = struct.field(pytree_node=False, default=0.0)
     observation_fn: Callable[[State], Array] = struct.field(
         pytree_node=False, default=observations.none
     )
@@ -228,6 +230,19 @@ class Environment(struct.PyTreeNode):
     action_set: Tuple[Callable[[State], State], ...] = struct.field(
         pytree_node=False, default=DEFAULT_ACTION_SET
     )
+
+    @property
+    def penality_coeff(self) -> float:
+        """Deprecated misspelling of `penalty_coeff`. Reads still work
+        (with a warning); pass `penalty_coeff` to `create` going
+        forward."""
+        warnings.warn(
+            "Environment.penality_coeff is a deprecated misspelling of "
+            "penalty_coeff; use penalty_coeff.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.penalty_coeff
 
     @classmethod
     def create(
@@ -276,12 +291,20 @@ class Environment(struct.PyTreeNode):
             reward_space (Space | None): `None` -> `Continuous((), -1, 1)`.
             disable_autoreset (bool): see the class attribute.
             **kwargs: extra fields forwarded to the subclass constructor
-                (e.g. `gamma`, `penality_coeff`, or an environment's own
+                (e.g. `gamma`, `penalty_coeff`, or an environment's own
                 layout options like `random_start`).
 
         Returns:
             Environment: the constructed environment.
         """
+        if "penality_coeff" in kwargs:
+            warnings.warn(
+                "Environment.create(penality_coeff=...) is a deprecated "
+                "misspelling; use penalty_coeff.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            kwargs.setdefault("penalty_coeff", kwargs.pop("penality_coeff"))
         if observation_space is None:
             observation_space = cls._get_obs_space_from_fn(
                 width, height, observation_fn
@@ -421,7 +444,7 @@ class Environment(struct.PyTreeNode):
         reward = self.reward_fn(timestep.state, action, state)
         reward = jax.lax.cond(
             step_type == StepType.TERMINATION,
-            lambda reward: reward - self.penality_coeff * (t / self.max_steps),
+            lambda reward: reward - self.penalty_coeff * (t / self.max_steps),
             lambda reward: reward,
             reward,
         )

--- a/navix/environments/go_to_door.py
+++ b/navix/environments/go_to_door.py
@@ -30,7 +30,6 @@ from typing import Union
 import jax
 import jax.numpy as jnp
 from jax import Array
-from flax import struct
 
 from navix import observations
 
@@ -48,14 +47,7 @@ class GoToDoor(Environment):
     """`Navix-GoToDoor-*`. A room with a coloured `Door` on each of the
     four walls; one is named in `State.mission`. The agent succeeds by
     signalling `done` next to the target door. Door positions and colours
-    and the room size are randomised each reset.
-
-    Attributes:
-        split_lava: unused by `GoToDoor`; kept for constructor
-            compatibility.
-    """
-
-    split_lava: bool = struct.field(pytree_node=False, default=False)
+    and the room size are randomised each reset."""
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
         # map

--- a/navix/rewards.py
+++ b/navix/rewards.py
@@ -134,22 +134,24 @@ def time_cost(
 def wall_hit_cost(
     prev_state: State, action: Array, state: State, cost: float = 0.01
 ) -> Array:
-    """`cost` on any step where the player moved into a wall this step
+    """`-cost` on any step where the player moved into a wall this step
     (detected via `events.on_wall_hit`), `0.0` otherwise. Opt-in shaping
-    for tasks that want to discourage bumping walls.
+    for tasks that want to discourage bumping walls; same sign convention
+    as `action_cost` / `time_cost`.
 
     Args:
         prev_state (State): $s_t$ (unused).
         action (Array): the integer action taken (unused).
         state (State): $s_{t+1}$ - read for the wall-hit event.
-        cost (float): the magnitude applied on a wall hit. Default
+        cost (float): the penalty magnitude on a wall hit. Default
             `0.01`.
 
     Returns:
-        Array: `f32[]` - `cost` on a wall hit, else `0.0`. Add it with a
-        negative sign (or via `compose` with a negating operator) to
-        make it a penalty."""
-    return jnp.asarray(events.on_wall_hit(prev_state, action, state), dtype=jnp.float32) * cost
+        Array: `f32[]` - `-cost` on a wall hit, else `0.0`."""
+    return (
+        -jnp.asarray(events.on_wall_hit(prev_state, action, state), dtype=jnp.float32)
+        * cost
+    )
 
 
 def on_door_done(prev_state: State, action: Array, state: State) -> Array:

--- a/navix/spaces.py
+++ b/navix/spaces.py
@@ -127,7 +127,10 @@ class Discrete(Space):
 
         Returns:
             Array: shape `shape`, dtype `dtype`."""
-        item = jax.random.randint(key, self.shape, self.minimum, self.maximum)
+        # `maximum` is the inclusive top value (`n_elements - 1`), but
+        # `jax.random.randint`'s `maxval` is exclusive - pass `+ 1` so the
+        # top value is actually reachable.
+        item = jax.random.randint(key, self.shape, self.minimum, self.maximum + 1)
         # randint cannot draw jnp.uint, so we cast it later
         return jnp.asarray(item, dtype=self.dtype)
 

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -1,5 +1,8 @@
+import warnings
+
 import jax
 import jax.numpy as jnp
+import pytest
 import navix as nx
 
 
@@ -301,6 +304,27 @@ def test_lava_crossing_structure_and_solvability():
         last_state = jax.tree.map(lambda x: x[-1], states)
         assert Entities.WALL not in last_state.entities
         assert Entities.LAVA in last_state.entities
+
+
+def test_penalty_coeff_rename_keeps_penality_coeff_as_a_deprecated_alias():
+    # https://github.com/epignatelli/navix/issues/213 - the misspelled
+    # `penality_coeff` field is renamed `penalty_coeff`, with the old
+    # name still readable (and accepted by `create`) but deprecated.
+    env = nx.environments.Room.create(height=5, width=5, penalty_coeff=0.3)
+    assert env.penalty_coeff == 0.3
+
+    with pytest.warns(DeprecationWarning, match="penalty_coeff"):
+        assert env.penality_coeff == 0.3
+
+    with pytest.warns(DeprecationWarning, match="penalty_coeff"):
+        env2 = nx.environments.Room.create(height=5, width=5, penality_coeff=0.2)
+    assert env2.penalty_coeff == 0.2
+
+    # no warning when only the new name is used
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        e = nx.environments.Room.create(height=5, width=5, penalty_coeff=0.1)
+        assert e.penalty_coeff == 0.1
 
 
 if __name__ == "__main__":

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -2,6 +2,7 @@ import sys
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from navix.spaces import Continuous, Discrete
 
 
@@ -21,6 +22,19 @@ def test_discrete():
                 sample = space.sample(key)
                 print(sample)
                 assert jnp.all(jnp.logical_not(jnp.isnan(sample)))
+
+
+def test_discrete_sample_covers_the_full_range():
+    # https://github.com/epignatelli/navix/issues/210 - `Discrete.sample`
+    # passed the inclusive `maximum` as randint's exclusive `maxval`, so
+    # the top value `n_elements - 1` was never drawn.
+    n = 5
+    space = Discrete.create(n)
+    keys = jax.random.split(jax.random.PRNGKey(0), 2000)
+    samples = np.asarray(jax.vmap(space.sample)(keys))
+    assert samples.min() == 0
+    assert samples.max() == n - 1  # the top value is reachable
+    assert set(np.unique(samples).tolist()) == set(range(n))
 
 
 def test_continuous():
@@ -45,4 +59,5 @@ def test_continuous():
 
 if __name__ == "__main__":
     test_discrete()
+    test_discrete_sample_covers_the_full_range()
     test_continuous()


### PR DESCRIPTION
_Posted by an AI agent on behalf of @epignatelli._

Four small, independent fixes surfaced during the #167 docs pass, one commit each.

- **#210** `fix(spaces)` — `Discrete.sample` passed the inclusive `maximum` (`n_elements - 1`) as `jax.random.randint`'s exclusive `maxval`, so the top value was never drawn. Now `maximum + 1`. Test: `tests/test_spaces.py::test_discrete_sample_covers_the_full_range`.
- **#212** `fix(rewards)` — `wall_hit_cost` returned `+cost` on a wall hit (a reward for bumping walls); negated to match its name and its siblings `action_cost` / `time_cost`.
- **#213** `fix(environments)` — renamed the misspelled public field `Environment.penality_coeff` → `penalty_coeff`, **with a deprecation path** as the issue asked: `create(penality_coeff=...)` and `env.penality_coeff` reads still work but emit a `DeprecationWarning`. `env.replace(penality_coeff=...)` and the raw `Environment(penality_coeff=...)` kwarg do not — flagged `BREAKING CHANGE:` in the commit. Test: `tests/test_environments.py::test_penalty_coeff_rename_keeps_penality_coeff_as_a_deprecated_alias`. (Supersedes the bare-rename PR #216.)
- **#214** `fix(environments)` — removed `GoToDoor.split_lava`, a field `_reset` never reads (copy-pasted from `DistShift`).

Not touched: #211 (`action_cost`'s hard-coded index — wants a small design decision) and #215 (the de-underscore sweep).

Verified: the touched test files plus `test_registry` / `test_ppo` / `test_pqn` / `test_events` / `test_terminations` / `test_go_to_object` pass; `examples/ppo.py` and `examples/hparam_search.py` run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
