### PR TITLE
fix(key_corridor): sample doors, walls and the agent start as MiniGrid does

### DIFF
--- a/navix/environments/key_corridor.py
+++ b/navix/environments/key_corridor.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from typing import List, Tuple, Union
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 
 from navix import observations, rewards, terminations
@@ -51,25 +52,18 @@ class KeyCorridor(Environment):
     """Find a key hidden behind unlocked doors, then use it to open the one
     locked door guarding the goal.
 
-    Rooms form an `n_rows x 3` grid: the middle column is one corridor (its
-    inter-row walls are removed), the key lives in a left-column room, and
-    the goal lives in a right-column room behind the episode's one locked
-    door.
+    Rooms form an `n_rows x 3` grid: the middle column is one corridor, the
+    key lives in a left-column room and the goal in a right-column room
+    behind the one locked door.
 
-    Every other door follows MiniGrid's `RoomGrid.connect_all`, which draws
-    walls uniformly with replacement and puts a closed door on each new one
-    that does not touch the locked room, stopping as soon as every room is
-    reachable. The order in which distinct eligible walls are first drawn is
-    a uniform permutation, so the doors it adds are exactly the shortest
-    prefix of a random permutation of eligible walls that connects the rooms
-    - walls between rooms that were already connected included. `_reset`
-    computes that prefix in one fixed-length pass, counting components with a
-    union-find.
+    Every other door follows MiniGrid's `RoomGrid.connect_all`: each wall not
+    touching the locked room gets a door, in uniformly random order, until
+    every room is reachable. MiniGrid draws walls with replacement, but the
+    order distinct walls are first drawn in is a uniform permutation, so one
+    pass over a permutation adds the same doors.
 
-    `jax.jit` needs a fixed entity count, so every candidate wall is a `Door`
-    entity. The ones `connect_all` never reaches sit at `DISCARD_PILE_COORDS`
-    and leave their cell a wall, so they render, encode and block exactly as
-    MiniGrid's plain walls do.
+    `jax.jit` needs a fixed entity count, so every candidate wall is a `Door`;
+    the ones left shut sit at `DISCARD_PILE_COORDS` and their cell stays a wall.
     """
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
@@ -104,26 +98,33 @@ class KeyCorridor(Environment):
         # `parent[parent]` pass after each union always restores it, and a
         # lookup is one gather however many rooms have merged.
         num_rooms = 3 * n_rows
-        # (row, u, v, col, side) - `col`/`side` are `position_on_border`'s
-        # own args for this wall; `u`/`v` are the two rooms it connects.
-        candidates: List[Tuple[int, int, int, int, int]] = []
+        # (row, u, v, wall cell before the offset, offset axis) - `u`/`v` are
+        # the two rooms the wall connects; the door sits `1..room_size` cells
+        # along the wall, uniformly, as MiniGrid's `door_pos` does.
+        candidates: List[Tuple[int, int, int, Tuple[int, int], int]] = []
         for row in range(n_rows):
-            candidates.append((row, _room_id(row, 0), _room_id(row, 1), 0, 1))
-            candidates.append((row, _room_id(row, 1), _room_id(row, 2), 2, 0))
+            r = row * pitch
+            candidates.append((row, _room_id(row, 0), _room_id(row, 1), (r, pitch), 0))
+            candidates.append(
+                (row, _room_id(row, 1), _room_id(row, 2), (r, 2 * pitch), 0)
+            )
         for row in range(n_rows - 1):
-            candidates.append((row, _room_id(row, 0), _room_id(row + 1, 0), 0, 3))
-            candidates.append((row, _room_id(row, 2), _room_id(row + 1, 2), 2, 3))
+            r = (row + 1) * pitch
+            candidates.append((row, _room_id(row, 0), _room_id(row + 1, 0), (r, 0), 1))
+            candidates.append(
+                (row, _room_id(row, 2), _room_id(row + 1, 2), (r, 2 * pitch), 1)
+            )
         num_candidates = len(candidates)
 
-        door_keys = jax.random.split(k_doors, num=num_candidates + 2)
-        positions = jnp.stack(
-            [
-                grid.position_on_border(row, col, side, key=door_keys[i])
-                for i, (row, _, _, col, side) in enumerate(candidates)
-            ]
+        k_offsets, k_colours, k_perm = jax.random.split(k_doors, num=3)
+        offsets = jax.random.randint(
+            k_offsets, (num_candidates,), minval=1, maxval=room_size + 1
         )
-        colours = random_colour(door_keys[num_candidates], num_candidates)
-        perm = jax.random.permutation(door_keys[num_candidates + 1], num_candidates)
+        wall_cells = jnp.asarray([cell for *_, cell, _ in candidates], dtype=jnp.int32)
+        along = jnp.asarray(np.eye(2, dtype=np.int32)[[a for *_, a in candidates]])
+        positions = wall_cells + offsets[:, None] * along
+        colours = random_colour(k_colours, num_candidates)
+        perm = jax.random.permutation(k_perm, num_candidates)
 
         row_ids = jnp.asarray([row for row, *_ in candidates])
         u_ids = jnp.asarray([u for _, u, _, _, _ in candidates])
@@ -149,16 +150,17 @@ class KeyCorridor(Environment):
         # the corridor merges `n_rows` rooms into one, the locked door one more
         components = jnp.asarray(num_rooms - n_rows)
 
-        added = jnp.zeros((num_candidates,), dtype=jnp.bool_)
+        u_perm, v_perm, eligible_perm = u_ids[perm], v_ids[perm], eligible[perm]
+        adds = []
         for i in range(num_candidates):
-            idx = perm[i]
-            ru, rv = parent[u_ids[idx]], parent[v_ids[idx]]
-            add = eligible[idx] & (components > 1)
+            ru, rv = parent[u_perm[i]], parent[v_perm[i]]
+            add = eligible_perm[i] & (components > 1)
             merge = add & (ru != rv)
             parent = parent.at[ru].set(jnp.where(merge, rv, ru))
             parent = parent[parent]  # one pointer-doubling pass restores flatness
             components = components - merge
-            added = added.at[idx].set(add)
+            adds.append(add)
+        added = jnp.zeros((num_candidates,), dtype=jnp.bool_).at[perm].set(jnp.stack(adds))
 
         on_grid = is_goal_slot | added
         door_colours = jnp.where(is_goal_slot, key_colour, colours)
@@ -168,33 +170,35 @@ class KeyCorridor(Environment):
             colour=door_colours,
             open=jnp.zeros((num_candidates,), dtype=jnp.int32),
         )
-        walls = grid.get_grid()
-        walls = walls.at[pitch : self.height - 1 : pitch, pitch + 1 : 2 * pitch].set(0)
+        # room walls with the corridor's inter-row walls removed, fixed per
+        # env, so built once at trace time as a constant
+        walls = np.zeros((self.height, self.width), dtype=np.float32)
+        walls[::pitch, :] = -1
+        walls[:, ::pitch] = -1
+        walls[pitch : self.height - 1 : pitch, pitch + 1 : 2 * pitch] = 0
         # a wall `connect_all` never reached stays a wall: its carve goes to
         # row `self.height`, out of bounds, which `mode="drop"` discards
         carved = jnp.where(on_grid[:, None], positions, jnp.asarray([self.height, 0]))
-        grid = walls.at[carved[:, 0], carved[:, 1]].set(0, mode="drop")
+        grid = jnp.asarray(walls).at[carved[:, 0], carved[:, 1]].set(0, mode="drop")
 
-        # agent: MiniGrid's `place_agent(1, n_rows // 2)`, which runs before
-        # `connect_all`. A uniform pose on any free cell of the middle corridor
-        # room's box, its corridor openings included, redrawn while it faces
-        # the locked door - the only object in front of that box at the time.
-        top = (n_rows // 2) * pitch
-        rows, cols = jnp.meshgrid(
-            jnp.arange(top, top + pitch + 1),
-            jnp.arange(pitch, 2 * pitch + 1),
-            indexing="ij",
-        )
-        cells = jnp.stack([rows.reshape(-1), cols.reshape(-1)], axis=-1)
-        # east, south, west, north, in `translate`'s direction order
-        fronts = cells[:, None] + jnp.asarray([[0, 1], [1, 0], [0, -1], [-1, 0]])
-        locked_door = positions[jnp.argmax(is_goal_slot)]
-        free = walls[cells[:, 0], cells[:, 1]] == 0
-        valid = free[:, None] & ~jnp.all(fronts == locked_door, axis=-1)
-        pose = jax.random.categorical(
-            k_agent, jnp.where(valid, 0.0, -jnp.inf).reshape(-1)
-        )
-        player = Player.create(cells[pose // 4], pose % 4, pocket=EMPTY_POCKET_ID)
+        # agent: MiniGrid's `place_agent(1, n_rows // 2)`, a uniform (cell,
+        # direction) in the middle corridor room, never facing the locked door.
+        # The free cells form a rectangle and only the east-facing pose beside
+        # the locked door can be invalid, so draw one index over the valid
+        # count and map that pose's slot to the last (north-facing) pose.
+        middle = n_rows // 2
+        first_row = middle * pitch + (0 if middle > 0 else 1)
+        last_row = middle * pitch + (pitch if middle < n_rows - 1 else room_size)
+        num_poses = (last_row - first_row + 1) * room_size * 4
+        locked_door_row = positions[jnp.argmax(is_goal_slot), 0]
+        blocked = (goal_room_row == middle).astype(jnp.int32)
+        blocked_pose = ((locked_door_row - first_row) * room_size + room_size - 1) * 4
+        pose = jax.random.randint(k_agent, (), minval=0, maxval=num_poses - blocked)
+        pose = jnp.where((blocked == 1) & (pose == blocked_pose), num_poses - 1, pose)
+        cell = pose // 4
+        agent_pos = jnp.stack([first_row + cell // room_size, pitch + 1 + cell % room_size])
+        # direction indices follow `translate`: east, south, west, north
+        player = Player.create(agent_pos, pose % 4, pocket=EMPTY_POCKET_ID)
 
         entities = {
             "player": player[None],

--- a/navix/environments/key_corridor.py
+++ b/navix/environments/key_corridor.py
@@ -39,7 +39,7 @@ from ..environments import Environment
 from ..entities import Goal, Player, Key, Door
 from ..states import State
 from ..environments import Timestep
-from ..grid import random_directions, random_colour, RoomsGrid
+from ..grid import random_colour, RoomsGrid
 from .registry import register_env
 
 
@@ -76,31 +76,26 @@ class KeyCorridor(Environment):
         n_rows_config = {3: 1, 5: 2}
         n_rows = n_rows_config.get(self.height, 3)
         room_size = (self.width - 3) // 3
-        k1, k2, k3, k4, k5, k6 = jax.random.split(key, num=6)
+        pitch = room_size + 1
+        k_key_row, k_key_pos, k_colour, k_goal_row, k_goal_pos, k_doors, k_agent = (
+            jax.random.split(key, num=7)
+        )
 
         # grid of rooms
         grid = RoomsGrid.create(n_rows, 3, (room_size, room_size))
 
         # key
-        key_room_row = jax.random.randint(k1, (), minval=0, maxval=n_rows)
+        key_room_row = jax.random.randint(k_key_row, (), minval=0, maxval=n_rows)
         key_pos = grid.position_in_room(
-            key_room_row, jnp.asarray(0, dtype=jnp.int32), key=k1
+            key_room_row, jnp.asarray(0, dtype=jnp.int32), key=k_key_pos
         )
-        key_colour = random_colour(k4)
+        key_colour = random_colour(k_colour)
         key_id = jnp.asarray(1)
         key_obj = Key.create(key_pos, key_colour, key_id)
 
-        # agent
-        pk_1, pk_2, pk_3 = jax.random.split(k2, num=3)
-        agent_room_row = jax.random.randint(pk_1, (), minval=0, maxval=n_rows)
-        agent_pos = grid.position_in_room(agent_room_row, jnp.asarray(1), key=pk_2)
-        player = Player.create(
-            agent_pos, random_directions(pk_3), pocket=EMPTY_POCKET_ID
-        )
-
         # goal
-        goal_room_row = jax.random.randint(k3, (), minval=0, maxval=n_rows)
-        goal_pos = grid.position_in_room(goal_room_row, jnp.asarray(2), key=k4)
+        goal_room_row = jax.random.randint(k_goal_row, (), minval=0, maxval=n_rows)
+        goal_pos = grid.position_in_room(goal_room_row, jnp.asarray(2), key=k_goal_pos)
         goal = Goal.create(goal_pos, probability=jnp.asarray(1.0))
 
         # Doors: connect_all - see the class docstring. `parent` (union-find)
@@ -120,7 +115,7 @@ class KeyCorridor(Environment):
             candidates.append((row, _room_id(row, 2), _room_id(row + 1, 2), 2, 3))
         num_candidates = len(candidates)
 
-        door_keys = jax.random.split(k5, num=num_candidates + 2)
+        door_keys = jax.random.split(k_doors, num=num_candidates + 2)
         positions = jnp.stack(
             [
                 grid.position_on_border(row, col, side, key=door_keys[i])
@@ -173,9 +168,33 @@ class KeyCorridor(Environment):
             colour=door_colours,
             open=jnp.zeros((num_candidates,), dtype=jnp.int32),
         )
+        walls = grid.get_grid()
+        walls = walls.at[pitch : self.height - 1 : pitch, pitch + 1 : 2 * pitch].set(0)
         # a wall `connect_all` never reached stays a wall: its carve goes to
         # row `self.height`, out of bounds, which `mode="drop"` discards
         carved = jnp.where(on_grid[:, None], positions, jnp.asarray([self.height, 0]))
+        grid = walls.at[carved[:, 0], carved[:, 1]].set(0, mode="drop")
+
+        # agent: MiniGrid's `place_agent(1, n_rows // 2)`, which runs before
+        # `connect_all`. A uniform pose on any free cell of the middle corridor
+        # room's box, its corridor openings included, redrawn while it faces
+        # the locked door - the only object in front of that box at the time.
+        top = (n_rows // 2) * pitch
+        rows, cols = jnp.meshgrid(
+            jnp.arange(top, top + pitch + 1),
+            jnp.arange(pitch, 2 * pitch + 1),
+            indexing="ij",
+        )
+        cells = jnp.stack([rows.reshape(-1), cols.reshape(-1)], axis=-1)
+        # east, south, west, north, in `translate`'s direction order
+        fronts = cells[:, None] + jnp.asarray([[0, 1], [1, 0], [0, -1], [-1, 0]])
+        locked_door = positions[jnp.argmax(is_goal_slot)]
+        free = walls[cells[:, 0], cells[:, 1]] == 0
+        valid = free[:, None] & ~jnp.all(fronts == locked_door, axis=-1)
+        pose = jax.random.categorical(
+            k_agent, jnp.where(valid, 0.0, -jnp.inf).reshape(-1)
+        )
+        player = Player.create(cells[pose // 4], pose % 4, pocket=EMPTY_POCKET_ID)
 
         entities = {
             "player": player[None],
@@ -184,11 +203,6 @@ class KeyCorridor(Environment):
             "goal": goal[None],
         }
 
-        grid = grid.get_grid().at[carved[:, 0], carved[:, 1]].set(0, mode="drop")
-        grid = grid.at[
-            1 + room_size : self.height - 1 : room_size + 1,
-            1 + room_size + 1 : 1 + room_size + 1 + room_size,
-        ].set(0)
         state = State(
             key=key,
             grid=grid,

--- a/navix/environments/key_corridor.py
+++ b/navix/environments/key_corridor.py
@@ -33,7 +33,7 @@ from jax import Array
 
 from navix import observations, rewards, terminations
 
-from ..components import EMPTY_POCKET_ID
+from ..components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
 from ..rendering.cache import RenderingCache
 from ..environments import Environment
 from ..entities import Goal, Player, Key, Door
@@ -41,14 +41,6 @@ from ..states import State
 from ..environments import Timestep
 from ..grid import random_directions, random_colour, RoomsGrid
 from .registry import register_env
-
-# A room stand-in for "no key will ever match this" - distinct from
-# EMPTY_POCKET_ID (-1, "no key needed") and from any real key id, so a
-# door assigned this permanently fails Door's `open` check. Used for
-# candidate connector walls that connect_all decides not to open, so
-# they act as ordinary walls (still a Door entity, for a fixed
-# per-n_rows entity count, but never passable).
-_UNOPENABLE = jnp.asarray(-2, dtype=jnp.int32)
 
 
 def _room_id(row: int, col: int) -> int:
@@ -59,36 +51,25 @@ class KeyCorridor(Environment):
     """Find a key hidden behind unlocked doors, then use it to open the one
     locked door guarding the goal.
 
-    Rooms form an `n_rows x 3` grid: the agent starts in the middle column
-    (always connected top-to-bottom - the "corridor"), keys live in the left
-    column, the goal lives in the right column behind the episode's one
-    locked door.
+    Rooms form an `n_rows x 3` grid: the middle column is one corridor (its
+    inter-row walls are removed), the key lives in a left-column room, and
+    the goal lives in a right-column room behind the episode's one locked
+    door.
 
-    Every other connector - including corridor<->key-room doors - comes from
-    a `jax.jit`-shaped port of MiniGrid's `RoomGrid.connect_all`: a
-    randomised search that keeps adding doors until every non-goal room is
-    reachable from the agent's start, without ever adding a second connector
-    to the goal room. Door positions, counts, and which side of the grid
-    gets inter-row connectors therefore vary per episode, rather than
-    following a fixed layout.
+    Every other door follows MiniGrid's `RoomGrid.connect_all`, which draws
+    walls uniformly with replacement and puts a closed door on each new one
+    that does not touch the locked room, stopping as soon as every room is
+    reachable. The order in which distinct eligible walls are first drawn is
+    a uniform permutation, so the doors it adds are exactly the shortest
+    prefix of a random permutation of eligible walls that connects the rooms
+    - walls between rooms that were already connected included. `_reset`
+    computes that prefix in one fixed-length pass, counting components with a
+    union-find.
 
-    Implemented as a single-pass, randomised Kruskal-style union-find
-    (activate a candidate wall iff it still joins two different components),
-    since MiniGrid's own sample-with-replacement retry loop has no static
-    iteration bound and can't be represented as a fixed-shape `jax.jit`
-    program. Candidate walls that end up not connecting anything still exist
-    as `Door` entities - a fixed count per `n_rows` is required for
-    `jax.jit` - but are permanently unopenable, so they behave as ordinary
-    walls.
-
-    Note:
-        Because those non-connecting candidates are still `Door` entities,
-        `observations.rgb`/`symbolic` render a closed, locked door sprite at
-        every candidate wall - including the ones that are functionally
-        solid walls. MiniGrid renders those as plain walls instead; there is
-        no way to tell them apart visually, only by checking
-        `state.entities["door"].requires` for the sentinel "no key can open
-        this" value.
+    `jax.jit` needs a fixed entity count, so every candidate wall is a `Door`
+    entity. The ones `connect_all` never reaches sit at `DISCARD_PILE_COORDS`
+    and leave their cell a wall, so they render, encode and block exactly as
+    MiniGrid's plain walls do.
     """
 
     def _reset(self, key: Array, cache: Union[RenderingCache, None] = None) -> Timestep:
@@ -122,12 +103,11 @@ class KeyCorridor(Environment):
         goal_pos = grid.position_in_room(goal_room_row, jnp.asarray(2), key=k4)
         goal = Goal.create(goal_pos, probability=jnp.asarray(1.0))
 
-        # Doors: connect_all port - see the class docstring for the full
-        # design. `parent` (union-find) is kept fully flat as an invariant:
-        # a union from a flat state only ever strands nodes one hop further
-        # off, so a single `parent[parent]` pass after each union always
-        # restores it - cheaper than scanning up to `num_rooms` hops per
-        # lookup, which matters since this loop's steps are sequential.
+        # Doors: connect_all - see the class docstring. `parent` (union-find)
+        # is kept fully flat as an invariant: a union from a flat state only
+        # ever strands nodes one hop further off, so a single
+        # `parent[parent]` pass after each union always restores it, and a
+        # lookup is one gather however many rooms have merged.
         num_rooms = 3 * n_rows
         # (row, u, v, col, side) - `col`/`side` are `position_on_border`'s
         # own args for this wall; `u`/`v` are the two rooms it connects.
@@ -171,27 +151,31 @@ class KeyCorridor(Environment):
         parent = parent.at[locked_room].set(corridor_root)
 
         eligible = (u_ids != locked_room) & (v_ids != locked_room)
+        # the corridor merges `n_rows` rooms into one, the locked door one more
+        components = jnp.asarray(num_rooms - n_rows)
 
-        active = jnp.zeros((num_candidates,), dtype=jnp.bool_)
+        added = jnp.zeros((num_candidates,), dtype=jnp.bool_)
         for i in range(num_candidates):
             idx = perm[i]
-            u, v, elig = u_ids[idx], v_ids[idx], eligible[idx]
-            ru, rv = parent[u], parent[v]  # O(1): parent enters every step flat
-            connect = elig & (ru != rv)
-            parent = parent.at[ru].set(jnp.where(connect, rv, ru))
+            ru, rv = parent[u_ids[idx]], parent[v_ids[idx]]
+            add = eligible[idx] & (components > 1)
+            merge = add & (ru != rv)
+            parent = parent.at[ru].set(jnp.where(merge, rv, ru))
             parent = parent[parent]  # one pointer-doubling pass restores flatness
-            active = active.at[idx].set(connect)
+            components = components - merge
+            added = added.at[idx].set(add)
 
-        requires = jnp.where(
-            is_goal_slot, key_id, jnp.where(active, EMPTY_POCKET_ID, _UNOPENABLE)
-        )
+        on_grid = is_goal_slot | added
         door_colours = jnp.where(is_goal_slot, key_colour, colours)
         doors = Door.create(
-            position=positions,
-            requires=requires,
+            position=jnp.where(on_grid[:, None], positions, DISCARD_PILE_COORDS),
+            requires=jnp.where(is_goal_slot, key_id, EMPTY_POCKET_ID),
             colour=door_colours,
             open=jnp.zeros((num_candidates,), dtype=jnp.int32),
         )
+        # a wall `connect_all` never reached stays a wall: its carve goes to
+        # row `self.height`, out of bounds, which `mode="drop"` discards
+        carved = jnp.where(on_grid[:, None], positions, jnp.asarray([self.height, 0]))
 
         entities = {
             "player": player[None],
@@ -200,7 +184,7 @@ class KeyCorridor(Environment):
             "goal": goal[None],
         }
 
-        grid = grid.get_grid(occupied_positions=doors.position)
+        grid = grid.get_grid().at[carved[:, 0], carved[:, 1]].set(0, mode="drop")
         grid = grid.at[
             1 + room_size : self.height - 1 : room_size + 1,
             1 + room_size + 1 : 1 + room_size + 1 + room_size,

--- a/navix/grid.py
+++ b/navix/grid.py
@@ -907,8 +907,8 @@ class RoomsGrid(struct.PyTreeNode):
         Returns:
             Array: A random position in the given room."""
         k1, k2 = jax.random.split(key)
-        local_row = jax.random.randint(k1, (), minval=1, maxval=self.room_size[0])
-        local_col = jax.random.randint(k2, (), minval=1, maxval=self.room_size[1])
+        local_row = jax.random.randint(k1, (), minval=1, maxval=self.room_size[0] + 1)
+        local_col = jax.random.randint(k2, (), minval=1, maxval=self.room_size[1] + 1)
         return jnp.asarray([local_row, local_col]) + self.room_starts[row, col]
 
     @partial(jax.jit, static_argnums=3)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -60,6 +60,17 @@ def test_random_positions():
         assert jnp.array_equal(grid[tuple(position)], 0), positions
 
 
+def test_position_in_room_covers_the_whole_interior():
+    rooms = nx.grid.RoomsGrid.create(2, 3, (3, 2))
+    keys = jax.random.split(jax.random.PRNGKey(0), 500)
+    positions = jax.vmap(lambda k: rooms.position_in_room(1, 2, key=k))(keys)
+    start_row, start_col = rooms.room_starts[1, 2].tolist()
+    interior = {
+        (start_row + r, start_col + c) for r in range(1, 4) for c in range(1, 3)
+    }
+    assert set(map(tuple, positions.tolist())) == interior
+
+
 def test_position_equal():
     # one to one
     a = jnp.array([1, 1])

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -179,7 +179,8 @@ def test_98():
     # actually control whether the agent can pass, since _can_walk_there
     # requires both the grid cell and the entity to be walkable
     doors = state.get_doors()
-    door_cells = state.grid[tuple(doors.position.T)]
+    on_grid = jnp.all(doors.position >= 0, axis=-1)
+    door_cells = state.grid[tuple(doors.position[on_grid].T)]
     assert jnp.all(door_cells == 0), (
         "Expected every door position to be floor (0) in the base grid, "
         "got {}".format(door_cells)
@@ -401,6 +402,8 @@ def test_160():
         for k in keys:
             timestep = env.reset(k)
             positions = timestep.state.get_doors().position
+            # the walls connect_all leaves shut all wait on the discard pile
+            positions = positions[jnp.all(positions >= 0, axis=-1)]
             n_unique = jnp.unique(positions, axis=0).shape[0]
             assert n_unique == positions.shape[0], (
                 f"{env_id}: expected every door to occupy its own cell, got "

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -402,7 +402,7 @@ def test_160():
         for k in keys:
             timestep = env.reset(k)
             positions = timestep.state.get_doors().position
-            # the walls connect_all leaves shut all wait on the discard pile
+            # unused candidate doors all share the off-grid discard pile
             positions = positions[jnp.all(positions >= 0, axis=-1)]
             n_unique = jnp.unique(positions, axis=0).shape[0]
             assert n_unique == positions.shape[0], (

--- a/tests/test_key_corridor.py
+++ b/tests/test_key_corridor.py
@@ -198,6 +198,41 @@ def test_unopened_candidate_walls_are_walls(env_id):
 
 
 @pytest.mark.parametrize("env_id", _ENV_IDS)
+def test_agent_starts_as_in_minigrid(env_id):
+    """MiniGrid's `place_agent(1, num_rows // 2)`: any free cell of the middle
+    corridor room, its corridor openings included, never facing the locked
+    door."""
+    env = nx.make(env_id)
+    n_rows = _N_ROWS_CONFIG.get(env.height, 3)
+    pitch = (env.width - 3) // 3 + 1
+
+    def start(key):
+        entities = env.reset(key).state.entities
+        return entities["player"], entities["door"], entities["key"].id
+
+    keys = jax.vmap(jax.random.PRNGKey)(jnp.arange(_N_COUNT_SEEDS))
+    player, doors, key_ids = jax.jit(jax.vmap(start))(keys)
+    positions = np.asarray(player.position)[:, 0]
+    directions = np.asarray(player.direction)[:, 0]
+
+    steps = np.asarray([[0, 1], [1, 0], [0, -1], [-1, 0]])  # east, south, west, north
+    locked = np.asarray(doors.requires) == np.asarray(key_ids)
+    locked_doors = np.asarray(doors.position)[locked]
+    assert not np.any(np.all(positions + steps[directions] == locked_doors, axis=-1)), (
+        f"{env_id}: an agent starts facing the locked door"
+    )
+
+    top = (n_rows // 2) * pitch
+    rows, cols = np.indices((env.height, env.width))
+    interior = (rows % pitch != 0) & (cols % pitch != 0)
+    corridor = (rows % pitch == 0) & (0 < rows) & (rows < env.height - 1)
+    box = (top <= rows) & (rows <= top + pitch) & (pitch < cols) & (cols < 2 * pitch)
+    assert set(map(tuple, positions.tolist())) == _cells(box & (interior | corridor))
+    # S3R1's middle room is one cell, and east of it is always the locked door
+    assert set(directions.tolist()) == ({1, 2, 3} if n_rows == 1 else {0, 1, 2, 3})
+
+
+@pytest.mark.parametrize("env_id", _ENV_IDS)
 def test_door_count_matches_minigrid(env_id):
     env = nx.make(env_id)
     expected = _MINIGRID_UNLOCKED_DOORS[_N_ROWS_CONFIG.get(env.height, 3)]

--- a/tests/test_key_corridor.py
+++ b/tests/test_key_corridor.py
@@ -17,12 +17,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
 """KeyCorridor's door placement mirrors MiniGrid's RoomGrid.connect_all
-- a randomised union-find that must guarantee every non-goal room stays
-reachable from the agent's start, the goal room never gets a second
-(openable) connector, and no two doors ever share a cell. #160 and #161
-were both silent regressions of exactly these invariants, so this
-checks them directly across many seeds rather than relying on luck."""
+- every room stays reachable from the corridor, the locked room never gets
+a second (openable) connector, no two doors ever share a cell, every wall
+connect_all does not open is a real wall, and the number of doors follows
+MiniGrid's. #160 and #161 were both silent regressions of these invariants,
+so this checks them directly across many seeds rather than relying on luck."""
 
 from typing import Optional, Set, Tuple
 
@@ -32,7 +33,7 @@ import jax.numpy as jnp
 import pytest
 
 import navix as nx
-from navix.environments.key_corridor import _UNOPENABLE
+from navix.components import DISCARD_PILE_COORDS, EMPTY_POCKET_ID
 
 _ENV_IDS = (
     "Navix-KeyCorridorS3R1-v0",
@@ -44,6 +45,18 @@ _ENV_IDS = (
 )
 _N_SEEDS = 200
 _N_ROWS_CONFIG = {3: 1, 5: 2}
+
+# Frequencies of the number of unlocked doors in real MiniGrid 3.1.0,
+# `KeyCorridorEnv(room_size, num_rows)` reset on seeds 0-2999. The count
+# depends only on the room graph, so the four R3 sizes are pooled (12000
+# resets). Keyed by `num_rows`.
+_MINIGRID_UNLOCKED_DOORS = {
+    1: {1: 1.0},
+    2: {3: 0.754, 4: 0.246},
+    3: {5: 0.414, 6: 0.366, 7: 0.220},
+}
+_N_COUNT_SEEDS = 2000
+_COUNT_TOLERANCE = 0.05  # over four standard errors at these sample sizes
 
 
 def _room_of(pos: Tuple[int, int], room_size: int) -> Optional[Tuple[int, int]]:
@@ -97,6 +110,10 @@ def _reachable_rooms(
     return seen
 
 
+def _cells(mask: np.ndarray) -> Set[Tuple[int, int]]:
+    return set(map(tuple, np.argwhere(mask).tolist()))
+
+
 @pytest.mark.parametrize("env_id", _ENV_IDS)
 def test_connect_all_reachability_and_door_uniqueness(env_id):
     env = nx.make(env_id)
@@ -109,12 +126,14 @@ def test_connect_all_reachability_and_door_uniqueness(env_id):
     positions = np.asarray(timestep.state.entities["door"].position)
     requires = np.asarray(timestep.state.entities["door"].requires)
     key_ids = np.asarray(timestep.state.entities["key"].id)[:, 0]
-    agent_positions = np.asarray(timestep.state.entities["player"].position)[:, 0]
-    unopenable = int(_UNOPENABLE)
 
     for seed in range(_N_SEEDS):
-        seed_positions = positions[seed]
-        seed_requires = requires[seed]
+        on_grid = np.all(positions[seed] >= 0, axis=-1)
+        assert np.all(positions[seed][~on_grid] == np.asarray(DISCARD_PILE_COORDS)), (
+            f"{env_id} seed={seed}: an off-grid door is not on the discard pile"
+        )
+        seed_positions = positions[seed][on_grid]
+        seed_requires = requires[seed][on_grid]
         key_id = int(key_ids[seed])
 
         unique_positions = set(map(tuple, seed_positions.tolist()))
@@ -128,27 +147,73 @@ def test_connect_all_reachability_and_door_uniqueness(env_id):
             f"{env_id} seed={seed}: expected exactly one locked goal door, "
             f"got {goal_mask.sum()}"
         )
+        assert np.all(seed_requires[~goal_mask] == EMPTY_POCKET_ID)
         goal_touching = _rooms_touching_wall(
             tuple(seed_positions[goal_mask][0]), room_size, n_rows
         )
         assert len(goal_touching) == 2
         locked_room = next(r for r in goal_touching if r[1] == 2)
 
-        agent_room = _room_of(tuple(agent_positions[seed]), room_size)
-        assert agent_room is not None and agent_room[1] == 1
-
-        reach = _reachable_rooms(seed_positions, room_size, n_rows, agent_room)
-        non_locked = {(r, c) for r in range(n_rows) for c in range(3)} - {locked_room}
-        assert non_locked.issubset(reach), (
-            f"{env_id} seed={seed}: unreachable non-goal rooms "
-            f"{non_locked - reach}"
+        reach = _reachable_rooms(seed_positions, room_size, n_rows, (0, 1))
+        all_rooms = {(r, c) for r in range(n_rows) for c in range(3)}
+        assert reach == all_rooms, (
+            f"{env_id} seed={seed}: unreachable rooms {all_rooms - reach}"
         )
 
-        for pos, req in zip(seed_positions, seed_requires):
-            if req == key_id or req == unopenable:
-                continue
+        for pos in seed_positions[~goal_mask]:
             touching = _rooms_touching_wall(tuple(pos), room_size, n_rows)
             assert locked_room not in touching, (
-                f"{env_id} seed={seed}: openable door at {tuple(pos)} "
-                f"(requires={req}) bypasses the locked room"
+                f"{env_id} seed={seed}: unlocked door at {tuple(pos)} "
+                "bypasses the locked room"
             )
+
+
+@pytest.mark.parametrize("env_id", _ENV_IDS)
+def test_unopened_candidate_walls_are_walls(env_id):
+    """The only floor cells on the room walls are doors and the corridor."""
+    env = nx.make(env_id)
+    pitch = (env.width - 3) // 3 + 1
+
+    keys = jax.vmap(jax.random.PRNGKey)(jnp.arange(_N_SEEDS))
+    timestep = jax.jit(jax.vmap(env.reset))(keys)
+    grids = np.asarray(timestep.state.grid)
+    positions = np.asarray(timestep.state.entities["door"].position)
+
+    rows, cols = np.indices(grids.shape[1:])
+    wall_lines = (rows % pitch == 0) | (cols % pitch == 0)
+    corridor = (
+        (rows % pitch == 0)
+        & (0 < rows)
+        & (rows < env.height - 1)
+        & (pitch < cols)
+        & (cols < 2 * pitch)
+    )
+    for seed in range(_N_SEEDS):
+        doors = {tuple(p) for p in positions[seed].tolist() if min(p) >= 0}
+        openings = _cells(wall_lines & (grids[seed] == 0))
+        assert openings == doors | _cells(corridor), (
+            f"{env_id} seed={seed}: wall openings {sorted(openings)} are not "
+            f"exactly the doors {sorted(doors)} plus the corridor"
+        )
+
+
+@pytest.mark.parametrize("env_id", _ENV_IDS)
+def test_door_count_matches_minigrid(env_id):
+    env = nx.make(env_id)
+    expected = _MINIGRID_UNLOCKED_DOORS[_N_ROWS_CONFIG.get(env.height, 3)]
+
+    keys = jax.vmap(jax.random.PRNGKey)(jnp.arange(_N_COUNT_SEEDS))
+    doors = jax.jit(jax.vmap(lambda k: env.reset(k).state.entities["door"]))(keys)
+    on_grid = np.all(np.asarray(doors.position) >= 0, axis=-1)
+    unlocked = on_grid & (np.asarray(doors.requires) == EMPTY_POCKET_ID)
+    counts = np.bincount(unlocked.sum(axis=1), minlength=16) / _N_COUNT_SEEDS
+
+    assert counts[list(expected)].sum() == pytest.approx(1.0), (
+        f"{env_id}: unlocked-door counts {np.nonzero(counts)[0].tolist()} "
+        f"outside MiniGrid's {sorted(expected)}"
+    )
+    for n, frequency in expected.items():
+        assert abs(counts[n] - frequency) < _COUNT_TOLERANCE, (
+            f"{env_id}: {n} unlocked doors in {counts[n]:.3f} of resets, "
+            f"MiniGrid {frequency:.3f}"
+        )


### PR DESCRIPTION
_Posted by an AI agent (Claude Opus 5, via Claude Code) on behalf of @xweinp._

Fixes #223.

## What this changes

#162 kept `KeyCorridor._reset` compatible with `jax.jit` in two ways. It replaced `connect_all`'s retry loop with a Kruskal pass, and it kept unused candidate walls as `Door` entities that can never open. This PR keeps both constraints, a fixed entity count and a fixed-length loop, and removes the ways the boards differed from MiniGrid because of them. `Navix-KeyCorridor*` boards are now drawn from the same distribution as MiniGrid's `KeyCorridorEnv`. There are four commits:

- **`fix(grid)`** — `RoomsGrid.position_in_room` now draws from `randint(1, room_size + 1)`, so the last interior row and column can be drawn. `position_on_border` already uses that bound, and KeyCorridor is the only caller.
- **`fix(key_corridor)`: doors as in `RoomGrid.connect_all`**
  - The random order of candidate walls and the flat union-find stay as they are.
  - A wall now gets a door if it doesn't touch the locked room and more than one component is still left, even when it doesn't merge two components.
  - Walls that never get a door move to `DISCARD_PILE_COORDS` and their grid cell stays a wall. `rgb`, `symbolic` and `categorical` therefore show a wall there, not a locked door.
  - The `-2` sentinel is removed.
- **`fix(key_corridor)`: agent start as in `place_agent(1, num_rows // 2)`** — the start is uniform over (cell, direction) pairs: free cells of the middle corridor room's box, corridor openings included, not facing the locked door. The PRNG keys are also split per use: the key's room and position used to share one key, and so did the key colour and the goal position.
- **`perf(key_corridor)`** — the sampled distribution stays the same:
  - every door offset comes from one `randint`;
  - the base wall grid is a NumPy constant built at trace time;
  - the loop writes its decisions with one scatter;
  - the agent start is one uniform index. The middle room's free cells form a rectangle and at most one pose is invalid, so that pose's slot maps to the last pose.

### Why one pass over a permutation is exact

`connect_all` draws `(room, side)` uniformly with replacement. Each interior wall can be drawn from exactly two `(room, side)` pairs, and a wall that already has a door is skipped. So the order in which distinct eligible walls are *first* drawn is a uniform random permutation. The loop stops the first time every room is reachable. The doors it adds are therefore exactly the shortest prefix of that permutation that connects the room graph, which one pass of `num_candidates` steps computes.

## ⚠️ This changes existing environments

Per `AGENTS.md`'s "Flag behavior-changing PRs explicitly": every `Navix-KeyCorridor*` reset returns a different board and different observations under the same ID. Boards have more doors on average, no door sprites on walls that can't be opened, and a different agent start and item cells. The `connect_all` commit carries a `BREAKING CHANGE:` footer.

## Checked against MiniGrid

I sampled 3000 boards per registered size from MiniGrid 3.1.0 (seeds 0–2999) and from this branch (`split(PRNGKey(0), 3000)`), and compared histograms of 13 layout statistics. The table below gives the total-variation distance for S4R3 / S6R3. The first column compares MiniGrid with a second, independent MiniGrid sample (seeds 3000–5999), which is the sampling-noise floor. The three statistics counted per door are normalised per board, so their distance can go above 1.

| statistic | MiniGrid vs MiniGrid | 4.0.0 | this PR |
|---|---|---|---|
| `agent_col` | 0.004 / 0.025 | 0.489 / 0.229 | 0.001 / 0.034 |
| `agent_dir` | 0.012 / 0.032 | 0.018 / 0.030 | 0.012 / 0.012 |
| `agent_faces` (none / unlocked / locked door) | 0.008 / 0.003 | 0.093 / 0.012 | 0.001 / 0.000 |
| `agent_row` | 0.029 / 0.020 | 0.744 / 0.653 | 0.018 / 0.029 |
| `door_offset` (along the wall, per door) | 0.061 / 0.093 | 1.589 / 1.601 | 0.014 / 0.067 |
| `key_offset` (within the room) | 0.006 / 0.031 | 0.755 / 0.435 | 0.015 / 0.043 |
| `key_room_row` | 0.011 / 0.016 | 0.029 / 0.024 | 0.006 / 0.014 |
| `locked_wall` (which wall, per door) | 0.018 / 0.018 | 2.000 / 2.000 | 0.012 / 0.012 |
| `n_locked` | 0.000 / 0.000 | 1.000 / 1.000 | 0.000 / 0.000 |
| `n_unlocked` | 0.027 / 0.010 | 0.591 / 0.583 | 0.019 / 0.005 |
| `target_offset` (within the room) | 0.020 / 0.037 | 0.735 / 0.445 | 0.020 / 0.031 |
| `target_room` | 0.018 / 0.018 | 0.015 / 0.015 | 0.012 / 0.012 |
| `unlocked_wall` (which wall, per door) | 0.059 / 0.061 | 0.410 / 0.399 | 0.044 / 0.056 |

`n_locked` counts every on-grid door with `requires != -1`, which is what `symbolic` encodes as locked, so 4.0.0's `-2` doors count there. Across all six sizes, this PR's distance is at most 0.015 above the MiniGrid-vs-MiniGrid distance for the same statistic.

Mean doors drawn per board, ± standard error:

| size | MiniGrid (seeds 0–2999) | MiniGrid (seeds 3000–5999) | 4.0.0 | this PR |
|---|---|---|---|---|
| S3R2 | 4.246 ± 0.008 | 4.245 ± 0.008 | 6.000 (4 can open) | 4.249 ± 0.008 |
| S4R3 | 6.821 ± 0.014 | 6.786 ± 0.014 | 10.000 (6 can open) | 6.794 ± 0.014 |
| S6R3 | 6.798 ± 0.014 | 6.781 ± 0.014 | 10.000 (6 can open) | 6.794 ± 0.014 |

The door draw doesn't depend on room size, so NAVIX gives the same door counts for all R3 sizes under the same keys.

## Timing

Board generation only. For NAVIX this is a jitted `vmap(reset)` returning just entities and grid, so XLA drops the observation and rendering cache. For MiniGrid it is `_gen_grid`. Times are per board, median of 30 batches (2000 calls at batch 1). CPU only (12 cores), one run.

| size | MiniGrid `_gen_grid` | 4.0.0, batch 1 | this PR, batch 1 | 4.0.0, batch 128 | this PR, batch 128 |
|---|---|---|---|---|---|
| S3R3 | 255 µs | 106 µs | 101 µs | 3.57 µs | 2.82 µs |
| S4R3 | 233 µs | 126 µs | 112 µs | 3.63 µs | 3.42 µs |
| S6R3 | 258 µs | 204 µs | 160 µs | 4.36 µs | 3.71 µs |

Compile time for the same function, 4.0.0 → this PR: 1.50 → 1.25 s (S3R3), 1.69 → 1.28 s (S4R3), 1.86 → 1.25 s (S6R3). A full `reset` including observation and rendering cache measured the same within run-to-run noise: S6R3 62.0 µs against 60.4 µs at batch 128.

## Tests

- `tests/test_key_corridor.py`:
  - The reachability and uniqueness test now covers on-grid doors only. It also checks that off-grid doors sit exactly on the discard pile and that every room, the locked one included, is reachable.
  - New `test_unopened_candidate_walls_are_walls`: the only floor cells on room walls are doors and the corridor.
  - New `test_agent_starts_as_in_minigrid`: the set of start cells is exactly the middle room's free cells plus its corridor openings, no start faces the locked door, and every valid direction occurs.
  - New `test_door_count_matches_minigrid`: the frequencies of the unlocked-door count over 2000 seeds are within 0.05 of MiniGrid 3.1.0's frequencies, measured over 3000 seeds and pasted in. That margin is more than four standard errors, and MiniGrid is not a test dependency.
- `tests/test_grid.py`: new `test_position_in_room_covers_the_whole_interior`.
- `tests/test_issues.py`: `test_98` and `test_160` now cover on-grid doors only, because unused candidates share the discard pile.

Run locally:
- **On the final commit:** `test_grid.py`, `test_key_corridor.py` and `test_issues.py`, 39 passed. `test_147` needs `requirements_test.txt` installed.
- **On the commit before `perf`:** `test_actions.py`, `test_entities.py`, `test_environments.py`, `test_events.py`, `test_fetch.py`, `test_go_to_object.py`, `test_locked_room.py`, `test_memory.py` and `test_observations.py` passed, one file at a time.
- **Not run:**
  - `test_multi_room.py` was killed at this machine's 3 GB memory cap; it does not touch KeyCorridor.
  - The other environment test files: obstructed maze, playground, put-near, red/blue doors, registry, spaces, tasks, terminations, unlock.
  - The PPO/PQN/Dreamer/agent suites and `examples/`.
