### PR TITLE
fix(door_key): draw the door row and goal as MiniGrid's DoorKeyEnv does

### DIFF
--- a/navix/environments/door_key.py
+++ b/navix/environments/door_key.py
@@ -45,15 +45,16 @@ from .registry import register_env
 class DoorKey(Environment):
     """`Navix-DoorKey-*`. A room split in two by an interior wall with a
     single locked yellow door; a matching key lies in the first half, the
-    goal in the second. The agent must pick up the key, unlock and open
-    the door, then reach the goal. Default reward/termination (`+1` at
-    the goal minus a step cost). The wall column and door row are
-    randomised every reset.
+    goal in the bottom-right corner of the second. The agent must pick up
+    the key, unlock and open the door, then reach the goal. Default
+    reward/termination (`+1` at the goal minus a step cost). The wall
+    column, door row and key are drawn as in MiniGrid's
+    `DoorKeyEnv._gen_grid`.
 
     Attributes:
-        random_start: `False` puts the player at a fixed corner of the
-            first room; `True` (the `-Random-` ids) samples the player
-            and key positions within the first room.
+        random_start: `True` (the `-Random-` ids) draws the player's cell
+            and direction uniformly in the first room, as MiniGrid does;
+            `False` puts the player at `(1, 1)` facing east.
     """
 
     random_start: bool = struct.field(pytree_node=False, default=False)
@@ -67,15 +68,14 @@ class DoorKey(Environment):
             self.width > 4
         ), f"Room width must be greater than 5, got {self.width} instead"
 
-        key, k1, k2, k3, k4 = jax.random.split(key, 5)
+        key, k_col, k_row, k_player_pos, k_player_dir, k_key = jax.random.split(key, 6)
 
         grid = room(height=self.height, width=self.width)
 
-        # door positions
-        # col can be between 1 and height - 2
-        door_col = jax.random.randint(k4, (), 2, self.width - 2)  # col
-        # row can be between 1 and height - 2
-        door_row = jax.random.randint(k3, (), 1, self.height - 1)  # row
+        # MiniGrid's `splitIdx` and `doorIdx`: the wall column is one of
+        # 2..width-3 and the door row one of 1..height-3
+        door_col = jax.random.randint(k_col, (), 2, self.width - 2)
+        door_row = jax.random.randint(k_row, (), 1, self.height - 2)
         door_pos = jnp.asarray((door_row, door_col))
         doors = Door.create(
             position=door_pos,
@@ -99,20 +99,15 @@ class DoorKey(Environment):
             grid, (jnp.asarray(self.height), door_col), jnp.less
         )
         first_room = jnp.where(first_room_mask, grid, -1)  # put walls where not mask
-        second_room_mask = mask_by_coordinates(
-            grid, (jnp.asarray(0), door_col), jnp.greater
-        )
-        second_room = jnp.where(second_room_mask, grid, -1)  # put walls where not mask
 
         # set player and goal pos
         if self.random_start:
-            player_pos = random_positions(k1, first_room)
-            player_dir = random_directions(k2)
-            goal_pos = random_positions(k2, second_room)
+            player_pos = random_positions(k_player_pos, first_room)
+            player_dir = random_directions(k_player_dir)
         else:
             player_pos = jnp.asarray([1, 1])
             player_dir = jnp.asarray(0)
-            goal_pos = jnp.asarray([self.height - 2, self.width - 2])
+        goal_pos = jnp.asarray([self.height - 2, self.width - 2])
 
         # spawn goal and player
         player = Player.create(
@@ -121,7 +116,7 @@ class DoorKey(Environment):
         goals = Goal.create(position=goal_pos, probability=jnp.asarray(1.0))
 
         # spawn key
-        key_pos = random_positions(k2, first_room, exclude=player_pos)
+        key_pos = random_positions(k_key, first_room, exclude=player_pos)
         keys = Key.create(position=key_pos, id=jnp.asarray(3), colour=PALETTE.YELLOW)
 
         # remove the wall beneath the door

--- a/tests/test_door_key.py
+++ b/tests/test_door_key.py
@@ -1,0 +1,74 @@
+# Copyright 2023 The Navix Authors.
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+"""DoorKey's board follows MiniGrid's `DoorKeyEnv._gen_grid`: the wall
+column, door row, goal and key for every id, and the player's cell and
+direction for the `-Random-` ids. Checked as exact supports over many seeds."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import navix as nx
+
+_SIZES = (5, 6, 8, 16)
+_N_SEEDS = 1000
+
+
+@pytest.mark.parametrize("size", _SIZES)
+@pytest.mark.parametrize("random_start", (False, True))
+def test_board_follows_minigrid(size, random_start):
+    env_id = f"Navix-DoorKey-{'Random-' if random_start else ''}{size}x{size}-v0"
+    env = nx.make(env_id)
+
+    def board(key):
+        entities = env.reset(key).state.entities
+        return [entities[name] for name in ("player", "door", "key", "goal")]
+
+    keys = jax.vmap(jax.random.PRNGKey)(jnp.arange(_N_SEEDS))
+    player, door, key, goal = jax.jit(jax.vmap(board))(keys)
+    player_pos = np.asarray(player.position)[:, 0]
+    direction = np.asarray(player.direction)[:, 0]
+    door_pos = np.asarray(door.position)[:, 0]
+    key_pos = np.asarray(key.position)[:, 0]
+    goal_pos = np.asarray(goal.position)[:, 0]
+
+    assert set(door_pos[:, 1].tolist()) == set(range(2, size - 2))
+    assert set(door_pos[:, 0].tolist()) == set(range(1, size - 2))
+    assert np.all(goal_pos == [size - 2, size - 2])
+
+    for p, k, d in zip(player_pos, key_pos, door_pos):
+        for name, cell in (("player", p), ("key", k)):
+            assert 1 <= cell[0] <= size - 2 and 1 <= cell[1] < d[1], (
+                f"{env_id}: {name} at {cell.tolist()} outside the first room "
+                f"left of the wall at column {d[1]}"
+            )
+        assert not np.array_equal(p, k), f"{env_id}: key on the player's cell"
+
+    if random_start:
+        assert set(direction.tolist()) == {0, 1, 2, 3}
+        if size <= 8:  # at 16x16 some cells are too rare to all show up
+            first_room_cells = {
+                (r, c) for r in range(1, size - 1) for c in range(1, size - 3)
+            }
+            assert set(map(tuple, player_pos.tolist())) == first_room_cells
+    else:
+        assert np.all(player_pos == [1, 1]) and np.all(direction == 0)


### PR DESCRIPTION
_Posted by an AI agent (Claude Opus 5, via Claude Code) on behalf of @xweinp._

Fixes #225.

## What this changes

`DoorKey._reset` now draws the board as MiniGrid's `DoorKeyEnv._gen_grid` does:

- **Door row:** `randint(1, height - 2)`, MiniGrid's `doorIdx`. The door is never in the bottom interior row.
- **Goal:** always `(height - 2, width - 2)`, on every ID. The `-Random-` IDs used to put it on a random cell of the second room.
- **PRNG keys:** one key per draw (wall column, door row, player cell, player direction, key cell). The player's direction, the goal and the key used to share `k2`.
- **Plain IDs** keep their fixed start at `(1, 1)` facing east. MiniGrid has no fixed-start DoorKey, so that variant stays as NAVIX defines it. `-Random-` IDs now match MiniGrid's DoorKey exactly.
- The class docstring and `random_start` attribute docs describe the above.

## ⚠️ This changes existing environments

Per `AGENTS.md`'s "Flag behavior-changing PRs explicitly": `Navix-DoorKey-*` resets draw different door rows and key cells under the same IDs, and `Navix-DoorKey-Random-*` resets always put the goal in the bottom-right corner. The commit carries a `BREAKING CHANGE:` footer.

## Checked against MiniGrid

I sampled 3000 boards per size from MiniGrid 3.1.0 (seeds 0–2999) and from NAVIX (`split(PRNGKey(0), 3000)`), and compared the histograms of each statistic. The table gives total-variation distance for `-Random-` IDs at 5x5 / 8x8 / 16x16; 6x6 was measured too and looks the same. The first column compares MiniGrid with an independent MiniGrid sample (seeds 3000–5999), which is the sampling-noise floor. At 16x16 the cell histograms spread over about 150 cells, so their noise floor is higher.

| statistic | MiniGrid vs MiniGrid | 4.0.0 | this PR |
|---|---|---|---|
| `door_row` | 0.008 / 0.023 / 0.049 | 0.334 / 0.164 / 0.080 | 0.013 / 0.016 / 0.023 |
| `goal_cell` | 0.000 / 0.000 / 0.000 | 0.661 / 0.915 / 0.978 | 0.000 / 0.000 / 0.000 |
| `door_col` | 0.000 / 0.023 / 0.036 | 0.000 / 0.030 / 0.033 | 0.000 / 0.015 / 0.038 |
| `player_cell` | 0.023 / 0.057 / 0.128 | 0.016 / 0.048 / 0.117 | 0.016 / 0.044 / 0.126 |
| `player_dir` | 0.017 / 0.015 / 0.020 | 0.021 / 0.017 / 0.022 | 0.006 / 0.015 / 0.025 |
| `player_col_and_wall` (joint) | 0.000 / 0.031 / 0.072 | 0.000 / 0.047 / 0.085 | 0.000 / 0.023 / 0.092 |
| `key_cell` | 0.005 / 0.037 / 0.128 | 0.004 / 0.049 / 0.137 | 0.005 / 0.043 / 0.118 |
| `key_col_and_wall` (joint) | 0.000 / 0.040 / 0.092 | 0.000 / 0.044 / 0.091 | 0.000 / 0.024 / 0.087 |

Across all four sizes and every statistic, this PR's distance is at most 0.02 above the MiniGrid-vs-MiniGrid distance. On the plain IDs, `door_row` (0.013 / 0.016 / 0.023) and `goal_cell` (0) match MiniGrid too. Their player and key statistics differ by design, because of the fixed start.

## Timing

Board generation only. For NAVIX this is a jitted `vmap(reset)` returning just entities and grid, so XLA drops the observation and rendering cache. For MiniGrid it is `_gen_grid`. Times are per board on `-Random-` IDs: median of 30 batches, or of 2000 calls at batch 1. CPU only (12 cores), one run.

| size | MiniGrid `_gen_grid` | 4.0.0, batch 1 | this PR, batch 1 | 4.0.0, batch 128 | this PR, batch 128 |
|---|---|---|---|---|---|
| 5x5 | 41.0 µs | 90.4 µs | 73.8 µs | 4.97 µs | 2.57 µs |
| 8x8 | 29.3 µs | 92.4 µs | 90.1 µs | 3.74 µs | 4.29 µs |
| 16x16 | 37.5 µs | 134.4 µs | 130.7 µs | 6.40 µs | 6.79 µs |

The PR does one random draw fewer and builds one mask fewer. Its differences from 4.0.0 go both ways across sizes, so they are within run-to-run noise. Compile time is 0.45–0.60 s for both.

## Tests

- New `tests/test_door_key.py`: 8 cases, 4 sizes × plain / `-Random-`, 1000 seeds each.
  - The wall column and door row take exactly MiniGrid's ranges.
  - The goal is always in the bottom-right corner.
  - The player and key are left of the wall, and the key is never on the player.
  - `-Random-` IDs produce every direction and, up to 8x8, every first-room cell; plain IDs always start at `(1, 1)` facing east.
- `tests/test_door_key.py`, `test_events.py`, `test_environments.py` and `test_issues.py`: 33 passed locally.
