### PR TITLE
fix(rewards): deprecate action_cost, drop per-step cost from DEFAULT_TASK (#211)

### DIFF
--- a/navix/environments/empty.py
+++ b/navix/environments/empty.py
@@ -45,8 +45,8 @@ from .registry import register_env
 class Room(Environment):
     """A single empty walled room - navix's `Empty` environments
     (`Navix-Empty-*`). One goal, one player, no obstacles; the task is
-    pure navigation. Reward and termination are the defaults: `+1` on
-    reaching the goal minus a per-step cost, episode ends on the goal.
+    pure navigation. `+1` on reaching the goal, `0` otherwise; the
+    episode ends on the goal.
 
     Attributes:
         random_start: `False` (the `Navix-Empty-NxN-v0` ids) places the

--- a/navix/environments/multi_room.py
+++ b/navix/environments/multi_room.py
@@ -535,7 +535,10 @@ def register_multi_room(env_id: str, num_rooms: int, max_room_size: int) -> None
             max_room_size=max_room_size,
             max_steps=kwargs.pop("max_steps", num_rooms * 20),
             observation_fn=kwargs.pop("observation_fn", observations.symbolic),
-            reward_fn=kwargs.pop("reward_fn", rewards.DEFAULT_TASK),
+            reward_fn=kwargs.pop(
+                "reward_fn",
+                rewards.compose(rewards.on_goal_reached, rewards.time_cost),
+            ),
             termination_fn=kwargs.pop("termination_fn", terminations.DEFAULT_TERMINATION),
             *args,
             **kwargs,

--- a/navix/environments/multi_room.py
+++ b/navix/environments/multi_room.py
@@ -113,6 +113,14 @@ MAX_LAYOUT_RESTARTS = 32  # a single room's own retry (MAX_PLACEMENT_TRIES,
 # restarts the *entire* room chain from scratch with a fresh key,
 # rather than trying to locally patch just the one room that failed.
 
+# MultiRoom keeps `DEFAULT_TASK`'s old shaped reward (goal `+1` minus a
+# per-step cost) even after `rewards.DEFAULT_TASK` dropped the cost.
+# Module-level (one shared object), so two MultiRoom instances of the
+# same id compare equal - `test_registry` checks a v1-alias redirect
+# builds an env `==` the direct one, which a fresh per-call `compose`
+# lambda would break.
+MULTI_ROOM_REWARD_FN = rewards.compose(rewards.on_goal_reached, rewards.time_cost)
+
 
 def room_top_left_east(key: Array, entry_row: Array, entry_col: Array, size_h: Array, size_w: Array) -> Array:
     # entered via the new room's own EAST wall -> room extends west
@@ -535,10 +543,7 @@ def register_multi_room(env_id: str, num_rooms: int, max_room_size: int) -> None
             max_room_size=max_room_size,
             max_steps=kwargs.pop("max_steps", num_rooms * 20),
             observation_fn=kwargs.pop("observation_fn", observations.symbolic),
-            reward_fn=kwargs.pop(
-                "reward_fn",
-                rewards.compose(rewards.on_goal_reached, rewards.time_cost),
-            ),
+            reward_fn=kwargs.pop("reward_fn", MULTI_ROOM_REWARD_FN),
             termination_fn=kwargs.pop("termination_fn", terminations.DEFAULT_TERMINATION),
             *args,
             **kwargs,

--- a/navix/events.py
+++ b/navix/events.py
@@ -51,10 +51,11 @@ from .entities import Entities, Player
 
 
 # Indices into navix.actions.MINIGRID_ACTION_SET/DEFAULT_ACTION_SET -
-# derived, not hardcoded, so they stay correct if that tuple's ordering
-# ever changes. Only meaningful for an environment actually using that
-# default action_set (matches the existing precedent of
-# `rewards.action_cost` hardcoding an action index the same way).
+# derived from the tuple, not hardcoded, so they stay correct if its
+# ordering ever changes. Only meaningful for an environment actually
+# using that default action_set; a detector that reads one of these
+# (e.g. on_target_done) is simply wrong under a different action_set,
+# which is why `rewards` no longer does the same thing.
 DONE_ACTION = jnp.asarray(actions.MINIGRID_ACTION_SET.index(actions.done))
 """The integer that means `actions.done` in the default action set -
 used by detectors like `on_target_done` that care *which* action was

--- a/navix/rewards.py
+++ b/navix/rewards.py
@@ -31,11 +31,13 @@ An `Environment`'s `reward_fn` has the signature shared with
   rewarded event and `0.0` otherwise; the `*_cost` functions return a
   small negative shaping term every step.
 
-`compose` reduces several into one (summed by default), and
-`DEFAULT_TASK` is `on_goal_reached` minus a per-step `action_cost`.
+`compose` reduces several into one (summed by default). `DEFAULT_TASK`
+is just `on_goal_reached` - `+1` at the goal, no per-step shaping; add a
+`time_cost` yourself if you want to reward faster solutions.
 """
 
 from __future__ import annotations
+import warnings
 from typing import Callable
 
 
@@ -57,8 +59,8 @@ def compose(
             `(prev_state, action, state) -> f32[]`.
         operator (Callable): reduces the stacked `f32[len(reward_functions)]`
             results to a scalar `f32[]`. Default `jnp.sum` - the rewards
-            add up (use `on_goal_reached` for `+1` and an `action_cost`
-            for the `-` shaping term, as `DEFAULT_TASK` does).
+            add up, e.g. `compose(on_goal_reached, time_cost)` for `+1` at
+            the goal minus a small per-step cost.
 
     Returns:
         Callable: a single `(prev_state, action, state) -> f32[]`
@@ -92,31 +94,12 @@ def on_goal_reached(prev_state: State, action: Array, state: State) -> Array:
     return jnp.asarray(events.on_goal_reached(prev_state, action, state), dtype=jnp.float32)
 
 
-def action_cost(
-    prev_state: State, action: Array, new_state: State, cost: float = 0.01
-) -> Array:
-    """A per-step penalty of `-cost` on every action except the one at
-    index `6` (the `done` action in the default `MINIGRID_ACTION_SET`),
-    which is free. Part of `DEFAULT_TASK`, where it makes shorter
-    successful episodes score higher.
-
-    Args:
-        prev_state (State): $s_t$ (unused).
-        action (Array): the integer action taken.
-        new_state (State): $s_{t+1}$ (unused).
-        cost (float): the per-action penalty magnitude. Default `0.01`.
-
-    Returns:
-        Array: `f32[]` - `-cost` if `action != 6`, else `0.0`."""
-    # noops are free
-    return -jnp.asarray(action != 6, dtype=jnp.float32) * cost
-
-
 def time_cost(
     prev_state: State, action: Array, new_state: State, cost: float = 0.01
 ) -> Array:
-    """A flat `-cost` on every step, regardless of the action (unlike
-    `action_cost`, which exempts `done`).
+    """A flat `-cost` on every step. Compose it with a goal reward
+    (`compose(on_goal_reached, time_cost)`) to make shorter successful
+    episodes score higher.
 
     Args:
         prev_state (State): $s_t$ (unused).
@@ -131,13 +114,41 @@ def time_cost(
     return -jnp.asarray(cost, dtype=jnp.float32)
 
 
+def action_cost(
+    prev_state: State, action: Array, new_state: State, cost: float = 0.01
+) -> Array:
+    """Deprecated alias of `time_cost`.
+
+    It used to exempt the action at index `6` (`done` in
+    `MINIGRID_ACTION_SET`), but a reward function has no way to know
+    which action set an environment uses, so the exemption was
+    action-set-dependent and wrong for any non-default set. Every action
+    now costs `cost` - identical to `time_cost` - so use that instead.
+
+    Args:
+        prev_state (State): $s_t$ (unused).
+        action (Array): the integer action taken (unused).
+        new_state (State): $s_{t+1}$ (unused).
+        cost (float): the per-step penalty magnitude. Default `0.01`.
+
+    Returns:
+        Array: `f32[]`, always `-cost`."""
+    warnings.warn(
+        "rewards.action_cost is deprecated; it is now identical to "
+        "rewards.time_cost (every action costs `cost`). Use time_cost.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return time_cost(prev_state, action, new_state, cost)
+
+
 def wall_hit_cost(
     prev_state: State, action: Array, state: State, cost: float = 0.01
 ) -> Array:
     """`-cost` on any step where the player moved into a wall this step
     (detected via `events.on_wall_hit`), `0.0` otherwise. Opt-in shaping
     for tasks that want to discourage bumping walls; same sign convention
-    as `action_cost` / `time_cost`.
+    as `time_cost`.
 
     Args:
         prev_state (State): $s_t$ (unused).
@@ -274,7 +285,7 @@ def on_memory_success(prev_state: State, action: Array, state: State) -> Array:
     return jnp.asarray(events.on_memory_success(prev_state, action, state), dtype=jnp.float32)
 
 
-DEFAULT_TASK = compose(on_goal_reached, action_cost)
+DEFAULT_TASK = on_goal_reached
 """The `reward_fn` an `Environment` uses unless overridden: `+1.0` on
-reaching the goal, plus a small negative `action_cost` on every step, so
-shorter successful episodes score higher."""
+reaching the goal, `0.0` every other step - no per-step shaping. Compose
+`time_cost` in yourself if you want to reward faster solutions."""

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -18,7 +18,7 @@ def test_room():
         reset = jax.jit(env._reset)
         step = jax.jit(env.step)
         timestep = reset(key)
-        # these are optimal actios for navigation + action_cost
+        # these are optimal actions for navigation
         actions = (
             0,  # noop sanity check
             2,  # rotate_ccw
@@ -53,7 +53,7 @@ def test_keydoor():
         reset = jax.jit(env._reset)
         step = jax.jit(env.step)
         timestep = reset(key)
-        #  these are optimal actions for navigation + action_cost
+        #  these are optimal actions for navigation
         actions = (
             0,  # rotate_ccw
             2,  # forward

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+import pytest
 
 import navix as nx
 from navix.states import State
@@ -50,7 +51,6 @@ def test_navigation():
 def test_tasks_composition():
     reward_fn = nx.rewards.compose(
         nx.rewards.on_goal_reached,
-        nx.rewards.action_cost,
         nx.rewards.time_cost,
         nx.rewards.wall_hit_cost,
     )
@@ -65,6 +65,39 @@ def test_tasks_composition():
         return timestep
 
     print(jax.jit(_test)())
+
+
+def test_default_task_is_unshaped_on_goal_reached():
+    # https://github.com/epignatelli/navix/issues/211 - DEFAULT_TASK no
+    # longer folds in a per-step cost; it is exactly `on_goal_reached`.
+    assert nx.rewards.DEFAULT_TASK is nx.rewards.on_goal_reached
+
+    env = nx.make("Navix-Empty-5x5-v0", reward_fn=nx.rewards.DEFAULT_TASK)
+    ts = env.reset(jax.random.PRNGKey(0))
+    # first (non-goal) step: no shaping, reward is exactly 0
+    ts = env.step(ts, jnp.asarray(0))  # rotate - definitely not on the goal
+    assert float(ts.reward) == 0.0
+
+
+def test_multiroom_keeps_its_per_step_cost():
+    # MultiRoom rode on the old shaped DEFAULT_TASK; it now pins its own
+    # `compose(on_goal_reached, time_cost)` so its reward is unchanged.
+    env = nx.make("Navix-MultiRoom-N2-S4-v0")
+    assert env.reward_fn is not nx.rewards.DEFAULT_TASK
+    ts = env.reset(jax.random.PRNGKey(0))
+    ts = env.step(ts, jnp.asarray(0))  # non-goal step
+    assert abs(float(ts.reward) - (-0.01)) < 1e-6
+
+
+def test_action_cost_is_a_deprecated_alias_of_time_cost():
+    # https://github.com/epignatelli/navix/issues/211 - the index-6
+    # `done` exemption was action-set-dependent; every action now costs
+    # `cost`, i.e. action_cost == time_cost.
+    with pytest.warns(DeprecationWarning, match="time_cost"):
+        a = nx.rewards.action_cost(None, jnp.asarray(6), None)
+    t = nx.rewards.time_cost(None, jnp.asarray(6), None)
+    assert float(a) == float(t)
+    assert abs(float(a) - (-0.01)) < 1e-6
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
_Posted by an AI agent on behalf of @epignatelli._

Closes #211.

## `action_cost` → deprecated alias of `time_cost`

`action_cost` exempted the action at index `6` (`done` in `MINIGRID_ACTION_SET`) from the per-step cost. But a reward function's signature is `(prev_state, action, state)` — it never sees the environment's `action_set`, so the hard-coded `6` is wrong for any other set (it's `left` in `COMPLETE_ACTION_SET`, out of range for a 3-action `DynamicObstacles`). There's no way to make an index-based exemption correct here.

With the exemption gone it's identical to `time_cost`, so `action_cost` now **emits a `DeprecationWarning` and delegates to `time_cost`**. Same name/signature.

## `DEFAULT_TASK` — no per-step shaping

`DEFAULT_TASK` was `compose(on_goal_reached, action_cost)`; it's now just **`on_goal_reached`** (`+1` at goal, `0` otherwise). `gamma` (0.99) is unchanged.

**Scope check** — instantiated all 83 registered envs: `multi_room.py` was the **only** one that opted into `DEFAULT_TASK` (`reward_fn=kwargs.pop("reward_fn", rewards.DEFAULT_TASK)`). To keep `Navix-MultiRoom-{N2-S4,N4-S5,N6}-v0` unchanged it now pins `compose(on_goal_reached, time_cost)` explicitly. Every other env already passes its own `reward_fn`. So **no `Navix-*` id's reward changes**; the `BREAKING CHANGE:` footer covers only the `Environment.create` fallback (`0.0` instead of `-0.01` on non-goal steps) and the `action_cost` deprecation.

## Also

- `empty.py`'s `Room` docstring said "…the goal minus a per-step cost" — already wrong (`Navix-Empty-*` uses `on_goal_reached`), fixed.
- Tests: `action_cost` warns + equals `time_cost`; `DEFAULT_TASK is on_goal_reached` and gives `0.0` on a non-goal step; `Navix-MultiRoom-N2-S4-v0` still gives `-0.01` on a non-goal step; `test_tasks_composition` off the deprecated fn.

Verified: `tests/test_tasks.py`, `tests/test_multi_room.py`, `tests/test_environments.py`, `tests/test_events.py` pass; `examples/ppo.py` + `examples/hparam_search.py` run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
