### PR TITLE
refactor(spaces): back Discrete/Continuous with distrax distributions

### DIFF
--- a/navix/__init__.py
+++ b/navix/__init__.py
@@ -52,8 +52,9 @@ Layout:
 - `navix.grid` - array helpers for grid geometry (cropping, rotation,
   line of sight).
 - `navix.rendering` - sprite/tile rendering for RGB observations.
-- `navix.spaces` - `Space` descriptors for observations, actions and
-  rewards.
+- `navix.spaces` - `Space` descriptors (shape / dtype / bounds) for
+  observations, actions and rewards; each is a `distrax` distribution
+  (`Discrete` <- `distrax.Categorical`, `Continuous` <- `distrax.Uniform`).
 - `navix.agents` - reference JAX implementations of PPO, PQN and
   DreamerV3, plus `navix.experiment.Experiment` to run and log them.
 - `navix.benchmarks` - experimental protocols that pin an environment,

--- a/navix/environments/environment.py
+++ b/navix/environments/environment.py
@@ -179,7 +179,8 @@ class Environment(struct.PyTreeNode):
             once `t >= max_steps`. Default (via `create`) is
             `4 * height * width`.
         observation_space: `Space` describing `observation_fn`'s output
-            (shape, dtype, bounds).
+            (shape, dtype, bounds). A `distrax` distribution - see
+            `navix.spaces`.
         action_space: `Discrete` over `len(action_set)`.
         reward_space: `Continuous` bound on the reward, `[-1, 1]` by
             default.

--- a/navix/spaces.py
+++ b/navix/spaces.py
@@ -14,9 +14,29 @@
 
 
 """`Space` descriptors for an environment's observation, action and
-reward arrays - shape, dtype and element-wise bounds, plus a `sample`
-that draws a conforming array. `Discrete` for integers, `Continuous` for
-floats.
+reward arrays.
+
+A space says three things about an array that flows through an
+environment - its `shape`, its `dtype`, and its element-wise
+`[minimum, maximum]` bounds - and can `sample` a conforming array.
+
+Each concrete space *is* a `distrax` distribution: `Discrete` subclasses
+`distrax.Categorical` (uniform over `0 .. n_elements - 1`) and
+`Continuous` subclasses `distrax.Uniform` (uniform over
+`[minimum, maximum]`). So a space also carries `log_prob`, `entropy`,
+`prob` and `mode` for free, and `isinstance(space, distrax.Distribution)`
+holds. `Space` re-exports `distrax.Distribution` as the common supertype
+navix annotates with.
+
+The distribution is over a *single* element: the underlying
+`distrax.Categorical.logits` is `1-D` (`(n_elements,)`), not
+`(*shape, n_elements)`, so the descriptor stays cheap even for a large
+image observation. `space.shape` / `space.dtype` are navix attributes on
+top of that; `space.event_shape` / `space.batch_shape` (the `distrax`
+introspection) are therefore `()`, not `space.shape`. `space.sample(key)`
+takes the key positionally (navix convention) and returns a
+`space.shape`-shaped array with iid elements - it does not follow
+`distrax`'s keyword-only `sample(*, seed, sample_shape)` signature.
 """
 
 from __future__ import annotations
@@ -24,169 +44,276 @@ from typing import Tuple
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
-from flax import struct
+import distrax
 
 Shape = Tuple[int, ...]
 """An array shape, i.e. a tuple of ints (`()` for a scalar)."""
 
+Space = distrax.Distribution
+"""The common supertype of every navix space, i.e. `distrax.Distribution`.
+An `Environment` exposes three spaces - `observation_space`,
+`action_space` and `reward_space` - so a caller knows what `reset`/`step`
+return and what `step` expects without running the environment."""
 
-class Space(struct.PyTreeNode):
-    """Describes one array that flows through an environment: its shape, its
-    dtype, and its element-wise value bounds.
 
-    An [`Environment`][navix.environments.environment.Environment] exposes
-    three of these - `observation_space`, `action_space` and
-    `reward_space` - so a caller knows what `reset`/`step` will return and
-    what `step` expects, without having to run the environment. `sample`
-    draws a random array that conforms to the space, which is useful for
-    smoke tests and for shaping neural-network inputs/outputs.
+class Discrete(distrax.Categorical):
+    """An integer-valued space: every element is one of the `n_elements`
+    integers `0, 1, ..., n_elements - 1`, drawn uniformly and
+    independently.
 
-    Use the `create` classmethod of a concrete subclass
-    ([`Discrete`][navix.spaces.Discrete] or
-    [`Continuous`][navix.spaces.Continuous]) to build one; the bare
-    constructor does no validation or bound broadcasting.
+    Subclasses `distrax.Categorical` with uniform `1-D` logits of length
+    `n_elements`, so `log_prob`/`entropy`/`prob`/`mode` all work (they
+    broadcast over whatever shape you pass). `shape` describes the array
+    the space stands for: `()` is a single categorical - the usual case
+    for an action index (`Environment.action_space`) - while `(H, W)` /
+    `(H, W, 3)` describe a grid or image observation whose every element
+    is an independent categorical over the same `n_elements` values.
 
     Attributes:
-        shape: the shape of the array the space describes. `()` means a
-            single scalar (e.g. a discrete action index or a scalar
-            reward); `(H, W)` / `(H, W, 3)` etc. describe a grid or image
-            observation, with every element independently constrained to
-            `[minimum, maximum]`.
-        dtype: the array's dtype (e.g. `jnp.int32` for a `Discrete`
-            action, `jnp.uint8` for a pixel observation, `jnp.float32`
-            for a reward).
-        minimum: element-wise lower bound (inclusive). A scalar array
-            broadcasts to `shape`.
-        maximum: element-wise upper bound (inclusive). A scalar array
-            broadcasts to `shape`."""
+        shape: shape of the array the space describes (`()` for a scalar).
+        dtype: integer dtype of a sampled array (default `jnp.int32`).
+        minimum: `0` (inclusive lower bound).
+        maximum: `n_elements - 1` (inclusive upper bound).
+        n: `n_elements`, i.e. `maximum + 1`.
+    """
 
-    shape: Shape = struct.field(pytree_node=False)
-    dtype: jnp.dtype = struct.field(pytree_node=False)
-    minimum: Array
-    maximum: Array
-
-    def sample(self, key: Array) -> Array:
-        """Draws one array of shape `shape` and dtype `dtype` whose
-        elements lie within `[minimum, maximum]`.
-
-        Args:
-            key (Array): a `jax.random` PRNG key.
-
-        Returns:
-            Array: the sampled array, shape `shape`, dtype `dtype`.
-
-        Raises:
-            NotImplementedError: `Space` is abstract; call `sample` on a
-                `Discrete` or `Continuous` instance."""
-        raise NotImplementedError()
-
-
-class Discrete(Space):
-    """An integer-valued space: every element is one of the `n_elements`
-    integers `0, 1, ..., n_elements - 1`.
-
-    With `shape=()` it describes a single categorical value - the usual
-    case for an action index (`Environment.action_space`). With a
-    non-empty `shape` it describes an array of independent categoricals,
-    e.g. a `categorical` observation is `Discrete` over entity tags with
-    `shape=(H, W)`."""
+    def __init__(
+        self,
+        n_elements: int | Array,
+        shape: Shape = (),
+        dtype: jnp.dtype = jnp.int32,
+    ):
+        """Args:
+        n_elements (int | Array): number of distinct values; `>= 1`.
+        shape (tuple[int, ...]): shape of the integer array the space
+            describes. `()` (the default) is a single scalar.
+        dtype: integer dtype of the sampled array (default `jnp.int32`).
+            Unsigned dtypes are allowed - `sample` draws with a signed
+            generator and casts."""
+        super().__init__(logits=jnp.zeros((int(n_elements),), dtype=jnp.float32))
+        self.shape: Shape = tuple(int(d) for d in shape)
+        self._np_dtype: np.dtype = jnp.dtype(dtype)
 
     @classmethod
     def create(
-        cls, n_elements: int | jax.Array, shape: Shape = (), dtype=jnp.int32
+        cls, n_elements: int | Array, shape: Shape = (), dtype: jnp.dtype = jnp.int32
     ) -> Discrete:
-        """Builds a `Discrete` space over `0 .. n_elements - 1`.
+        """Builds a `Discrete` space over `0 .. n_elements - 1`. Kept as a
+        named constructor for parity with the rest of navix; identical to
+        `Discrete(n_elements, shape, dtype)`.
 
         Args:
-            n_elements (int | Array): number of distinct values; must be
-                `>= 1`. Stored as `maximum = n_elements - 1` (with
-                `minimum = 0`), so `space.n` recovers it.
-            shape (tuple[int, ...]): shape of the integer array the space
-                describes. `()` (the default) is a single scalar.
+            n_elements (int | Array): number of distinct values; `>= 1`.
+            shape (tuple[int, ...]): shape of the integer array (default
+                `()`, a scalar).
             dtype: integer dtype of the sampled array (default
-                `jnp.int32`). Unsigned dtypes are allowed - `sample`
-                draws with a signed generator and casts.
+                `jnp.int32`).
 
         Returns:
             Discrete: the space, with `minimum = 0` and
             `maximum = n_elements - 1`."""
-        return Discrete(
-            shape=shape,
-            dtype=dtype,
-            minimum=jnp.asarray(0),
-            maximum=jnp.asarray(n_elements) - 1,
-        )
+        return cls(n_elements, shape, dtype)
 
-    def sample(self, key: Array) -> Array:
+    def sample(self, key: Array) -> Array:  # type: ignore[override]
         """Draws integers uniformly from `0 .. n_elements - 1`,
-        independently per element.
+        independently per element. Takes the key positionally (navix
+        convention), not as `distrax`'s keyword-only `seed`.
 
         Args:
             key (Array): a `jax.random` PRNG key.
 
         Returns:
             Array: shape `shape`, dtype `dtype`."""
-        # `maximum` is the inclusive top value (`n_elements - 1`), but
-        # `jax.random.randint`'s `maxval` is exclusive - pass `+ 1` so the
-        # top value is actually reachable.
-        item = jax.random.randint(key, self.shape, self.minimum, self.maximum + 1)
-        # randint cannot draw jnp.uint, so we cast it later
-        return jnp.asarray(item, dtype=self.dtype)
+        # randint's `maxval` is exclusive, so `num_categories` (not
+        # `num_categories - 1`) makes the top value reachable. randint
+        # cannot target an unsigned dtype, so draw signed and cast.
+        item = jax.random.randint(key, self.shape, 0, self.num_categories)
+        return jnp.asarray(item, dtype=self._np_dtype)
+
+    @property
+    def dtype(self) -> np.dtype:  # type: ignore[override]
+        """The dtype of a sampled array (a navix attribute; `distrax`
+        would otherwise infer it from `sample`)."""
+        return self._np_dtype
+
+    @property
+    def minimum(self) -> Array:
+        """Element-wise lower bound (inclusive): `0`."""
+        return jnp.asarray(0)
+
+    @property
+    def maximum(self) -> Array:
+        """Element-wise upper bound (inclusive): `n_elements - 1`."""
+        return jnp.asarray(self.num_categories - 1)
 
     @property
     def n(self) -> Array:
-        """The number of distinct values, `n_elements` (i.e.
-        `maximum + 1`). For an action space, `len(env.action_set)`."""
-        return self.maximum + 1
+        """The number of distinct values, `n_elements` (`maximum + 1`).
+        For an action space, `len(env.action_set)`."""
+        return jnp.asarray(self.num_categories)
+
+    def replace(self, **changes) -> Discrete:
+        """Returns a copy with some of `n_elements` / `shape` / `dtype`
+        overridden (mirrors `flax.struct`'s `replace`; used e.g. to flatten
+        an observation space: `space.replace(shape=(prod(space.shape),))`)."""
+        return Discrete(
+            changes.get("n_elements", self.num_categories),
+            changes.get("shape", self.shape),
+            changes.get("dtype", self._np_dtype),
+        )
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, Discrete)
+            and int(self.num_categories) == int(other.num_categories)
+            and self.shape == other.shape
+            and self._np_dtype == other._np_dtype
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            ("Discrete", int(self.num_categories), self.shape, str(self._np_dtype))
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"Discrete(n_elements={int(self.num_categories)}, "
+            f"shape={self.shape}, dtype={self._np_dtype.name})"
+        )
 
 
-class Continuous(Space):
-    """A floating-point space: every element lies in `[minimum, maximum]`.
+class Continuous(distrax.Uniform):
+    """A floating-point space: every element lies in `[minimum, maximum]`,
+    drawn uniformly and independently.
 
+    Subclasses `distrax.Uniform`, so `log_prob`/`entropy`/`prob` work.
     navix uses it for `reward_space` (`shape=()`, bounds `[-1, 1]` by
     default) and for float observations. Bounds may be infinite
-    (`-jnp.inf` / `jnp.inf`) to express "unbounded"; `sample` then falls
-    back to a finite range (see below)."""
+    (`-jnp.inf` / `jnp.inf`) to express "unbounded"; `sample` maps those
+    to the largest finite value of `dtype` (via `jnp.nan_to_num`) so an
+    unbounded space still yields a number rather than `nan`.
+
+    Attributes:
+        shape: shape of the array the space describes (`()` for a scalar).
+        dtype: floating dtype of a sampled array (default `jnp.float32`).
+        minimum: element-wise lower bound (`low`), broadcast to `shape`.
+        maximum: element-wise upper bound (`high`), broadcast to `shape`.
+    """
+
+    def __init__(
+        self,
+        shape: Shape,
+        minimum: Array,
+        maximum: Array,
+        dtype: jnp.dtype = jnp.float32,
+    ):
+        """Args:
+        shape (tuple[int, ...]): shape of the array (`()` is a scalar).
+        minimum (Array): element-wise lower bound (inclusive); a scalar
+            broadcasts to `shape`. May be `-jnp.inf`.
+        maximum (Array): element-wise upper bound (inclusive); a scalar
+            broadcasts to `shape`. May be `jnp.inf`.
+        dtype: floating dtype of the sampled array (default
+            `jnp.float32`)."""
+        np_dtype = jnp.dtype(dtype)
+        low = jnp.broadcast_to(jnp.asarray(minimum, np_dtype), shape)
+        high = jnp.broadcast_to(jnp.asarray(maximum, np_dtype), shape)
+        super().__init__(low=low, high=high)
+        self.shape: Shape = tuple(int(d) for d in shape)
+        self._np_dtype: np.dtype = np_dtype
 
     @classmethod
     def create(
-        cls, shape: Shape, minimum: Array, maximum: Array, dtype=jnp.float32
+        cls,
+        shape: Shape,
+        minimum: Array,
+        maximum: Array,
+        dtype: jnp.dtype = jnp.float32,
     ) -> Continuous:
-        """Builds a `Continuous` space.
+        """Builds a `Continuous` space. Kept as a named constructor for
+        parity with the rest of navix; identical to
+        `Continuous(shape, minimum, maximum, dtype)`.
 
         Args:
-            shape (tuple[int, ...]): shape of the array the space
-                describes. `()` is a scalar (e.g. a reward).
-            minimum (Array): element-wise lower bound (inclusive); a
-                scalar broadcasts to `shape`. May be `-jnp.inf`.
-            maximum (Array): element-wise upper bound (inclusive); a
-                scalar broadcasts to `shape`. May be `jnp.inf`.
+            shape (tuple[int, ...]): shape of the array (`()` is a scalar).
+            minimum (Array): element-wise lower bound; may be `-jnp.inf`.
+            maximum (Array): element-wise upper bound; may be `jnp.inf`.
             dtype: floating dtype of the sampled array (default
                 `jnp.float32`).
 
         Returns:
             Continuous: the space."""
-        return Continuous(shape=shape, dtype=dtype, minimum=minimum, maximum=maximum)
+        return cls(shape, minimum, maximum, dtype)
 
-    def sample(self, key: Array) -> Array:
+    def sample(self, key: Array) -> Array:  # type: ignore[override]
         """Draws values uniformly from `[minimum, maximum)`, independently
-        per element. Infinite bounds are first mapped to the largest
-        finite value of `dtype` (via `jnp.nan_to_num`), so an unbounded
-        space still yields a finite draw rather than `nan`.
+        per element. Takes the key positionally (navix convention), not as
+        `distrax`'s keyword-only `seed`. Infinite bounds are first mapped
+        to the largest finite value of `dtype` (via `jnp.nan_to_num`), so
+        an unbounded space still yields a number rather than `nan`.
 
         Args:
             key (Array): a `jax.random` PRNG key.
 
         Returns:
-            Array: shape `shape`, dtype `dtype`.
-
-        Raises:
-            AssertionError: if `dtype` is not a floating type."""
-        assert jnp.issubdtype(self.dtype, jnp.floating)
+            Array: shape `shape`, dtype `dtype`."""
         # see: https://github.com/google/jax/issues/14003
-        lower = jnp.nan_to_num(self.minimum)
-        upper = jnp.nan_to_num(self.maximum)
+        lower = jnp.nan_to_num(self.low)
+        upper = jnp.nan_to_num(self.high)
         return jax.random.uniform(
-            key, self.shape, minval=lower, maxval=upper, dtype=self.dtype
+            key, self.shape, self._np_dtype, minval=lower, maxval=upper
+        )
+
+    @property
+    def dtype(self) -> np.dtype:  # type: ignore[override]
+        """The dtype of a sampled array (a navix attribute; `distrax`
+        would otherwise infer it from `sample`)."""
+        return self._np_dtype
+
+    @property
+    def minimum(self) -> Array:
+        """Element-wise lower bound (inclusive), i.e. `distrax.Uniform.low`."""
+        return self.low
+
+    @property
+    def maximum(self) -> Array:
+        """Element-wise upper bound (inclusive), i.e. `distrax.Uniform.high`."""
+        return self.high
+
+    def replace(self, **changes) -> Continuous:
+        """Returns a copy with some of `shape` / `minimum` / `maximum` /
+        `dtype` overridden (mirrors `flax.struct`'s `replace`). When only
+        `shape` changes, the current bounds are collapsed to their
+        min/max scalar and re-broadcast to it (navix builds `Continuous`
+        with constant bounds, so this is exact)."""
+        low = changes.get("minimum", jnp.min(self.low) if self.low.size else self.low)
+        high = changes.get(
+            "maximum", jnp.max(self.high) if self.high.size else self.high
+        )
+        return Continuous(
+            changes.get("shape", self.shape),
+            low,
+            high,
+            changes.get("dtype", self._np_dtype),
+        )
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, Continuous)
+            and self.shape == other.shape
+            and self._np_dtype == other._np_dtype
+            and bool(jnp.all(self.low == other.low))
+            and bool(jnp.all(self.high == other.high))
+        )
+
+    def __hash__(self) -> int:
+        return hash(("Continuous", self.shape, str(self._np_dtype)))
+
+    def __repr__(self) -> str:
+        return (
+            f"Continuous(shape={self.shape}, dtype={self._np_dtype.name}, "
+            f"minimum={np.asarray(self.low).min()}, "
+            f"maximum={np.asarray(self.high).max()})"
         )

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -1,27 +1,29 @@
-import sys
-
 import jax
 import jax.numpy as jnp
 import numpy as np
+import distrax
+
+import navix as nx
 from navix.spaces import Continuous, Discrete
-
-
-MAX_INT = 100_000_000
-MIN_INT = -100_000_000
 
 
 def test_discrete():
     key = jax.random.PRNGKey(42)
-    elements = (5, 0, MAX_INT, MIN_INT)
+    # n_elements is materialised as `distrax.Categorical` logits of that
+    # length, so it is a small count in practice (action counts, entity
+    # tags, 256 for a pixel) - not the ~1e8 the old hand-rolled space
+    # tolerated.
+    elements = (1, 2, 7, 11, 256)
     shapes = ((), (0,), (0, 0), (1, 2), (5, 5))
-    dtypes = (jnp.int8, jnp.int16, jnp.int32)
     for element in elements:
         for shape in shapes:
-            for dtype in dtypes:
-                space = Discrete.create(element, shape, dtype)
-                sample = space.sample(key)
-                print(sample)
-                assert jnp.all(jnp.logical_not(jnp.isnan(sample)))
+            # int dtype wide enough to hold `element - 1`
+            dtype = jnp.int16 if element > 128 else jnp.int8
+            space = Discrete.create(element, shape, dtype)
+            sample = space.sample(key)
+            assert sample.shape == shape
+            assert sample.dtype == jnp.dtype(dtype)
+            assert jnp.all((sample >= 0) & (sample < element))
 
 
 def test_discrete_sample_covers_the_full_range():
@@ -37,6 +39,15 @@ def test_discrete_sample_covers_the_full_range():
     assert set(np.unique(samples).tolist()) == set(range(n))
 
 
+def test_discrete_bounds_and_n():
+    space = Discrete.create(7, shape=(3, 3), dtype=jnp.uint8)
+    assert int(space.minimum) == 0
+    assert int(space.maximum) == 6
+    assert int(space.n) == 7
+    assert space.shape == (3, 3)
+    assert space.dtype == jnp.dtype(jnp.uint8)
+
+
 def test_continuous():
     key = jax.random.PRNGKey(42)
     shapes = ((), (0,), (0, 0), (1, 2), (5, 5))
@@ -45,7 +56,7 @@ def test_continuous():
         (0.0, 1),
         (0, 1),
         (1.0, -1.0),
-        (MIN_INT, MAX_INT),
+        (-1e8, 1e8),
     ]
     for shape in shapes:
         for minimum, maximum in min_max:
@@ -53,8 +64,75 @@ def test_continuous():
                 shape=shape, minimum=jnp.asarray(minimum), maximum=jnp.asarray(maximum)
             )
             sample = space.sample(key)
-            print(sample)
+            assert sample.shape == shape
             assert jnp.all(jnp.logical_not(jnp.isnan(sample)))
+
+
+def test_continuous_infinite_bounds_map_to_finite():
+    # `sample` runs the bounds through `jnp.nan_to_num`, so +/-inf bounds
+    # become the largest finite float rather than producing `nan`.
+    space = Continuous.create(
+        shape=(4,), minimum=jnp.asarray(-jnp.inf), maximum=jnp.asarray(jnp.inf)
+    )
+    sample = space.sample(jax.random.PRNGKey(0))
+    assert jnp.all(jnp.logical_not(jnp.isnan(sample)))
+
+
+def test_spaces_are_distrax_distributions():
+    # the "full replace": a space *is* a distrax distribution, so the
+    # distribution API is available on top of the shape/dtype/bounds
+    # descriptor.
+    d = Discrete.create(4, shape=(2,))
+    assert isinstance(d, distrax.Distribution)
+    assert isinstance(d, distrax.Categorical)
+    # uniform over 4 categories: log_prob is -log(4) everywhere
+    np.testing.assert_allclose(float(d.log_prob(jnp.asarray(0))), -np.log(4), rtol=1e-6)
+    np.testing.assert_allclose(float(d.entropy()), np.log(4), rtol=1e-6)
+
+    c = Continuous.create(shape=(), minimum=jnp.asarray(0.0), maximum=jnp.asarray(2.0))
+    assert isinstance(c, distrax.Distribution)
+    assert isinstance(c, distrax.Uniform)
+    np.testing.assert_allclose(float(c.log_prob(jnp.asarray(1.0))), -np.log(2), rtol=1e-6)
+
+
+def test_space_replace_and_equality():
+    d = Discrete.create(11, shape=(5, 5, 3), dtype=jnp.uint8)
+    flat = d.replace(shape=(75,))
+    assert flat.shape == (75,)
+    assert int(flat.n) == 11 and flat.dtype == jnp.dtype(jnp.uint8)
+    # value-based equality (two independently built spaces compare equal)
+    assert d == Discrete.create(11, shape=(5, 5, 3), dtype=jnp.uint8)
+    assert d != Discrete.create(11, shape=(5, 5, 3), dtype=jnp.int32)
+    assert hash(d) == hash(Discrete.create(11, shape=(5, 5, 3), dtype=jnp.uint8))
+
+    # Continuous.replace re-broadcasts constant bounds to the new shape
+    c = Continuous.create(shape=(2, 3), minimum=jnp.asarray(-1.0), maximum=jnp.asarray(1.0))
+    flat_c = c.replace(shape=(6,))
+    assert flat_c.shape == (6,)
+    assert flat_c.minimum.shape == (6,) and float(flat_c.minimum.min()) == -1.0
+    assert flat_c == Continuous.create(
+        shape=(6,), minimum=jnp.asarray(-1.0), maximum=jnp.asarray(1.0)
+    )
+
+
+def test_space_survives_jit_as_static_env_field():
+    # Environment stores the spaces as pytree_node=False, so they land in
+    # the jit treedef: they must be hashable and compare by value, and
+    # `nx.make(id) == nx.make(id)` must hold (test_registry relies on it).
+    a = nx.make("Navix-Empty-5x5-v0")
+    b = nx.make("Navix-Empty-5x5-v0")
+    assert a.observation_space == b.observation_space
+    assert a.action_space == b.action_space
+    assert a == b
+
+    @jax.jit
+    def rollout(env, key):
+        ts = env.reset(key)
+        return env.step(ts, env.action_space.sample(key)).reward
+
+    r1 = rollout(a, jax.random.PRNGKey(0))
+    r2 = rollout(b, jax.random.PRNGKey(0))  # same treedef -> cache hit, same result
+    assert float(r1) == float(r2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #219 (the "full replace" option).

## What changed

`navix/spaces.py` no longer defines a bespoke `Space(struct.PyTreeNode)`
hierarchy with a hand-rolled `sample`. Instead:

- `Discrete` **subclasses `distrax.Categorical`** (uniform `1-D` logits of
  length `n_elements`).
- `Continuous` **subclasses `distrax.Uniform`**.
- `spaces.Space` is now an alias for `distrax.Distribution` — the common
  supertype the `Environment` type hints use.

So `isinstance(env.action_space, distrax.Distribution)` holds and
`log_prob` / `entropy` / `prob` / `mode` are available on any space.

## What stayed the same (so nothing downstream breaks)

Every attribute navix code reads off a space is preserved as a thin
override:

| surface | kept as |
|---|---|
| `space.shape` | navix attribute set in `__init__` |
| `space.dtype` | overridden property → the descriptor dtype |
| `space.minimum` / `space.maximum` | `0` / `n-1` for `Discrete`; `low` / `high` for `Continuous` |
| `space.n` (`Discrete`) | `num_categories` |
| `space.sample(key)` | positional key, returns a `space.shape`-shaped iid array |
| `space.replace(shape=…)` | rebuilds the space (used to flatten obs) |
| `Discrete.create` / `Continuous.create` | thin named constructors, unchanged call sites |
| `Space` symbol imported from `navix.spaces` | now `distrax.Distribution` |

`__eq__` / `__hash__` are defined by value on both classes, so
`nx.make(id) == nx.make(id)` still holds (the spaces are
`pytree_node=False` fields on the frozen `Environment` and land in the jit
treedef — `test_registry::test_v1_aliases_redirect_and_warn` covers this).

## Deliberate deviations from vanilla distrax

Trying the literal "spaces *are* distributions" turned up three places
where a faithful mapping is either wrong or wasteful, so the subclasses
deviate on purpose (all documented in the module docstring):

1. **Logits are `1-D` `(n_elements,)`, not `(*shape, n_elements)`.** A
   faithful event-shaped categorical for a `(56, 56, 3)` pixel
   observation would allocate a multi-MB zero-logits array *per
   environment* just to describe the space. The `1-D` distribution is
   "one element's distribution", and navix's array shape lives in
   `space.shape`. Consequence: `space.event_shape` / `space.batch_shape`
   are `()`, not `space.shape`.
2. **`sample(key)` keeps navix's positional-key signature**, not
   distrax's keyword-only `sample(*, seed, sample_shape)`. Call sites all
   pass the key positionally.
3. **`dtype` is overridden** to return the descriptor dtype (`distrax`
   otherwise infers it by `eval_shape`-ing `sample`, which our override
   defeats).

## Behaviour

**No environment behaviour change.** `Discrete.sample` /
`Continuous.sample` issue the same `jax.random.randint` / `.uniform` call
as before — same draws for the same key. This is a `refactor`, not a
`fix`/`feat`.

One narrow edge: the old `Discrete` tolerated `n_elements ~ 1e8` (it never
materialised anything); the new one allocates a length-`n_elements`
logits vector, so pathological counts cost memory. Real `n_elements`
(action counts, entity-tag counts, `256`) are trivially small.
`tests/test_spaces.py` was updated to reflect this and to cover the
distrax API, value equality, `replace`, and jit-treedef stability.

## Tests

`pytest tests/test_spaces.py tests/test_registry.py tests/test_environments.py
tests/test_memory.py tests/test_tasks.py tests/test_ppo.py tests/test_pqn.py
tests/test_dreamer.py tests/test_benchmark.py tests/test_agents.py
tests/test_models.py tests/test_experiment.py tests/test_issues.py` — all
pass. `examples/ppo.py`, `examples/ppo_pomdp.py`, `examples/hparam_search.py`
run clean. Full suite run before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJApsbeqR3TNKVhj5d6NbT
